### PR TITLE
Add configurable bastion instance type for Azure

### DIFF
--- a/lib/types/workload.go
+++ b/lib/types/workload.go
@@ -95,6 +95,7 @@ type AzureWorkloadConfig struct {
 	ClientID                   string                                `yaml:"client_id"`
 	SecretsProviderClientID    string                                `yaml:"secrets_provider_client_id"`
 	AdminGroupID               string                                `yaml:"admin_group_id"`
+	BastionInstanceType        string                                `yaml:"bastion_instance_type"`
 	InstanceType               string                                `yaml:"instance_type"`
 	ControlPlaneNodeCount      int                                   `yaml:"control_plane_node_count"`
 	WorkerNodeCount            int                                   `yaml:"worker_node_count"`

--- a/lib/types/workload_test.go
+++ b/lib/types/workload_test.go
@@ -151,6 +151,60 @@ func TestAzureWorkloadConfigSerialization(t *testing.T) {
 		unmarshaledConfig.Clusters["main"].Components.SecretStoreCsiDriverAzureProviderVersion)
 }
 
+func TestAzureWorkloadConfigBastionInstanceType(t *testing.T) {
+	// Test that bastion_instance_type field is properly serialized/deserialized
+	config := AzureWorkloadConfig{
+		SubscriptionID:          "123456789-abcd-efgh-ijkl-1234567890ab",
+		TenantID:                "abcdefgh-1234-5678-ijkl-1234567890ab",
+		Region:                  "eastus",
+		ClientID:                "12345678-abcd-efgh-ijkl-1234567890ab",
+		SecretsProviderClientID: "98765432-abcd-efgh-ijkl-1234567890ab",
+		BastionInstanceType:     "Standard_B2s",
+		InstanceType:            "Standard_D4s_v3",
+		ControlPlaneNodeCount:   1,
+		WorkerNodeCount:         1,
+		DBStorageSizeGB:         20,
+	}
+
+	// Marshal to YAML
+	yamlData, err := yaml.Marshal(config)
+	assert.NoError(t, err)
+
+	// Verify the YAML contains the bastion_instance_type field
+	yamlString := string(yamlData)
+	assert.Contains(t, yamlString, "bastion_instance_type: Standard_B2s")
+
+	// Unmarshal from YAML
+	var unmarshaledConfig AzureWorkloadConfig
+	err = yaml.Unmarshal(yamlData, &unmarshaledConfig)
+	assert.NoError(t, err)
+
+	// Verify bastion_instance_type matches
+	assert.Equal(t, config.BastionInstanceType, unmarshaledConfig.BastionInstanceType)
+	assert.Equal(t, "Standard_B2s", unmarshaledConfig.BastionInstanceType)
+}
+
+func TestAzureWorkloadConfigBastionInstanceTypeFromYAML(t *testing.T) {
+	// Test parsing bastion_instance_type from YAML
+	yamlContent := `
+subscription_id: "123456789-abcd-efgh-ijkl-1234567890ab"
+tenant_id: "abcdefgh-1234-5678-ijkl-1234567890ab"
+region: "eastus"
+client_id: "12345678-abcd-efgh-ijkl-1234567890ab"
+secrets_provider_client_id: "98765432-abcd-efgh-ijkl-1234567890ab"
+bastion_instance_type: "Standard_D2s_v3"
+instance_type: "Standard_D4s_v3"
+control_plane_node_count: 1
+worker_node_count: 1
+db_storage_size_gb: 20
+`
+
+	var config AzureWorkloadConfig
+	err := yaml.Unmarshal([]byte(yamlContent), &config)
+	assert.NoError(t, err)
+	assert.Equal(t, "Standard_D2s_v3", config.BastionInstanceType)
+}
+
 func TestAzureUserNodePoolConfigSerialization(t *testing.T) {
 	initialCount := 5
 	maxPods := 50

--- a/python-pulumi/src/ptd/azure_workload.py
+++ b/python-pulumi/src/ptd/azure_workload.py
@@ -66,6 +66,7 @@ class AzureWorkloadConfig(ptd.WorkloadConfig):
     resource_tags: dict[str, str] | None = None
     protect_persistent_resources: bool = True
     admin_group_id: str | None = None
+    bastion_instance_type: str = "Standard_B1s"
     ppm_file_share_size_gib: int = 100  # Minimum size for PPM Azure File Share in GiB
 
 

--- a/python-pulumi/src/ptd/pulumi_resources/azure_bastion.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_bastion.py
@@ -26,6 +26,7 @@ class AzureBastion(pulumi.ComponentResource):
         resource_group_name: str | pulumi.Output[str],
         location: str | pulumi.Output[str],
         tags: dict[str, str],
+        vm_size: str | pulumi.Output[str],
         *args,
         **kwargs,
     ):
@@ -39,6 +40,8 @@ class AzureBastion(pulumi.ComponentResource):
             *args,
             **kwargs,
         )
+
+        self.vm_size = vm_size
 
         # generate a key pair for the jumpbox
         self.jumpbox_ssh_key = tls.PrivateKey(
@@ -106,7 +109,7 @@ class AzureBastion(pulumi.ComponentResource):
             resource_group_name=resource_group_name,
             location=location,
             hardware_profile=compute.HardwareProfileArgs(
-                vm_size="Standard_B1s",
+                vm_size=self.vm_size,
             ),
             storage_profile=compute.StorageProfileArgs(
                 image_reference=compute.ImageReferenceArgs(

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_persistent.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_persistent.py
@@ -789,6 +789,7 @@ class AzureWorkloadPersistent(pulumi.ComponentResource):
             resource_group_name=self.vnet_rsg_name,
             location=self.workload.cfg.region,
             tags=self.required_tags,
+            vm_size=self.workload.cfg.bastion_instance_type,
             opts=pulumi.ResourceOptions(
                 protect=self.workload.cfg.protect_persistent_resources,
             ),

--- a/python-pulumi/tests/test_azure_bastion_config.py
+++ b/python-pulumi/tests/test_azure_bastion_config.py
@@ -1,0 +1,143 @@
+"""Tests for Azure Bastion instance type configuration."""
+
+import typing
+
+import pulumi
+
+import ptd.azure_workload
+
+
+class AzureBastionMocks(pulumi.runtime.Mocks):
+    """Mock Pulumi resource calls for testing."""
+
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs) -> tuple[str | None, dict[typing.Any, typing.Any]]:
+        """Mock resource creation - return resource ID and properties."""
+        # Return the inputs as outputs for testing
+        return args.name, dict(args.inputs)
+
+    def call(
+        self, _args: pulumi.runtime.MockCallArgs
+    ) -> dict[typing.Any, typing.Any] | tuple[dict[typing.Any, typing.Any], list[tuple[str, str]] | None]:
+        """Mock function calls."""
+        return {}
+
+
+pulumi.runtime.set_mocks(AzureBastionMocks(), preview=False)
+
+
+def test_azure_workload_config_default_bastion_instance_type():
+    """Test that AzureWorkloadConfig has correct default bastion_instance_type."""
+    config = ptd.azure_workload.AzureWorkloadConfig(
+        clusters={},
+        subscription_id="test-sub-id",
+        tenant_id="test-tenant-id",
+        client_id="test-client-id",
+        secrets_provider_client_id="test-sp-client-id",
+        network=ptd.azure_workload.NetworkConfig(
+            private_subnet_cidr="10.0.1.0/24",
+            db_subnet_cidr="10.0.2.0/24",
+            netapp_subnet_cidr="10.0.3.0/24",
+            app_gateway_subnet_cidr="10.0.4.0/24",
+            bastion_subnet_cidr="10.0.5.0/24",
+        ),
+        region="eastus",
+        control_room_account_id="test-account",
+        control_room_cluster_name="test-cluster",
+        control_room_domain="test.example.com",
+        control_room_region="eastus",
+        control_room_role_name="test-role",
+        control_room_state_bucket="test-bucket",
+        environment="test",
+        network_trust=ptd.NetworkTrust.FULL,
+        sites={},
+        true_name="test-workload",
+    )
+
+    # Verify default value
+    assert config.bastion_instance_type == "Standard_B1s"
+
+
+def test_azure_workload_config_custom_bastion_instance_type():
+    """Test that AzureWorkloadConfig accepts custom bastion_instance_type."""
+    config = ptd.azure_workload.AzureWorkloadConfig(
+        clusters={},
+        subscription_id="test-sub-id",
+        tenant_id="test-tenant-id",
+        client_id="test-client-id",
+        secrets_provider_client_id="test-sp-client-id",
+        network=ptd.azure_workload.NetworkConfig(
+            private_subnet_cidr="10.0.1.0/24",
+            db_subnet_cidr="10.0.2.0/24",
+            netapp_subnet_cidr="10.0.3.0/24",
+            app_gateway_subnet_cidr="10.0.4.0/24",
+            bastion_subnet_cidr="10.0.5.0/24",
+        ),
+        region="eastus",
+        bastion_instance_type="Standard_B2s",
+        control_room_account_id="test-account",
+        control_room_cluster_name="test-cluster",
+        control_room_domain="test.example.com",
+        control_room_region="eastus",
+        control_room_role_name="test-role",
+        control_room_state_bucket="test-bucket",
+        environment="test",
+        network_trust=ptd.NetworkTrust.FULL,
+        sites={},
+        true_name="test-workload",
+    )
+
+    # Verify custom value
+    assert config.bastion_instance_type == "Standard_B2s"
+
+
+def test_azure_workload_config_bastion_instance_type_matches_aws_pattern():
+    """Test that Azure uses same field name as AWS for consistency."""
+    aws_config = ptd.aws_workload.AWSWorkloadConfig(
+        clusters={},
+        account_id="123456789012",
+        region="us-east-1",
+        control_room_account_id="123456789012",
+        control_room_cluster_name="test-cluster",
+        control_room_domain="test.example.com",
+        control_room_region="us-east-1",
+        control_room_role_name="test-role",
+        control_room_state_bucket="test-bucket",
+        environment="test",
+        network_trust=ptd.NetworkTrust.FULL,
+        sites={},
+        true_name="test-workload",
+    )
+
+    azure_config = ptd.azure_workload.AzureWorkloadConfig(
+        clusters={},
+        subscription_id="test-sub-id",
+        tenant_id="test-tenant-id",
+        client_id="test-client-id",
+        secrets_provider_client_id="test-sp-client-id",
+        network=ptd.azure_workload.NetworkConfig(
+            private_subnet_cidr="10.0.1.0/24",
+            db_subnet_cidr="10.0.2.0/24",
+            netapp_subnet_cidr="10.0.3.0/24",
+            app_gateway_subnet_cidr="10.0.4.0/24",
+            bastion_subnet_cidr="10.0.5.0/24",
+        ),
+        region="eastus",
+        control_room_account_id="test-account",
+        control_room_cluster_name="test-cluster",
+        control_room_domain="test.example.com",
+        control_room_region="eastus",
+        control_room_role_name="test-role",
+        control_room_state_bucket="test-bucket",
+        environment="test",
+        network_trust=ptd.NetworkTrust.FULL,
+        sites={},
+        true_name="test-workload",
+    )
+
+    # Both configs should have the same field name for bastion instance type
+    assert hasattr(aws_config, "bastion_instance_type")
+    assert hasattr(azure_config, "bastion_instance_type")
+
+    # Verify they have appropriate defaults for their cloud provider
+    assert aws_config.bastion_instance_type == "t4g.nano"  # AWS default
+    assert azure_config.bastion_instance_type == "Standard_B1s"  # Azure default


### PR DESCRIPTION
## Summary

- Adds configurable `bastion_instance_type` field to Azure workload configuration
- Maintains parity with existing AWS functionality
- Sets sensible default of `Standard_B1s` for Azure bastion VMs

## Changes

- **Go**: Added `BastionInstanceType` field to `AzureWorkloadConfig` in lib/types/workload.go:98
- **Python**: Added `bastion_instance_type` field with default value in python-pulumi/src/ptd/azure_workload.py:69
- **Infrastructure**: Updated Azure bastion resource to use configurable VM size in python-pulumi/src/ptd/pulumi_resources/azure_bastion.py:109
- **Tests**: Added comprehensive test coverage for the new field in both Go and Python

## Test Plan

- [x] Unit tests pass for Go (bastion instance type serialization/deserialization)
- [x] Unit tests pass for Python (default and custom values)
- [x] Verified by running against a workload with custom bastion instance type