### PR TITLE
Update alert queries to use latest observation

### DIFF
--- a/python-pulumi/src/ptd/grafana_alerts/pods.yaml
+++ b/python-pulumi/src/ptd/grafana_alerts/pods.yaml
@@ -118,11 +118,11 @@ groups:
                 expr: count by(cluster, pod, reason) (kube_pod_container_status_terminated_reason{reason!="Completed"} * on(cluster,pod) group_left(label_launcher_instance_id) kube_pod_labels{label_launcher_instance_id=""})
                 fullMetaSearch: false
                 includeNullMetadata: true
-                instant: false
+                instant: true
                 intervalMs: 1000
                 legendFormat: __auto
                 maxDataPoints: 43200
-                range: true
+                range: false
                 refId: A
                 useBackend: false
             - refId: B
@@ -209,11 +209,11 @@ groups:
                 expr: sum by (cluster, pod, phase) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"} * on(cluster,pod) group_left(label_launcher_instance_id) kube_pod_labels{label_launcher_instance_id=""}) > 0
                 fullMetaSearch: false
                 includeNullMetadata: true
-                instant: false
+                instant: true
                 intervalMs: 60000
                 legendFormat: __auto
                 maxDataPoints: 43200
-                range: true
+                range: false
                 refId: A
                 useBackend: false
             - refId: B
@@ -389,11 +389,11 @@ groups:
                 expr: kube_deployment_spec_replicas != kube_deployment_status_replicas_available
                 fullMetaSearch: false
                 includeNullMetadata: true
-                instant: false
+                instant: true
                 intervalMs: 60000
                 legendFormat: __auto
                 maxDataPoints: 43200
-                range: true
+                range: false
                 refId: A
                 useBackend: false
             - refId: B
@@ -474,11 +474,11 @@ groups:
                 expr: kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas
                 fullMetaSearch: false
                 includeNullMetadata: true
-                instant: false
+                instant: true
                 intervalMs: 60000
                 legendFormat: __auto
                 maxDataPoints: 43200
-                range: true
+                range: false
                 refId: A
                 useBackend: false
             - refId: B


### PR DESCRIPTION
# Description

## Fix: Grafana Alert False Positives Due to Range Queries

### Problem

Several Grafana alerts were firing false positives for transient issues that had already resolved. Specifically, the `PodNotHealthy` alert was triggering when pods had been in `Pending` state for ~11 minutes before transitioning to `Running`, despite the alert being configured with a 15-minute threshold.

### Root Cause

The affected alerts were using **range queries** (`instant: false`, `range: true`) with a 10-minute lookback window (`relativeTimeRange.from: 600`). This configuration caused alerts to evaluate historical data within the lookback window rather than the current state.

#### Timeline Example (PodNotHealthy)

```
T=0min:   Pod enters Pending state
T=11min:  Pod transitions to Running (healthy)
T=15min:  Alert evaluation runs
          ├─ Looks back 10 minutes (T=5min to T=15min)
          ├─ Pod WAS in Pending state during T=5min to T=11min
          ├─ Range query returns this historical data
          └─ Alert fires even though pod is currently healthy
```

The `for: 15m` duration only ensures the condition is true for 15 consecutive evaluations, but the condition itself was incorrectly evaluating historical state instead of current state.

### Solution

Changed all affected alerts from **range queries** to **instant queries** (`instant: true`, `range: false`). This ensures alerts evaluate the current state at the moment of evaluation, not historical state within a lookback window.

### Alerts Fixed

Fixed **4 alerts** in `ptd/python-pulumi/src/ptd/grafana_alerts/pods.yaml`:

| Alert | Issue | Impact |
|-------|-------|--------|
| **PodNotHealthy** | Could alert on pods that were unhealthy but recovered | False alerts for transient pod startup delays |
| **Pod Error** | Could alert on containers that terminated with errors but recovered | False alerts for containers that crashed and recovered |
| **DeploymentReplicaMismatch** | Could alert on deployments with temporary mismatches during rollouts | False alerts during normal deployment updates |
| **StatefulSetReplicaMismatch** | Could alert on statefulsets with temporary mismatches during updates | False alerts during normal statefulset updates |

### Verification

All other alerts were reviewed:

- **PodRestarts**: Correctly uses range queries (intentionally measures restart *rate* over time using `avg_over_time(increase(...))`)
- **CrashLoopBackoff**: Already using instant queries correctly
- **All other alert files** (applications.yaml, cloudwatch.yaml, healthchecks.yaml, mimir.yaml, nodes.yaml): Already using instant queries correctly

### Expected Behavior After Fix

#### Before (Incorrect)
```
Pod Pending → Running after 11 minutes = ⚠️ Alert fires (incorrect)
```

#### After (Correct)
```
Pod Pending → Running after 11 minutes = ✅ No alert (correct)
Pod Pending for 15+ minutes continuously = ⚠️ Alert fires (correct)
```

### Technical Details

**Changed fields:**
```diff
- instant: false
+ instant: true
- range: true
+ range: false
```

This ensures that:
1. The Prometheus query evaluates the metric's value **at the moment of evaluation**
2. The `for: 15m` duration correctly means "alert only if the condition is **currently** true for 15 consecutive minutes"
3. Transient issues that resolve themselves no longer trigger alerts


## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
