### PR TITLE
fix: bump default aws alb idle connection timeout

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/aws_workload_helm.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_workload_helm.py
@@ -835,7 +835,7 @@ class AWSWorkloadHelm(pulumi.ComponentResource):
             "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-FS-1-2-2019-08",
             "alb.ingress.kubernetes.io/healthcheck-path": "/ping",
             "alb.ingress.kubernetes.io/healthcheck-port": "32090",
-            "alb.ingress.kubernetes.io/load-balancer-attributes": "routing.http.drop_invalid_header_fields.enabled=true",
+            "alb.ingress.kubernetes.io/load-balancer-attributes": "routing.http.drop_invalid_header_fields.enabled=true,idle_timeout.timeout_seconds=300",
         }
 
         if self.workload.cfg.provisioned_vpc:


### PR DESCRIPTION
# Description

Increase AWS Application Load Balancer idle timeout from 60 seconds (default) to 300 seconds (5 minutes) to support long-running WebSocket connections and large file uploads in Posit Connect. Our Azure load balancers already default to 4 minutes for this timeout, which is likely still sufficient.

## Problem

Users uploading large CSV files to Streamlit apps in Posit Connect on AWS workloads have observed intermittent failures. The uploads would work for smaller files but fail for larger ones that take more than 60 seconds to process.

Root cause: The AWS ALB idle timeout defaults to 60 seconds, causing the load balancer to terminate WebSocket connections too quickly.

## Solution

Configure the ALB idle timeout to 300 seconds via the `idle_timeout.timeout_seconds` load balancer attribute. This allows:
- WebSocket connections to stay open for up to 5 minutes
- Streamlit apps in Connect to maintain persistent connections during data processing

## Testing

Deployed a simple websocket echo service (image: jmalloc/echo-server:latest) to our test environment and ran:
`time wscat -c "wss://ws-test.{domain}/"`
- **Before:** WebSocket connection terminated at ~60 seconds
- **After:** WebSocket connection remained stable for 5+ minutes

User who reported this also verified that manually bumping the timeout in AWS solves their issue.
## Issue


## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
