### PR TITLE
fix: incorrect default alert grouping

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -1971,10 +1971,10 @@ class AWSEKSCluster(pulumi.ComponentResource):
                             "contactPoints": [
                                 {
                                     "orgId": 1,
-                                    "name": "PositOpsGenie",
+                                    "name": "posit-opsgenie",
                                     "receivers": [
                                         {
-                                            "uid": "positOpsGenie",
+                                            "uid": "posit-opsgenie",
                                             "type": "opsgenie",
                                             "settings": {
                                                 "apiKey": '${{ "{" }}POSIT_OPSGENIE_KEY{{ "}" }}',  # ${POSIT_OPSGENIE_KEY} in the resulting configMap,
@@ -1990,7 +1990,7 @@ class AWSEKSCluster(pulumi.ComponentResource):
                             "policies": [
                                 {
                                     "orgId": 1,
-                                    "receiver": "PositOpsGenie",
+                                    "receiver": "posit-opsgenie",
                                     "group_by": ["alertname", "cluster"],
                                     "matchers": ["opsgenie = 1"],
                                     "group_wait": "30s",


### PR DESCRIPTION
# Description

Grafana was using default notification policies because we never configured policies.yaml. The default behavior groups alerts only by alertname and grafana_folder, which caused multiple clusters to be combined into one alert.

 1. Added policies.yaml configuration:                                                                                                                                    
  - group_by: [alertname, cluster] - Alerts are now grouped per-cluster, each cluster gets separate notification for each alert type
  - matchers: ["opsgenie = 1"] - Only routes alerts with the opsgenie label to OpsGenie                                                                                 
  - group_wait: 30s - Wait 30s before sending first notification (allows related alerts to group)                                                                       
  - group_interval: 5m - Wait 5m before sending updates to an existing alert group                                                                                      
  - repeat_interval: 4h - Re-notify every 4h if alert is still firing

2. Using posit-opsgenie everywhere for the receiver name and id instead of inconsistent casing
3. Updated the apiversion string. Pulumi/Helm serializes the Python dict to YAML for the Helm values, 1 (Python int) becomes 1 (YAML int), which matches what the Grafana docs show.
Reference here: https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/ 


## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
