### PR TITLE
fix(proxy): Remove sensitive values from debug logs

### DIFF
--- a/lib/aws/proxy.go
+++ b/lib/aws/proxy.go
@@ -107,7 +107,7 @@ func (p *ProxySession) Start(ctx context.Context) error {
 	}
 
 	slog.Info("Adding SSH key", "bastion_id", bastionId)
-	slog.Debug("Adding temporary SSH key to bastion via SSM")
+	slog.Debug("Sending temporary SSH key via SSM", "region", p.region, "ssm_document", SSMRunShellDocumentName, "ttl_seconds", 60)
 	err = SsmSendCommand(ctx, awsCreds, p.region, bastionId, addSshKeyCommand)
 	if err != nil {
 		return err
@@ -133,7 +133,7 @@ func (p *ProxySession) Start(ctx context.Context) error {
 	p.command.Env = append(p.command.Env, fmt.Sprintf("AWS_REGION=%s", p.region))
 	// add the session manager plugin path
 	p.command.Env = append(p.command.Env, "PATH="+os.Getenv("PATH")+":"+SessionManagerPluginDir)
-	slog.Debug("Starting SSH proxy session via SSM", "bastion_id", bastionId, "local_port", p.localPort)
+	slog.Debug("Starting SSH SOCKS proxy via SSM", "bastion_id", bastionId, "local_port", p.localPort, "region", p.region, "ssm_document", SSMStartSSHSessionDocumentName)
 
 	if ctx.Value("verbose") != nil && ctx.Value("verbose").(bool) {
 		slog.Debug("Verbose turned on, attaching command output to stdout and stderr")

--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -150,7 +150,7 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		p.socksCommand.Env = append(p.socksCommand.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	slog.Debug("Starting Azure network tunnel to bastion", "tunnel_port", "22001")
+	slog.Debug("Starting Azure bastion tunnel", "bastion_name", bastionName, "resource_group", resourceGroupName, "tunnel_port", "22001", "target_port", "22")
 	if ctx.Value("verbose") != nil && ctx.Value("verbose").(bool) {
 		slog.Debug("Verbose turned on, attaching command output to stdout and stderr")
 		p.tunnelCommand.Stdout = os.Stdout
@@ -170,7 +170,7 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		return fmt.Errorf("tunnel session did not start successfully on port 22001")
 	}
 
-	slog.Debug("Starting SOCKS proxy", "local_port", p.localPort)
+	slog.Debug("Starting SSH SOCKS proxy via tunnel", "local_port", p.localPort, "tunnel_port", "22001", "user", "ptd-admin")
 	if ctx.Value("verbose") != nil && ctx.Value("verbose").(bool) {
 		slog.Debug("Verbose turned on, attaching command output to stdout and stderr")
 		p.socksCommand.Stdout = os.Stdout


### PR DESCRIPTION
# Description

Removes exposure of some sensitive authentication values from the Proxy command debug logs. I believe these are largely ephemeral values but we should still not expose them if possible. 

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
