### PR TITLE
feat(karpenter): Enable Karpenter consolidation options

### DIFF
--- a/python-pulumi/src/ptd/aws_workload.py
+++ b/python-pulumi/src/ptd/aws_workload.py
@@ -101,6 +101,9 @@ class KarpenterNodePool:
     weight: int = 100
     root_volume_size: str = "100Gi"
     session_taints: bool = False  # Default False, opt-in for session isolation
+    # Disruption configuration
+    consolidation_policy: str = "WhenEmptyOrUnderutilized"  # Karpenter consolidation policy
+    consolidate_after: str = "5m"  # Duration after which nodes are considered for consolidation
     # Overprovisioning configuration per nodepool
     overprovisioning_replicas: int = 0  # Number of overprovisioning pods for this pool (0 = disabled)
     overprovisioning_cpu_request: str | None = None  # CPU request per overprovisioning pod
@@ -378,6 +381,8 @@ class AWSWorkload(ptd.workload.AbstractWorkload):
                         weight=pool_spec.get("weight", 100),
                         root_volume_size=pool_spec.get("root_volume_size", "100Gi"),
                         session_taints=session_taints,
+                        consolidation_policy=pool_spec.get("consolidation_policy", "WhenEmptyOrUnderutilized"),
+                        consolidate_after=pool_spec.get("consolidate_after", "5m"),
                         overprovisioning_replicas=pool_spec.get("overprovisioning_replicas", 0),
                         overprovisioning_cpu_request=pool_spec.get("overprovisioning_cpu_request"),
                         overprovisioning_memory_request=pool_spec.get("overprovisioning_memory_request"),

--- a/python-pulumi/src/ptd/pulumi_resources/aws_workload_helm.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_workload_helm.py
@@ -1035,7 +1035,10 @@ class AWSWorkloadHelm(pulumi.ComponentResource):
                             },
                         }
                     },
-                    "disruption": {"consolidationPolicy": "WhenEmptyOrUnderutilized", "consolidateAfter": "5m"},
+                    "disruption": {
+                        "consolidationPolicy": node_pool.consolidation_policy,
+                        "consolidateAfter": node_pool.consolidate_after,
+                    },
                 }
 
                 # Add weight for NodePool priority


### PR DESCRIPTION
# Description

  - Add configurable consolidation_policy and consolidate_after options to Karpenter node pools in ptd.yaml                                              
  - Defaults to existing values (WhenEmptyOrUnderutilized, 5m) for backward compatibility

Example usage in ptd.yaml:
```
  karpenter_config:                                                                                                                                      
    node_pools:                                                                                                                                          
      - name: default-session-node-pool                                                                                                                  
        consolidate_after: 60m                                                                                                                            
        consolidation_policy: "WhenEmpty" 
```


## Category of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
