### PR TITLE
fix: add helm.sh/resource-policy: keep to CRD patch

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/team_operator.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_operator.py
@@ -210,7 +210,7 @@ class TeamOperator(pulumi.ComponentResource):
 
         # Build patch commands for CRDs (names are standard, not transformed)
         crd_commands = [
-            f'kubectl patch crd {crd} --type=merge -p \'{{"metadata":{{"labels":{{"app.kubernetes.io/managed-by":"Helm"}},"annotations":{{"meta.helm.sh/release-name":"{release_name}","meta.helm.sh/release-namespace":"{release_namespace}"}}}}}}\' 2>/dev/null || echo "  {crd} not found or already adopted"'
+            f'kubectl patch crd {crd} --type=merge -p \'{{"metadata":{{"labels":{{"app.kubernetes.io/managed-by":"Helm"}},"annotations":{{"meta.helm.sh/release-name":"{release_name}","meta.helm.sh/release-namespace":"{release_namespace}","helm.sh/resource-policy":"keep"}}}}}}\' 2>/dev/null || echo "  {crd} not found or already adopted"'
             for crd in KUSTOMIZE_CRDS
         ]
 


### PR DESCRIPTION
## Summary
- Adds `helm.sh/resource-policy: keep` annotation to CRD patch during kustomize→Helm migration

## Why
When Helm install fails during migration and the release is removed from Pulumi, `helm uninstall` was deleting the CRDs because they lacked the keep policy. This caused cascade deletion of all Site custom resources.

## Related
Bean: `ptd-fvuq`