### PR TITLE
chore: bump team operator chart to v1.6.0

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/team_operator.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_operator.py
@@ -23,7 +23,7 @@ KUSTOMIZE_CRDS = [
 KUSTOMIZE_MANAGED_BY_LABEL = "posit.team/managed-by=ptd.pulumi_resources.team_operator"
 
 # Default Helm chart version (OCI charts require explicit version, no "latest")
-DEFAULT_CHART_VERSION = "v1.5.0"
+DEFAULT_CHART_VERSION = "v1.6.0"
 
 
 class TeamOperator(pulumi.ComponentResource):


### PR DESCRIPTION
## Summary
Bump default team operator Helm chart version from v1.5.0 to v1.6.0.

## Test plan
- [x] Deploy to staging cluster and verify team operator works correctly