### PR TITLE
fix: empty string bug in Fsx config

### DIFF
--- a/lib/types/workload.go
+++ b/lib/types/workload.go
@@ -52,7 +52,7 @@ type AWSWorkloadConfig struct {
 	ExternalID                              *uuid.UUID                          `json:"external_id" yaml:"external_id"`
 	ExtraClusterOidcUrls                    []string                            `json:"extra_cluster_oidc_urls" yaml:"extra_cluster_oidc_urls"`
 	ExtraPostgresDbs                        []string                            `json:"extra_postgres_dbs" yaml:"extra_postgres_dbs"`
-	FsxOpenzfsDailyAutomaticBackupStartTime string                              `json:"fsx_openzfs_daily_automatic_backup_start_time" yaml:"fsx_openzfs_daily_automatic_backup_start_time"`
+	FsxOpenzfsDailyAutomaticBackupStartTime *string                             `json:"fsx_openzfs_daily_automatic_backup_start_time" yaml:"fsx_openzfs_daily_automatic_backup_start_time"`
 	FsxOpenzfsMultiAz                       bool                                `json:"fsx_openzfs_multi_az" yaml:"fsx_openzfs_multi_az"`
 	FsxOpenzfsOverrideDeploymentType        *string                             `json:"fsx_openzfs_override_deployment_type" yaml:"fsx_openzfs_override_deployment_type"`
 	FsxOpenzfsStorageCapacity               int                                 `json:"fsx_openzfs_storage_capacity" yaml:"fsx_openzfs_storage_capacity"`


### PR DESCRIPTION
# Description

Changed FsxOpenzfsDailyAutomaticBackupStartTime from string to *string in ptd/lib/types/workload.go:55. This ensures that when the field is omitted from YAML configs, it becomes nil in JSON instead of an empty string, allowing the Python default of "02:00" to be used.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
