### PR TITLE
fix: support workon for custom steps

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/posit-dev/ptd/lib v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/term v0.37.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -73,6 +74,7 @@ require (
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa // indirect
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -123,6 +125,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1 // indirect

--- a/cmd/workon_test.go
+++ b/cmd/workon_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/posit-dev/ptd/lib/customization"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFindCustomStep(t *testing.T) {
+	tests := []struct {
+		name         string
+		manifest     *customization.Manifest
+		stepName     string
+		expectFound  bool
+		expectedPath string
+	}{
+		{
+			name: "finds enabled custom step",
+			manifest: &customization.Manifest{
+				Version: 1,
+				CustomSteps: []customization.CustomStep{
+					{
+						Name:        "test-step",
+						Description: "Test custom step",
+						Path:        "test-step/",
+						Enabled:     boolPtr(true),
+					},
+				},
+			},
+			stepName:     "test-step",
+			expectFound:  true,
+			expectedPath: "test-step/",
+		},
+		{
+			name: "does not find disabled custom step",
+			manifest: &customization.Manifest{
+				Version: 1,
+				CustomSteps: []customization.CustomStep{
+					{
+						Name:        "disabled-step",
+						Description: "Disabled custom step",
+						Path:        "disabled-step/",
+						Enabled:     boolPtr(false),
+					},
+				},
+			},
+			stepName:    "disabled-step",
+			expectFound: false,
+		},
+		{
+			name: "does not find non-existent step",
+			manifest: &customization.Manifest{
+				Version: 1,
+				CustomSteps: []customization.CustomStep{
+					{
+						Name:        "existing-step",
+						Description: "Existing custom step",
+						Path:        "existing-step/",
+					},
+				},
+			},
+			stepName:    "non-existent",
+			expectFound: false,
+		},
+		{
+			name: "finds step when enabled is nil (default true)",
+			manifest: &customization.Manifest{
+				Version: 1,
+				CustomSteps: []customization.CustomStep{
+					{
+						Name:        "default-enabled",
+						Description: "Default enabled custom step",
+						Path:        "default-enabled/",
+						Enabled:     nil,
+					},
+				},
+			},
+			stepName:     "default-enabled",
+			expectFound:  true,
+			expectedPath: "default-enabled/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary manifest file for testing
+			tempDir := t.TempDir()
+			workloadPath := filepath.Join(tempDir, "workload")
+			customizationsPath := filepath.Join(workloadPath, "customizations")
+			require.NoError(t, os.MkdirAll(customizationsPath, 0755))
+
+			manifestPath := filepath.Join(customizationsPath, "manifest.yaml")
+			manifestData, err := yaml.Marshal(tt.manifest)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(manifestPath, manifestData, 0644))
+
+			// Test the findCustomStep function
+			step, found := findCustomStep(workloadPath, tt.stepName)
+
+			assert.Equal(t, tt.expectFound, found)
+			if tt.expectFound {
+				assert.NotNil(t, step)
+				assert.Equal(t, tt.expectedPath, step.Path)
+			} else {
+				assert.Nil(t, step)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
# Description

Augments the `workon` command to handle custom steps in addition to the default steps already supported.

## Issue

https://github.com/posit-dev/ptd/issues/106

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
