### PR TITLE
fix(proxy): Remove SIGINT signal causing proxy bug

### DIFF
--- a/lib/helpers/ps.go
+++ b/lib/helpers/ps.go
@@ -1,7 +1,10 @@
 package helpers
 
-import "os"
-import "log/slog"
+import (
+	"log/slog"
+	"os"
+	"syscall"
+)
 
 func KillProcess(pid int) error {
 	process, err := os.FindProcess(pid)
@@ -26,7 +29,7 @@ func ProcessRunning(pid int) bool {
 		return false
 	}
 
-	err = process.Signal(os.Interrupt) // Sending an interrupt signal to check if the process is running
+	err = process.Signal(syscall.Signal(0)) // Send signal 0 to check if process exists without disturbing it
 	if err != nil {
 		slog.Debug("Process does not appear to be running", "pid", pid, "error", err)
 		return false


### PR DESCRIPTION
# Description

The function that checks to see if an existing proxy is running was sending SIGINT and unintentionally killing the process. It also was recognizing the existing running proxy and carrying on as if successful. This was causing a bug that made it impossible to run the cli commands with an existing proxy running.


## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
