### PR TITLE
Fix RDS identifier_prefix perpetual diff

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/aws_workload_persistent.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_workload_persistent.py
@@ -408,6 +408,7 @@ class AWSWorkloadPersistent(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(
                 parent=self.vpc,
                 protect=self.workload.cfg.protect_persistent_resources,
+                ignore_changes=["identifier_prefix"],
             ),
         )
 


### PR DESCRIPTION
## Summary

Add `ignore_changes=["identifier_prefix"]` to the workload RDS instance ResourceOptions.

## Problem

`identifier_prefix` is a write-only property in AWS - it's used during resource creation but AWS doesn't return it in the API response. This causes Pulumi to always show it as a pending change:

```
~ aws:rds/instance:Instance: (update)
  + identifierPrefix: "ganso01-staging-"
```

## Solution

Add `ignore_changes=["identifier_prefix"]` to match the existing fix in `aws_control_room_persistent.py` (line 225).

## Test plan

- [x] Verified control room already has this fix
- [x] Run `ptd ensure <workload> --only-steps persistent --dry-run` to confirm diff is gone