### PR TITLE
Enable 30-day automatic backup retention for FSx OpenZFS

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/aws_fsx_openzfs_multi.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_fsx_openzfs_multi.py
@@ -8,6 +8,7 @@ import pulumi_aws as aws
 
 @dataclasses.dataclass
 class AWSFsxOpenZfsMultiArgs:
+    automatic_backup_retention_days: pulumi.Input[int]
     copy_tags_to_backups: pulumi.Input[bool]
     copy_tags_to_volumes: pulumi.Input[bool]
     daily_automatic_backup_start_time: pulumi.Input[str]
@@ -86,6 +87,7 @@ class AWSFsxOpenZfsMulti(pulumi.ComponentResource):
 
         self.file_system = aws.fsx.OpenZfsFileSystem(
             f"{name}-filesystem",
+            automatic_backup_retention_days=props.automatic_backup_retention_days,
             deployment_type=props.deployment_type,
             preferred_subnet_id=preferred_subnet_id,
             subnet_ids=props.subnet_ids,

--- a/python-pulumi/src/ptd/pulumi_resources/aws_workload_persistent.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_workload_persistent.py
@@ -835,6 +835,7 @@ class AWSWorkloadPersistent(pulumi.ComponentResource):
             self.fsx_openzfs_fs = ptd.pulumi_resources.aws_fsx_openzfs_multi.AWSFsxOpenZfsMulti(
                 self.workload.compound_name,
                 props=ptd.pulumi_resources.aws_fsx_openzfs_multi.AWSFsxOpenZfsMultiArgs(
+                    automatic_backup_retention_days=30,
                     subnet_ids=self.private_subnet_ids[:2],
                     daily_automatic_backup_start_time=self.workload.cfg.fsx_openzfs_daily_automatic_backup_start_time,
                     deployment_type=deployment_type,
@@ -867,6 +868,7 @@ class AWSWorkloadPersistent(pulumi.ComponentResource):
         else:
             self.fsx_openzfs_fs = aws.fsx.OpenZfsFileSystem(
                 self.workload.compound_name,
+                automatic_backup_retention_days=30,
                 preferred_subnet_id=(subnet_ids[0] if deployment_type.startswith("MULTI") else None),
                 subnet_ids=subnet_ids,
                 deployment_type=deployment_type,


### PR DESCRIPTION
## Summary

- Add `automatic_backup_retention_days` parameter to FSx OpenZFS component resource
- Set retention to 30 days for both MULTI_AZ and SINGLE_AZ deployments
- Previously defaulted to 0 (disabled), making `daily_automatic_backup_start_time` ineffective

## Test plan

- [x] Deploy to a test cluster and verify FSx backup settings in AWS console
- [x] Confirm existing deployments update without replacement on next `ptd ensure`