### PR TITLE
Add Claude review workflows

### DIFF
--- a/.claude/review-guidelines.md
+++ b/.claude/review-guidelines.md
@@ -1,0 +1,62 @@
+# PTD Code Review Guidelines
+
+## Core Principles
+
+### Simplicity
+- Prefer explicit over clever
+- Functions should do one thing
+- Names should reveal intent
+- Avoid premature abstraction
+
+### Maintainability
+- Follow existing patterns in the codebase
+- New code should look like it belongs
+- Dependencies should be minimal and justified
+- Breaking changes need migration paths
+
+### Security (Elevated Scrutiny)
+
+These changes require extra review attention:
+- File system operations (paths, permissions)
+- Network operations (URLs, ports, proxies)
+- Credential handling (secrets, tokens, keys)
+- Kubernetes RBAC and network policies
+- Cloud IAM policies and roles
+
+## Review Checklist by Area
+
+### PTD CLI (`cmd/`)
+- [ ] Commands support `--verbose` flag
+- [ ] Cloud operations use Target interface
+- [ ] Auto-completion works for new arguments
+- [ ] Error messages are actionable
+
+### Go Libraries (`lib/`)
+- [ ] Public APIs are well-documented
+- [ ] Breaking changes have migration paths
+- [ ] Unit tests cover edge cases
+- [ ] Error handling is consistent
+
+### Python/Pulumi (`python-pulumi/`)
+- [ ] Configuration uses dataclasses
+- [ ] Pulumi resources have proper typing
+- [ ] Cloud provider abstraction is maintained
+- [ ] No hardcoded credentials or regions
+
+### Documentation (`docs/`)
+- [ ] CLI reference is up to date
+- [ ] Examples match current configuration format
+- [ ] Guides are actionable and tested
+
+## What NOT to Comment On
+
+- Style issues handled by formatters (run `just format`)
+- Personal preferences without clear benefit
+- Theoretical concerns without concrete impact
+
+## Comment Format
+
+Use clear, actionable language:
+- **Critical**: "This will break X because Y. Consider Z."
+- **Important**: "This pattern differs from existing code in A. Recommend B for consistency."
+- **Suggestion**: "Consider X for improved Y."

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,0 +1,57 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened]
+
+env:
+  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+
+jobs:
+  auto-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
+          role-session-name: gha-claude-code-action
+          aws-region: us-east-2
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@beta
+        if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
+        with:
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          use_bedrock: true
+          model: "us.anthropic.claude-opus-4-6-v1"
+          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          timeout_minutes: "60"
+          direct_prompt: |
+            Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
+
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+
+            Review priorities from guidelines:
+            - **Simplicity**: Code should be explicit, not clever. Functions do one thing. Names reveal intent.
+            - **Maintainability**: Follow existing patterns. New code should look like it belongs.
+            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
+
+            Use the area-specific checklists from the guidelines for PTD CLI, Go libraries, and Python/Pulumi changes.
+
+            Provide constructive feedback with specific suggestions for improvement.
+            Don't be overly complimentary; focus on actionable insights and keep your comments concise.
+            Use inline comments to highlight specific areas of concern.
+
+            IMPORTANT: Do NOT post any additional comments after submitting the review. The GitHub review itself is sufficient and any additional summary comments will be redundant.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,54 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+env:
+  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
+          role-session-name: gha-claude-code-action
+          aws-region: us-east-2
+
+      - name: Run Claude Code Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          model: "us.anthropic.claude-opus-4-6-v1"
+          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          timeout_minutes: "60"
+          use_bedrock: true
+          branch_prefix: "claude-"
+          additional_permissions: "actions: read"
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          custom_instructions: |
+            You are a helpful AI assistant for code reviews and issue triage.
+            Respond to comments and issues that mention you with relevant code suggestions or triage actions.
+            If you cannot assist, politely inform the user. In your responses, don't be overly complimentary.
+            Stick to the facts and provide actionable advice.


### PR DESCRIPTION
## Summary
- Add `claude-auto-review.yml` for automatic PR reviews on open
- Add `claude.yml` PR assistant (responds to `@claude` mentions in PRs/issues)
- Add `.claude/review-guidelines.md` with PTD-specific review checklists (CLI, Go libs, Python/Pulumi)
- All workflows use Opus 4.6 (`us.anthropic.claude-opus-4-6-v1`) via Bedrock

## Prerequisites
- [ ] `PTD_AWS_ACCOUNT` secret must be configured in repo settings

## Test plan
- [ ] Verify auto-review triggers on next PR opened
- [ ] Verify `@claude` mentions work in PR comments