### PR TITLE
chore: bump default team-operator chart version to v1.5.0

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/team_operator.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_operator.py
@@ -23,7 +23,7 @@ KUSTOMIZE_CRDS = [
 KUSTOMIZE_MANAGED_BY_LABEL = "posit.team/managed-by=ptd.pulumi_resources.team_operator"
 
 # Default Helm chart version (OCI charts require explicit version, no "latest")
-DEFAULT_CHART_VERSION = "v1.3.0"
+DEFAULT_CHART_VERSION = "v1.5.0"
 
 
 class TeamOperator(pulumi.ComponentResource):


### PR DESCRIPTION
# Description

Bump the default Team Operator Helm chart version from v1.3.0 to v1.5.0.

This ensures new workloads without an explicit `team_operator_chart_version` will use the latest stable release.

## Category of change

- [x] Version upgrade (upgrading the version of a service or product)