### PR TITLE
fix(fsx): ignore daily_automatic_backup_start_time in diffs

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/aws_fsx_openzfs_multi.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_fsx_openzfs_multi.py
@@ -99,7 +99,13 @@ class AWSFsxOpenZfsMulti(pulumi.ComponentResource):
             route_table_ids=props.route_table_ids,
             root_volume_configuration=root_volume_configuration,
             tags=props.tags,
-            opts=pulumi.ResourceOptions(parent=self),
+            # ignore_changes for daily_automatic_backup_start_time: This field is not
+            # properly read back from AWS after import, causing perpetual diffs.
+            # See: https://github.com/posit-dev/ptd/issues/5
+            opts=pulumi.ResourceOptions(
+                parent=self,
+                ignore_changes=["daily_automatic_backup_start_time"],
+            ),
         )
 
         # Export the outputs


### PR DESCRIPTION
## Summary

- Adds `ignore_changes` for `daily_automatic_backup_start_time` on FSx OpenZFS resources to prevent perpetual diffs

## Problem

After FSx OpenZFS filesystems were migrated from dynamic resources to native Pulumi resources via `pulumi import`, the `daily_automatic_backup_start_time` field wasn't properly captured in state. This caused the field to show up in every single diff during the persistent step, even when no actual changes were made.

## Solution

Added `ignore_changes=["daily_automatic_backup_start_time"]` to the `ResourceOptions`. This tells Pulumi to not compare this field during diffs while still setting the value on resource creation.

## Test plan

- [ ] Run `ptd ensure <workload> persistent` on an affected workload
- [ ] Verify `dailyAutomaticBackupStartTime` no longer appears in the diff

Fixes #5