### PR TITLE
feat(eks): enable access entries by default

### DIFF
--- a/python-pulumi/src/ptd/__init__.py
+++ b/python-pulumi/src/ptd/__init__.py
@@ -367,7 +367,7 @@ class Taint:
 class EKSAccessEntriesConfig:
     """Configuration for EKS Access Entries."""
 
-    enabled: bool = False  # Whether to use EKS Access Entries instead of aws-auth ConfigMap
+    enabled: bool = True  # Whether to use EKS Access Entries instead of aws-auth ConfigMap
     additional_entries: list[dict] = dataclasses.field(default_factory=list)  # Additional access entries to create
     include_same_account_poweruser: bool = False  # Whether to include PowerUser role from the same account
 

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -639,6 +639,13 @@ class AWSEKSCluster(pulumi.ComponentResource):
             )
 
         # Use the legacy aws-auth ConfigMap approach
+        warnings.warn(
+            "aws-auth ConfigMap authentication is deprecated. "
+            "Set eks_access_entries.enabled=True in cluster configuration. "
+            "ConfigMap support will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if node_role is None:
             if self.default_node_role is not None:
                 node_role = self.default_node_role

--- a/python-pulumi/tests/test_eks_access_entries_simple_integration.py
+++ b/python-pulumi/tests/test_eks_access_entries_simple_integration.py
@@ -173,8 +173,8 @@ def test_backward_compatibility_patterns():
         ptd_controller_image="v2.0.0",
     )
 
-    # Should have default values for new fields
-    assert old_config.eks_access_entries.enabled is False
+    # Should have default values for new fields (enabled by default now)
+    assert old_config.eks_access_entries.enabled is True
     assert old_config.eks_access_entries.additional_entries == []
 
     # Migration pattern: enable Access Entries but no additional entries
@@ -312,15 +312,15 @@ def test_configuration_immutability():
 
 def test_feature_flag_consistency():
     """Test that feature flag behavior is consistent."""
-    # Default behavior (ConfigMap)
+    # Default behavior (Access Entries enabled by default)
     default_config = ptd.WorkloadClusterConfig()
-    assert default_config.eks_access_entries.enabled is False
+    assert default_config.eks_access_entries.enabled is True
 
-    # Explicit ConfigMap mode
+    # Explicit ConfigMap mode (opt-out)
     configmap_config = ptd.WorkloadClusterConfig(eks_access_entries=ptd.EKSAccessEntriesConfig(enabled=False))
     assert configmap_config.eks_access_entries.enabled is False
 
-    # Access Entries mode
+    # Explicit Access Entries mode
     access_entries_config = ptd.WorkloadClusterConfig(eks_access_entries=ptd.EKSAccessEntriesConfig(enabled=True))
     assert access_entries_config.eks_access_entries.enabled is True
 
@@ -349,20 +349,11 @@ def test_feature_flag_consistency():
 
 def test_poweruser_configuration():
     """Test PowerUser role configuration options."""
-    # Default: PowerUser not included
+    # Default: PowerUser NOT included (only for internal clusters)
     default_config = ptd.WorkloadClusterConfig()
     assert default_config.eks_access_entries.include_same_account_poweruser is False
 
-    # Explicitly exclude PowerUser
-    no_poweruser = ptd.WorkloadClusterConfig(
-        eks_access_entries=ptd.EKSAccessEntriesConfig(
-            enabled=True,
-            include_same_account_poweruser=False,
-        )
-    )
-    assert no_poweruser.eks_access_entries.include_same_account_poweruser is False
-
-    # Include PowerUser
+    # Explicitly include PowerUser (opt-in for internal clusters)
     with_poweruser = ptd.WorkloadClusterConfig(
         eks_access_entries=ptd.EKSAccessEntriesConfig(
             enabled=True,

--- a/python-pulumi/tests/test_workload_cluster_config.py
+++ b/python-pulumi/tests/test_workload_cluster_config.py
@@ -12,7 +12,7 @@ def test_workload_cluster_config_default_initialization():
     # Test default values
     assert config.team_operator_image == "latest"
     assert config.ptd_controller_image == "latest"
-    assert config.eks_access_entries.enabled is False
+    assert config.eks_access_entries.enabled is True
     assert config.eks_access_entries.additional_entries == []
     assert config.eks_access_entries.include_same_account_poweruser is False
 
@@ -194,8 +194,8 @@ def test_workload_cluster_config_backwards_compatibility():
         ptd_controller_image="v2.0.0",
     )
 
-    # Verify new fields have defaults
-    assert config.eks_access_entries.enabled is False
+    # Verify new fields have defaults (enabled by default now)
+    assert config.eks_access_entries.enabled is True
     assert config.eks_access_entries.additional_entries == []
     assert config.eks_access_entries.include_same_account_poweruser is False
 


### PR DESCRIPTION
## Summary
- Change `EKSAccessEntriesConfig.enabled` default from `False` to `True`
- Add deprecation warning when using legacy aws-auth ConfigMap
- Update tests for new defaults

This makes EKS Access Entries the default authentication mechanism instead of the legacy aws-auth ConfigMap, preventing issues where ConfigMap patches clobber entries from other systems (like Karpenter).

## Test plan
- [x] Unit tests updated and passing
- [x] Test on staging cluster
- [x] Verify access entries are created instead of ConfigMap patches

Closes #111