### PR TITLE
fix: add missing site yaml for sites step

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/team_site.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_site.py
@@ -166,13 +166,7 @@ class TeamSite(pulumi.ComponentResource):
 
         self.site = kubernetes.yaml.ConfigFile(
             self.site_name,
-            file=str(
-                ptd.paths.top()
-                / "team-operator"
-                / "config"
-                / "samples"
-                / f"core.posit.team_{api_version_path}_site.yaml"
-            ),
+            file=str(ptd.paths.HERE / "site_templates" / f"core.posit.team_{api_version_path}_site.yaml"),
             transformations=(
                 [
                     *list(self.transformations),

--- a/python-pulumi/src/ptd/site_templates/core.posit.team_v1beta1_site.yaml
+++ b/python-pulumi/src/ptd/site_templates/core.posit.team_v1beta1_site.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.posit.team/v1beta1
+kind: Site
+metadata:
+  labels:
+    app.kubernetes.io/name: site
+    app.kubernetes.io/instance: site-sample
+    app.kubernetes.io/part-of: team-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: team-operator
+  name: site-sample
+spec: {}


### PR DESCRIPTION
# Description

Fixing the site step which expects an empty starting site definition on which to apply transformations. This new YAML file is a copy of what was used prior to moving `/team-operator` elsewhere.


## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
