### PR TITLE
Add ptd verify command for post-deploy VIP testing

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,6 +5,7 @@ go 1.25.3
 replace github.com/posit-dev/ptd/lib => ../lib
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/log v0.4.2
 	github.com/posit-dev/ptd/lib v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.9.1
@@ -28,7 +29,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
-	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -36,8 +36,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
-github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
-github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/cmd/internal/verify/cleanup.go
+++ b/cmd/internal/verify/cleanup.go
@@ -1,0 +1,149 @@
+package verify
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// CleanupCredentials deletes VIP test credentials and resources.
+func CleanupCredentials(ctx context.Context, env []string, namespace, connectURL string) error {
+	// Read vip-test-credentials Secret to get the Connect API key and key name
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "secret", vipTestCredentialsSecret,
+		"-n", namespace,
+		"-o", "json")
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Secret doesn't exist, nothing to clean up
+			if strings.Contains(string(exitErr.Stderr), "not found") {
+				fmt.Fprintf(os.Stderr, "No credentials secret found, nothing to clean up\n")
+				return nil
+			}
+			return fmt.Errorf("failed to get credentials secret: %s", string(exitErr.Stderr))
+		}
+		return fmt.Errorf("failed to get credentials secret: %w", err)
+	}
+
+	var secret struct {
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(output, &secret); err != nil {
+		return fmt.Errorf("failed to parse secret: %w", err)
+	}
+
+	// Extract and decode the Connect API key and key name
+	apiKeyB64, hasAPIKey := secret.Data["VIP_CONNECT_API_KEY"]
+	keyNameB64, hasKeyName := secret.Data["VIP_CONNECT_KEY_NAME"]
+
+	if hasAPIKey && hasKeyName && connectURL != "" {
+		// Decode base64 values
+		apiKeyBytes, err := base64.StdEncoding.DecodeString(apiKeyB64)
+		if err != nil {
+			return fmt.Errorf("failed to decode API key: %w", err)
+		}
+		apiKey := string(apiKeyBytes)
+
+		keyNameBytes, err := base64.StdEncoding.DecodeString(keyNameB64)
+		if err != nil {
+			return fmt.Errorf("failed to decode key name: %w", err)
+		}
+		keyName := string(keyNameBytes)
+
+		// Delete the Connect API key via the Connect API
+		if err := deleteConnectAPIKey(ctx, connectURL, apiKey, keyName); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to delete Connect API key: %v\n", err)
+			// Continue with cleanup even if API key deletion fails
+		} else {
+			fmt.Fprintf(os.Stderr, "Deleted Connect API key: %s\n", keyName)
+		}
+	}
+
+	// Delete the vip-test-credentials K8s Secret
+	deleteCmd := exec.CommandContext(ctx, "kubectl", "delete", "secret", vipTestCredentialsSecret,
+		"-n", namespace,
+		"--ignore-not-found")
+	deleteCmd.Env = env
+
+	if err := deleteCmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete credentials secret: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Deleted credentials secret: %s\n", vipTestCredentialsSecret)
+	return nil
+}
+
+// deleteConnectAPIKey deletes a Connect API key by name using the Connect API.
+func deleteConnectAPIKey(ctx context.Context, connectURL, apiKey, keyName string) error {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	// GET all API keys for the user
+	listURL := fmt.Sprintf("%s/__api__/v1/user/api_keys", connectURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", listURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Key "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("list API keys failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var apiKeys []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiKeys); err != nil {
+		return fmt.Errorf("failed to parse API keys response: %w", err)
+	}
+
+	// Find the key by name
+	var keyID string
+	for _, key := range apiKeys {
+		if key.Name == keyName {
+			keyID = key.ID
+			break
+		}
+	}
+
+	if keyID == "" {
+		return fmt.Errorf("API key with name %q not found", keyName)
+	}
+
+	// DELETE the API key by ID
+	deleteURL := fmt.Sprintf("%s/__api__/v1/user/api_keys/%s", connectURL, keyID)
+	req, err = http.NewRequestWithContext(ctx, "DELETE", deleteURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Key "+apiKey)
+
+	resp, err = client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete API key failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -55,6 +55,11 @@ type SiteSpec struct {
 
 type ProductSpec struct {
 	DomainPrefix string   `yaml:"domainPrefix,omitempty"`
+	// BaseDomain is the bare parent domain for this product (e.g. "example.com").
+	// It must NOT include the product subdomain; buildProductURL always prepends the
+	// product prefix (DomainPrefix or the default) to form the final URL.
+	// For example, BaseDomain="example.com" with default prefix "connect" yields
+	// "https://connect.example.com".
 	BaseDomain   string   `yaml:"baseDomain,omitempty"`
 	Auth         *AuthSpec `yaml:"auth,omitempty"`
 }
@@ -148,7 +153,10 @@ func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 	return buf.String(), nil
 }
 
-// buildProductURL constructs the product URL from the product spec
+// buildProductURL constructs the product URL from the product spec.
+// The prefix (DomainPrefix or defaultPrefix) is always prepended to the domain, so
+// ProductSpec.BaseDomain must be a bare parent domain (e.g. "example.com"), not a
+// fully-qualified hostname that already includes the product subdomain.
 func buildProductURL(spec *ProductSpec, defaultPrefix, baseDomain string) string {
 	prefix := defaultPrefix
 	if spec.DomainPrefix != "" {

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/BurntSushi/toml"
-	"gopkg.in/yaml.v3"
 )
 
 // VIPConfig represents the vip.toml configuration structure
@@ -68,13 +67,8 @@ type KeycloakSpec struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-// GenerateConfig generates a vip.toml configuration from a Site CR YAML
-func GenerateConfig(siteYAML []byte, targetName string) (string, error) {
-	var site SiteCR
-	if err := yaml.Unmarshal(siteYAML, &site); err != nil {
-		return "", fmt.Errorf("failed to parse Site CR YAML: %w", err)
-	}
-
+// GenerateConfig generates a vip.toml configuration from a parsed Site CR
+func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 	config := VIPConfig{
 		General: GeneralConfig{
 			DeploymentName: targetName,
@@ -101,10 +95,10 @@ func GenerateConfig(siteYAML []byte, targetName string) (string, error) {
 
 	// Configure Connect
 	if site.Spec.Connect != nil {
-		url := buildProductURL(site.Spec.Connect, "connect", site.Spec.Domain)
+		productURL := buildProductURL(site.Spec.Connect, "connect", site.Spec.Domain)
 		config.Connect = ProductConfig{
 			Enabled: true,
-			URL:     url,
+			URL:     productURL,
 		}
 	} else {
 		config.Connect = ProductConfig{Enabled: false}
@@ -112,10 +106,10 @@ func GenerateConfig(siteYAML []byte, targetName string) (string, error) {
 
 	// Configure Workbench
 	if site.Spec.Workbench != nil {
-		url := buildProductURL(site.Spec.Workbench, "workbench", site.Spec.Domain)
+		productURL := buildProductURL(site.Spec.Workbench, "workbench", site.Spec.Domain)
 		config.Workbench = ProductConfig{
 			Enabled: true,
-			URL:     url,
+			URL:     productURL,
 		}
 	} else {
 		config.Workbench = ProductConfig{Enabled: false}
@@ -123,10 +117,10 @@ func GenerateConfig(siteYAML []byte, targetName string) (string, error) {
 
 	// Configure Package Manager
 	if site.Spec.PackageManager != nil {
-		url := buildProductURL(site.Spec.PackageManager, "packagemanager", site.Spec.Domain)
+		productURL := buildProductURL(site.Spec.PackageManager, "packagemanager", site.Spec.Domain)
 		config.PackageManager = ProductConfig{
 			Enabled: true,
-			URL:     url,
+			URL:     productURL,
 		}
 	} else {
 		config.PackageManager = ProductConfig{Enabled: false}

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -73,8 +73,11 @@ func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 		return "", fmt.Errorf("site cannot be nil")
 	}
 
-	if site.Spec.Domain == "" && (site.Spec.Connect != nil || site.Spec.Workbench != nil || site.Spec.PackageManager != nil) {
-		return "", fmt.Errorf("site domain is required when products are configured")
+	needsDomain := (site.Spec.Connect != nil && site.Spec.Connect.BaseDomain == "") ||
+		(site.Spec.Workbench != nil && site.Spec.Workbench.BaseDomain == "") ||
+		(site.Spec.PackageManager != nil && site.Spec.PackageManager.BaseDomain == "")
+	if site.Spec.Domain == "" && needsDomain {
+		return "", fmt.Errorf("site domain is required when products are configured without a per-product baseDomain")
 	}
 
 	config := VIPConfig{

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -158,6 +158,9 @@ func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 // ProductSpec.BaseDomain must be a bare parent domain (e.g. "example.com"), not a
 // fully-qualified hostname that already includes the product subdomain.
 func buildProductURL(spec *ProductSpec, defaultPrefix, baseDomain string) string {
+	if spec == nil {
+		return fmt.Sprintf("https://%s.%s", defaultPrefix, baseDomain)
+	}
 	prefix := defaultPrefix
 	if spec.DomainPrefix != "" {
 		prefix = spec.DomainPrefix

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -69,6 +69,10 @@ type KeycloakSpec struct {
 
 // GenerateConfig generates a vip.toml configuration from a parsed Site CR
 func GenerateConfig(site *SiteCR, targetName string) (string, error) {
+	if site == nil {
+		return "", fmt.Errorf("site cannot be nil")
+	}
+
 	config := VIPConfig{
 		General: GeneralConfig{
 			DeploymentName: targetName,

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -95,7 +95,8 @@ func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 		},
 	}
 
-	// Determine auth provider
+	// Determine auth provider. PackageManager is intentionally excluded: it does not
+	// support authentication types that VIP tests against, so its auth spec is not consulted.
 	authProvider := "oidc" // default
 	if site.Spec.Connect != nil && site.Spec.Connect.Auth != nil && site.Spec.Connect.Auth.Type != "" {
 		authProvider = site.Spec.Connect.Auth.Type

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -1,0 +1,158 @@
+package verify
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+	"gopkg.in/yaml.v3"
+)
+
+// VIPConfig represents the vip.toml configuration structure
+type VIPConfig struct {
+	General        GeneralConfig        `toml:"general"`
+	Connect        ProductConfig        `toml:"connect"`
+	Workbench      ProductConfig        `toml:"workbench"`
+	PackageManager ProductConfig        `toml:"package_manager"`
+	Auth           AuthConfig           `toml:"auth"`
+	Email          DisableableConfig    `toml:"email"`
+	Monitoring     DisableableConfig    `toml:"monitoring"`
+	Security       SecurityConfig       `toml:"security"`
+}
+
+type GeneralConfig struct {
+	DeploymentName string `toml:"deployment_name"`
+}
+
+type ProductConfig struct {
+	Enabled bool   `toml:"enabled"`
+	URL     string `toml:"url,omitempty"`
+}
+
+type AuthConfig struct {
+	Provider string `toml:"provider"`
+}
+
+type DisableableConfig struct {
+	Enabled bool `toml:"enabled"`
+}
+
+type SecurityConfig struct {
+	PolicyChecksEnabled bool `toml:"policy_checks_enabled"`
+}
+
+// SiteCR represents the Kubernetes Site custom resource
+type SiteCR struct {
+	Spec SiteSpec `yaml:"spec"`
+}
+
+type SiteSpec struct {
+	Domain         string              `yaml:"domain"`
+	Connect        *ProductSpec        `yaml:"connect,omitempty"`
+	Workbench      *ProductSpec        `yaml:"workbench,omitempty"`
+	PackageManager *ProductSpec        `yaml:"packageManager,omitempty"`
+	Keycloak       *KeycloakSpec       `yaml:"keycloak,omitempty"`
+}
+
+type ProductSpec struct {
+	DomainPrefix string   `yaml:"domainPrefix,omitempty"`
+	BaseDomain   string   `yaml:"baseDomain,omitempty"`
+	Auth         *AuthSpec `yaml:"auth,omitempty"`
+}
+
+type AuthSpec struct {
+	Type string `yaml:"type"`
+}
+
+type KeycloakSpec struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// GenerateConfig generates a vip.toml configuration from a Site CR YAML
+func GenerateConfig(siteYAML []byte, targetName string) (string, error) {
+	var site SiteCR
+	if err := yaml.Unmarshal(siteYAML, &site); err != nil {
+		return "", fmt.Errorf("failed to parse Site CR YAML: %w", err)
+	}
+
+	config := VIPConfig{
+		General: GeneralConfig{
+			DeploymentName: targetName,
+		},
+		Email: DisableableConfig{
+			Enabled: false,
+		},
+		Monitoring: DisableableConfig{
+			Enabled: false,
+		},
+		Security: SecurityConfig{
+			PolicyChecksEnabled: false,
+		},
+	}
+
+	// Determine auth provider
+	authProvider := "oidc" // default
+	if site.Spec.Connect != nil && site.Spec.Connect.Auth != nil {
+		authProvider = site.Spec.Connect.Auth.Type
+	} else if site.Spec.Workbench != nil && site.Spec.Workbench.Auth != nil {
+		authProvider = site.Spec.Workbench.Auth.Type
+	}
+	config.Auth = AuthConfig{Provider: authProvider}
+
+	// Configure Connect
+	if site.Spec.Connect != nil {
+		url := buildProductURL(site.Spec.Connect, "connect", site.Spec.Domain)
+		config.Connect = ProductConfig{
+			Enabled: true,
+			URL:     url,
+		}
+	} else {
+		config.Connect = ProductConfig{Enabled: false}
+	}
+
+	// Configure Workbench
+	if site.Spec.Workbench != nil {
+		url := buildProductURL(site.Spec.Workbench, "workbench", site.Spec.Domain)
+		config.Workbench = ProductConfig{
+			Enabled: true,
+			URL:     url,
+		}
+	} else {
+		config.Workbench = ProductConfig{Enabled: false}
+	}
+
+	// Configure Package Manager
+	if site.Spec.PackageManager != nil {
+		url := buildProductURL(site.Spec.PackageManager, "packagemanager", site.Spec.Domain)
+		config.PackageManager = ProductConfig{
+			Enabled: true,
+			URL:     url,
+		}
+	} else {
+		config.PackageManager = ProductConfig{Enabled: false}
+	}
+
+	// Encode to TOML
+	var buf bytes.Buffer
+	encoder := toml.NewEncoder(&buf)
+	if err := encoder.Encode(config); err != nil {
+		return "", fmt.Errorf("failed to encode TOML: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// buildProductURL constructs the product URL from the product spec
+func buildProductURL(spec *ProductSpec, defaultPrefix, baseDomain string) string {
+	prefix := defaultPrefix
+	if spec.DomainPrefix != "" {
+		prefix = spec.DomainPrefix
+	}
+
+	domain := baseDomain
+	if spec.BaseDomain != "" {
+		domain = spec.BaseDomain
+	}
+
+	return fmt.Sprintf("https://%s.%s", prefix, domain)
+}

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -73,6 +73,10 @@ func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 		return "", fmt.Errorf("site cannot be nil")
 	}
 
+	if site.Spec.Domain == "" && (site.Spec.Connect != nil || site.Spec.Workbench != nil || site.Spec.PackageManager != nil) {
+		return "", fmt.Errorf("site domain is required when products are configured")
+	}
+
 	config := VIPConfig{
 		General: GeneralConfig{
 			DeploymentName: targetName,

--- a/cmd/internal/verify/config.go
+++ b/cmd/internal/verify/config.go
@@ -86,9 +86,9 @@ func GenerateConfig(site *SiteCR, targetName string) (string, error) {
 
 	// Determine auth provider
 	authProvider := "oidc" // default
-	if site.Spec.Connect != nil && site.Spec.Connect.Auth != nil {
+	if site.Spec.Connect != nil && site.Spec.Connect.Auth != nil && site.Spec.Connect.Auth.Type != "" {
 		authProvider = site.Spec.Connect.Auth.Type
-	} else if site.Spec.Workbench != nil && site.Spec.Workbench.Auth != nil {
+	} else if site.Spec.Workbench != nil && site.Spec.Workbench.Auth != nil && site.Spec.Workbench.Auth.Type != "" {
 		authProvider = site.Spec.Workbench.Auth.Type
 	}
 	config.Auth = AuthConfig{Provider: authProvider}

--- a/cmd/internal/verify/credentials.go
+++ b/cmd/internal/verify/credentials.go
@@ -1,0 +1,135 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// MintConnectKey calls the VIP CLI to mint a Connect API key via interactive browser auth.
+// Returns the API key and key name from the VIP CLI output.
+func MintConnectKey(ctx context.Context, connectURL string) (apiKey string, keyName string, err error) {
+	// Check if vip CLI is available
+	if _, err := exec.LookPath("vip"); err != nil {
+		return "", "", fmt.Errorf("VIP CLI not found. Install with: pip install /path/to/vip")
+	}
+
+	cmd := exec.CommandContext(ctx, "vip", "auth", "mint-connect-key", "--url", connectURL)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", "", fmt.Errorf("vip auth mint-connect-key failed: %s", string(exitErr.Stderr))
+		}
+		return "", "", fmt.Errorf("vip auth mint-connect-key failed: %w", err)
+	}
+
+	// Parse JSON output: {"api_key": "...", "key_name": "..."}
+	var result struct {
+		APIKey  string `json:"api_key"`
+		KeyName string `json:"key_name"`
+	}
+	if err := json.Unmarshal(output, &result); err != nil {
+		return "", "", fmt.Errorf("failed to parse vip CLI output: %w", err)
+	}
+
+	if result.APIKey == "" || result.KeyName == "" {
+		return "", "", fmt.Errorf("vip CLI returned empty api_key or key_name")
+	}
+
+	return result.APIKey, result.KeyName, nil
+}
+
+// GenerateWorkbenchToken generates a Workbench API token via kubectl exec.
+func GenerateWorkbenchToken(ctx context.Context, env []string, namespace, siteName, username string) (string, error) {
+	deploymentName := fmt.Sprintf("workbench-%s", siteName)
+	cmd := exec.CommandContext(ctx, "kubectl", "exec",
+		fmt.Sprintf("deploy/%s", deploymentName),
+		"-n", namespace,
+		"--",
+		"rstudio-server", "generate-api-token", "user", "vip-test", username)
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("kubectl exec generate-api-token failed: %s", string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("kubectl exec generate-api-token failed: %w", err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GeneratePackageManagerToken generates a PM token via kubectl exec.
+func GeneratePackageManagerToken(ctx context.Context, env []string, namespace, siteName string) (string, error) {
+	deploymentName := fmt.Sprintf("package-manager-%s", siteName)
+	cmd := exec.CommandContext(ctx, "kubectl", "exec",
+		fmt.Sprintf("deploy/%s", deploymentName),
+		"-n", namespace,
+		"--",
+		"rspm", "create", "token", "--scope=repos:read", "--quiet")
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("kubectl exec rspm create token failed: %s", string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("kubectl exec rspm create token failed: %w", err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+// SaveCredentialsSecret creates or updates the vip-test-credentials K8s Secret with all tokens.
+func SaveCredentialsSecret(ctx context.Context, env []string, namespace string, creds map[string]string) error {
+	// Build kubectl create secret generic command
+	args := []string{"create", "secret", "generic", vipTestCredentialsSecret, "-n", namespace}
+	for key, value := range creds {
+		args = append(args, fmt.Sprintf("--from-literal=%s=%s", key, value))
+	}
+	args = append(args, "--dry-run=client", "-o", "json")
+
+	// Generate the secret manifest
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	cmd.Env = env
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("kubectl create secret failed: %s", string(exitErr.Stderr))
+		}
+		return fmt.Errorf("kubectl create secret failed: %w", err)
+	}
+
+	// Parse the generated secret to add labels
+	var secret map[string]interface{}
+	if err := json.Unmarshal(output, &secret); err != nil {
+		return fmt.Errorf("failed to parse secret manifest: %w", err)
+	}
+
+	// Add labels
+	metadata := secret["metadata"].(map[string]interface{})
+	metadata["labels"] = map[string]string{
+		"app.kubernetes.io/managed-by": "ptd",
+		"app.kubernetes.io/name":       "vip-verify",
+	}
+
+	// Marshal back to JSON
+	secretJSON, err := json.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("failed to marshal secret: %w", err)
+	}
+
+	// Apply the secret
+	applyCmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", "-", "-n", namespace)
+	applyCmd.Env = env
+	applyCmd.Stdin = strings.NewReader(string(secretJSON))
+
+	if output, err := applyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply secret failed: %s", string(output))
+	}
+
+	return nil
+}

--- a/cmd/internal/verify/job.go
+++ b/cmd/internal/verify/job.go
@@ -261,6 +261,7 @@ func WaitForJob(ctx context.Context, env []string, jobName string, namespace str
 
 			output, err := cmd.Output()
 			if err != nil {
+				slog.Warn("kubectl get job failed, retrying", "error", err)
 				continue
 			}
 

--- a/cmd/internal/verify/job.go
+++ b/cmd/internal/verify/job.go
@@ -1,0 +1,233 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// JobOptions contains options for creating a VIP verification Job
+type JobOptions struct {
+	Image      string
+	Categories string
+	JobName    string
+	ConfigName string
+}
+
+// CreateConfigMap creates a Kubernetes ConfigMap with the vip.toml configuration
+func CreateConfigMap(ctx context.Context, env []string, configName string, config string) error {
+	// Create a temporary file with the config
+	tmpfile, err := os.CreateTemp("", "vip-config-*.toml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString(config); err != nil {
+		tmpfile.Close()
+		return fmt.Errorf("failed to write config to temp file: %w", err)
+	}
+	tmpfile.Close()
+
+	// Create ConfigMap from the file
+	cmd := exec.CommandContext(ctx, "kubectl", "create", "configmap", configName,
+		"--from-file=vip.toml="+tmpfile.Name(),
+		"-n", "posit-team",
+		"--dry-run=client",
+		"-o", "yaml")
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("kubectl create configmap failed: %s", string(exitErr.Stderr))
+		}
+		return fmt.Errorf("kubectl create configmap failed: %w", err)
+	}
+
+	// Apply the ConfigMap
+	applyCmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", "-", "-n", "posit-team")
+	applyCmd.Env = env
+	applyCmd.Stdin = strings.NewReader(string(output))
+
+	if output, err := applyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply configmap failed: %s", string(output))
+	}
+
+	return nil
+}
+
+// CreateJob creates a Kubernetes Job for running VIP tests
+func CreateJob(ctx context.Context, env []string, opts JobOptions) error {
+	// Build args - only add -m filter if categories are specified
+	args := `["--tb=short", "-v"]`
+	if opts.Categories != "" {
+		args = fmt.Sprintf(`["--tb=short", "-v", "-m", "%s"]`, opts.Categories)
+	}
+
+	jobYAML := fmt.Sprintf(`apiVersion: batch/v1
+kind: Job
+metadata:
+  name: %s
+  namespace: posit-team
+  labels:
+    app.kubernetes.io/name: vip-verify
+    app.kubernetes.io/managed-by: ptd
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: vip
+        image: %s
+        args: %s
+        volumeMounts:
+        - name: config
+          mountPath: /app/vip.toml
+          subPath: vip.toml
+        env:
+        - name: VIP_TEST_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: vip-test-credentials
+              key: username
+        - name: VIP_TEST_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: vip-test-credentials
+              key: password
+      volumes:
+      - name: config
+        configMap:
+          name: %s
+`, opts.JobName, opts.Image, args, opts.ConfigName)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", "-", "-n", "posit-team")
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(jobYAML)
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply job failed: %s", string(output))
+	}
+
+	return nil
+}
+
+// StreamLogs follows the logs of the Job pod
+func StreamLogs(ctx context.Context, env []string, jobName string) error {
+	// Wait for pod to be created (timeout after 30 seconds)
+	podName, err := waitForPod(ctx, env, jobName, 30*time.Second)
+	if err != nil {
+		return err
+	}
+
+	// Stream the pod logs
+	cmd := exec.CommandContext(ctx, "kubectl", "logs", "-f", podName, "-n", "posit-team")
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		// Don't return error if the pod has already completed
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Exit code 1 from kubectl logs usually means pod is already done
+			if exitErr.ExitCode() == 1 {
+				return nil
+			}
+		}
+		return fmt.Errorf("failed to stream logs: %w", err)
+	}
+
+	return nil
+}
+
+// waitForPod waits for a pod associated with the job to be created
+func waitForPod(ctx context.Context, env []string, jobName string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("timeout waiting for pod to be created")
+		case <-ticker.C:
+			cmd := exec.CommandContext(ctx, "kubectl", "get", "pods",
+				"-n", "posit-team",
+				"-l", "batch.kubernetes.io/job-name="+jobName,
+				"-o", "jsonpath={.items[0].metadata.name}")
+			cmd.Env = env
+
+			output, err := cmd.Output()
+			if err == nil && len(output) > 0 {
+				return string(output), nil
+			}
+		}
+	}
+}
+
+// WaitForJob waits for the Job to complete and returns success status
+func WaitForJob(ctx context.Context, env []string, jobName string) (bool, error) {
+	// Wait for job to complete (timeout after 15 minutes)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false, fmt.Errorf("timeout waiting for job to complete")
+		case <-ticker.C:
+			cmd := exec.CommandContext(ctx, "kubectl", "get", "job", jobName,
+				"-n", "posit-team",
+				"-o", "jsonpath={.status.conditions[?(@.type==\"Complete\")].status} {.status.conditions[?(@.type==\"Failed\")].status}")
+			cmd.Env = env
+
+			output, err := cmd.Output()
+			if err != nil {
+				continue
+			}
+
+			status := strings.TrimSpace(string(output))
+			parts := strings.Fields(status)
+
+			// Check if job completed successfully
+			if len(parts) >= 1 && parts[0] == "True" {
+				return true, nil
+			}
+
+			// Check if job failed
+			if len(parts) >= 2 && parts[1] == "True" {
+				return false, nil
+			}
+		}
+	}
+}
+
+// Cleanup removes the Job and ConfigMap
+func Cleanup(ctx context.Context, env []string, jobName string, configName string) error {
+	// Delete job
+	jobCmd := exec.CommandContext(ctx, "kubectl", "delete", "job", jobName, "-n", "posit-team", "--ignore-not-found")
+	jobCmd.Env = env
+	if err := jobCmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete job: %w", err)
+	}
+
+	// Delete configmap
+	cmCmd := exec.CommandContext(ctx, "kubectl", "delete", "configmap", configName, "-n", "posit-team", "--ignore-not-found")
+	cmCmd.Env = env
+	if err := cmCmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete configmap: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/internal/verify/job.go
+++ b/cmd/internal/verify/job.go
@@ -219,7 +219,10 @@ func waitForPod(ctx context.Context, env []string, jobName string, timeout time.
 	for {
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("timeout waiting for pod to be created")
+			if ctx.Err() == context.DeadlineExceeded {
+				return "", fmt.Errorf("timeout waiting for pod to be created")
+			}
+			return "", fmt.Errorf("cancelled while waiting for pod to be created")
 		case <-ticker.C:
 			cmd := exec.CommandContext(ctx, "kubectl", "get", "pods",
 				"-n", namespace,

--- a/cmd/internal/verify/job.go
+++ b/cmd/internal/verify/job.go
@@ -188,7 +188,7 @@ func StreamLogs(ctx context.Context, env []string, jobName string, namespace str
 				return nil
 			}
 			// Phase unknown or check failed; warn but continue to WaitForJob.
-			slog.Warn("kubectl logs exited with code 1; log output may be incomplete", "pod", podName)
+			slog.Warn("kubectl logs exited with code 1; log output may be incomplete", "pod", podName, "phaseErr", phaseErr)
 			return nil
 		}
 		return fmt.Errorf("failed to stream logs: %w", err)

--- a/cmd/internal/verify/job.go
+++ b/cmd/internal/verify/job.go
@@ -249,7 +249,10 @@ func WaitForJob(ctx context.Context, env []string, jobName string, namespace str
 	for {
 		select {
 		case <-ctx.Done():
-			return false, fmt.Errorf("timeout waiting for job to complete")
+			if ctx.Err() == context.DeadlineExceeded {
+				return false, fmt.Errorf("timeout waiting for job to complete")
+			}
+			return false, fmt.Errorf("cancelled while waiting for job to complete")
 		case <-ticker.C:
 			cmd := exec.CommandContext(ctx, "kubectl", "get", "job", jobName,
 				"-n", namespace,

--- a/cmd/internal/verify/job.go
+++ b/cmd/internal/verify/job.go
@@ -20,6 +20,7 @@ type JobOptions struct {
 	ConfigName           string
 	Namespace            string
 	CredentialsAvailable bool // whether vip-test-credentials Secret exists
+	InteractiveAuth      bool // whether using interactive auth (API tokens) vs Keycloak (username/password)
 	Timeout              time.Duration
 }
 
@@ -102,25 +103,59 @@ func buildJobSpec(opts JobOptions) map[string]interface{} {
 		},
 	}
 	if opts.CredentialsAvailable {
-		container["env"] = []map[string]interface{}{
-			{
-				"name": "VIP_TEST_USERNAME",
-				"valueFrom": map[string]interface{}{
-					"secretKeyRef": map[string]string{
-						"name": "vip-test-credentials",
-						"key":  "username",
+		if opts.InteractiveAuth {
+			// Interactive auth mode: use API tokens from Secret
+			container["env"] = []map[string]interface{}{
+				{
+					"name": "VIP_CONNECT_API_KEY",
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]string{
+							"name": "vip-test-credentials",
+							"key":  "VIP_CONNECT_API_KEY",
+						},
 					},
 				},
-			},
-			{
-				"name": "VIP_TEST_PASSWORD",
-				"valueFrom": map[string]interface{}{
-					"secretKeyRef": map[string]string{
-						"name": "vip-test-credentials",
-						"key":  "password",
+				{
+					"name": "VIP_WORKBENCH_API_KEY",
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]string{
+							"name": "vip-test-credentials",
+							"key":  "VIP_WORKBENCH_API_KEY",
+						},
 					},
 				},
-			},
+				{
+					"name": "VIP_PM_TOKEN",
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]string{
+							"name": "vip-test-credentials",
+							"key":  "VIP_PM_TOKEN",
+						},
+					},
+				},
+			}
+		} else {
+			// Keycloak mode: use username/password from Secret
+			container["env"] = []map[string]interface{}{
+				{
+					"name": "VIP_TEST_USERNAME",
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]string{
+							"name": "vip-test-credentials",
+							"key":  "username",
+						},
+					},
+				},
+				{
+					"name": "VIP_TEST_PASSWORD",
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]string{
+							"name": "vip-test-credentials",
+							"key":  "password",
+						},
+					},
+				},
+			}
 		}
 	}
 

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -68,6 +68,11 @@ func EnsureTestUser(ctx context.Context, env []string, siteName string, keycloak
 	return nil
 }
 
+// getTestCredentials retrieves VIP test user credentials from the vip-test-credentials Secret.
+func getTestCredentials(ctx context.Context, env []string) (string, string, error) {
+	return getKeycloakAdminCreds(ctx, env, "vip-test-credentials")
+}
+
 // generatePassword generates a cryptographically random password of the given length.
 func generatePassword(length int) (string, error) {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -51,7 +51,7 @@ func EnsureTestUser(ctx context.Context, env []string, keycloakURL string, realm
 
 	slog.Info("Creating test user in Keycloak")
 
-	adminUser, adminPass, err := getKeycloakAdminCreds(ctx, env, adminSecretName, namespace)
+	adminUser, adminPass, err := getSecretCredentials(ctx, env, adminSecretName, namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get Keycloak admin credentials: %w", err)
 	}
@@ -96,8 +96,8 @@ func generatePassword(length int) (string, error) {
 	return string(result), nil
 }
 
-// getKeycloakAdminCreds retrieves Keycloak admin credentials from the secret
-func getKeycloakAdminCreds(ctx context.Context, env []string, secretName string, namespace string) (string, string, error) {
+// getSecretCredentials retrieves username and password from a Kubernetes Secret.
+func getSecretCredentials(ctx context.Context, env []string, secretName string, namespace string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, "kubectl", "get", "secret", secretName,
 		"-n", namespace,
 		"-o", "jsonpath={.data.username} {.data.password}")

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -161,7 +161,7 @@ func getKeycloakAdminToken(ctx context.Context, keycloakURL, username, password 
 // always matches the actual Keycloak credentials.
 func createKeycloakUser(ctx context.Context, keycloakURL, realm, token, username, password string) error {
 	client := &http.Client{Timeout: keycloakHTTPTimeout}
-	usersURL := fmt.Sprintf("%s/admin/realms/%s/users", keycloakURL, realm)
+	usersURL := fmt.Sprintf("%s/admin/realms/%s/users", keycloakURL, url.PathEscape(realm))
 
 	// Check if user already exists; use url.Values to safely encode the username.
 	params := url.Values{"username": {username}, "exact": {"true"}}
@@ -230,7 +230,7 @@ func createKeycloakUser(ctx context.Context, keycloakURL, realm, token, username
 
 // resetKeycloakUserPassword sets a user's password via the Keycloak admin API.
 func resetKeycloakUserPassword(ctx context.Context, keycloakURL, realm, token, userID, password string, client *http.Client) error {
-	resetURL := fmt.Sprintf("%s/admin/realms/%s/users/%s/reset-password", keycloakURL, realm, userID)
+	resetURL := fmt.Sprintf("%s/admin/realms/%s/users/%s/reset-password", keycloakURL, url.PathEscape(realm), url.PathEscape(userID))
 	payload := map[string]interface{}{
 		"type":      "password",
 		"value":     password,

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -1,0 +1,215 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"strings"
+)
+
+// EnsureTestUser ensures a test user exists in Keycloak and credentials are in a Secret
+func EnsureTestUser(ctx context.Context, env []string, siteName string, keycloakURL string, realm string) error {
+	// Check if the vip-test-credentials secret already exists
+	checkCmd := exec.CommandContext(ctx, "kubectl", "get", "secret", "vip-test-credentials",
+		"-n", "posit-team", "--ignore-not-found", "-o", "jsonpath={.metadata.name}")
+	checkCmd.Env = env
+
+	output, err := checkCmd.Output()
+	if err == nil && strings.TrimSpace(string(output)) == "vip-test-credentials" {
+		slog.Info("Test user credentials secret already exists, skipping creation")
+		return nil
+	}
+
+	slog.Info("Creating test user in Keycloak")
+
+	// Get Keycloak admin credentials from the Keycloak Operator's initial-admin secret
+	// The Keycloak Operator creates this as {keycloak-cr-name}-initial-admin
+	adminSecretName := fmt.Sprintf("%s-keycloak-initial-admin", siteName)
+	adminUser, adminPass, err := getKeycloakAdminCreds(ctx, env, adminSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to get Keycloak admin credentials: %w", err)
+	}
+
+	// Get admin access token
+	token, err := getKeycloakAdminToken(keycloakURL, realm, adminUser, adminPass)
+	if err != nil {
+		return fmt.Errorf("failed to get admin token: %w", err)
+	}
+
+	// Create test user
+	username := "vip-test-user"
+	password := "vip-test-password-12345"
+
+	if err := createKeycloakUser(keycloakURL, realm, token, username, password); err != nil {
+		return fmt.Errorf("failed to create test user: %w", err)
+	}
+
+	// Create the vip-test-credentials secret
+	if err := createCredentialsSecret(ctx, env, username, password); err != nil {
+		return fmt.Errorf("failed to create credentials secret: %w", err)
+	}
+
+	slog.Info("Test user created successfully", "username", username)
+	return nil
+}
+
+// getKeycloakAdminCreds retrieves Keycloak admin credentials from the secret
+func getKeycloakAdminCreds(ctx context.Context, env []string, secretName string) (string, string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "secret", secretName,
+		"-n", "posit-team",
+		"-o", "jsonpath={.data.username} {.data.password}")
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", "", fmt.Errorf("kubectl get secret failed: %s", string(exitErr.Stderr))
+		}
+		return "", "", fmt.Errorf("kubectl get secret failed: %w", err)
+	}
+
+	parts := strings.Fields(string(output))
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected secret format")
+	}
+
+	// Decode base64 values
+	userCmd := exec.CommandContext(ctx, "base64", "-d")
+	userCmd.Stdin = strings.NewReader(parts[0])
+	username, err := userCmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decode username: %w", err)
+	}
+
+	passCmd := exec.CommandContext(ctx, "base64", "-d")
+	passCmd.Stdin = strings.NewReader(parts[1])
+	password, err := passCmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decode password: %w", err)
+	}
+
+	return string(username), string(password), nil
+}
+
+// getKeycloakAdminToken gets an admin access token from Keycloak's master realm
+func getKeycloakAdminToken(keycloakURL, _, username, password string) (string, error) {
+	// Admin tokens are always obtained from the master realm
+	tokenURL := fmt.Sprintf("%s/realms/master/protocol/openid-connect/token", keycloakURL)
+
+	data := fmt.Sprintf("grant_type=password&client_id=admin-cli&username=%s&password=%s", username, password)
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.AccessToken, nil
+}
+
+// createKeycloakUser creates a user in Keycloak
+func createKeycloakUser(keycloakURL, realm, token, username, password string) error {
+	usersURL := fmt.Sprintf("%s/admin/realms/%s/users", keycloakURL, realm)
+
+	// Check if user already exists
+	searchURL := fmt.Sprintf("%s?username=%s&exact=true", usersURL, username)
+	req, err := http.NewRequest("GET", searchURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		var users []map[string]interface{}
+		if err := json.Unmarshal(body, &users); err == nil && len(users) > 0 {
+			slog.Info("User already exists in Keycloak", "username", username)
+			return nil
+		}
+	}
+
+	// Create user
+	userPayload := map[string]interface{}{
+		"username":      username,
+		"enabled":       true,
+		"emailVerified": true,
+		"credentials": []map[string]interface{}{
+			{
+				"type":      "password",
+				"value":     password,
+				"temporary": false,
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(userPayload)
+	if err != nil {
+		return err
+	}
+
+	req, err = http.NewRequest("POST", usersURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("create user failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// createCredentialsSecret creates a K8s secret with test user credentials
+func createCredentialsSecret(ctx context.Context, env []string, username, password string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "create", "secret", "generic", "vip-test-credentials",
+		"--from-literal=username="+username,
+		"--from-literal=password="+password,
+		"-n", "posit-team")
+	cmd.Env = env
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl create secret failed: %s", string(output))
+	}
+
+	return nil
+}

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -293,9 +293,13 @@ func buildSecretSpec(name, namespace, username, password string) map[string]inte
 	return map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Secret",
-		"metadata": map[string]string{
+		"metadata": map[string]interface{}{
 			"name":      name,
 			"namespace": namespace,
+			"labels": map[string]string{
+				"app.kubernetes.io/name":       "vip-verify",
+				"app.kubernetes.io/managed-by": "ptd",
+			},
 		},
 		"type": "Opaque",
 		"data": map[string]string{

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -100,7 +100,13 @@ func getKeycloakAdminCreds(ctx context.Context, env []string, secretName string,
 		return "", "", fmt.Errorf("kubectl get secret failed: %w", err)
 	}
 
-	parts := strings.Fields(string(output))
+	return parseSecretData(string(output))
+}
+
+// parseSecretData parses kubectl jsonpath output of the form "<base64user> <base64pass>"
+// and returns the decoded username and password.
+func parseSecretData(output string) (string, string, error) {
+	parts := strings.Fields(strings.TrimSpace(output))
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf("unexpected secret format")
 	}

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -185,7 +185,10 @@ func createKeycloakUser(ctx context.Context, keycloakURL, realm, token, username
 	if err != nil {
 		return err
 	}
-	defer searchResp.Body.Close()
+	defer func() {
+		io.Copy(io.Discard, searchResp.Body)
+		searchResp.Body.Close()
+	}()
 
 	if searchResp.StatusCode == http.StatusOK {
 		body, _ := io.ReadAll(searchResp.Body)

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -162,6 +162,10 @@ func getKeycloakAdminToken(ctx context.Context, keycloakURL, username, password 
 		return "", err
 	}
 
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("access_token missing from token response")
+	}
+
 	return result.AccessToken, nil
 }
 

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -84,7 +84,7 @@ func EnsureTestUser(ctx context.Context, env []string, keycloakURL string, realm
 
 // generatePassword generates a cryptographically random password of the given length.
 func generatePassword(length int) (string, error) {
-	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%"
 	result := make([]byte, length)
 	for i := range result {
 		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -79,7 +79,7 @@ func getTestCredentials(ctx context.Context, env []string, namespace string) (st
 
 // generatePassword generates a cryptographically random password of the given length.
 func generatePassword(length int) (string, error) {
-	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%"
 	result := make([]byte, length)
 	for i := range result {
 		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))

--- a/cmd/internal/verify/keycloak.go
+++ b/cmd/internal/verify/keycloak.go
@@ -20,7 +20,7 @@ import (
 const keycloakHTTPTimeout = 30 * time.Second
 
 // EnsureTestUser ensures a test user exists in Keycloak and credentials are in a Secret
-func EnsureTestUser(ctx context.Context, env []string, siteName string, keycloakURL string, realm string) error {
+func EnsureTestUser(ctx context.Context, env []string, siteName string, keycloakURL string, realm string, testUsername string) error {
 	// Check if the vip-test-credentials secret already exists
 	checkCmd := exec.CommandContext(ctx, "kubectl", "get", "secret", "vip-test-credentials",
 		"-n", namespace, "--ignore-not-found", "-o", "jsonpath={.metadata.name}")
@@ -49,7 +49,7 @@ func EnsureTestUser(ctx context.Context, env []string, siteName string, keycloak
 	}
 
 	// Create test user with a randomly generated password
-	username := "vip-test-user"
+	username := testUsername
 	password, err := generatePassword(32)
 	if err != nil {
 		return fmt.Errorf("failed to generate password: %w", err)

--- a/cmd/internal/verify/keycloak_test.go
+++ b/cmd/internal/verify/keycloak_test.go
@@ -1,0 +1,116 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetKeycloakAdminToken_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	_, err := getKeycloakAdminToken(context.Background(), srv.URL, "admin", "wrongpass")
+	if err == nil {
+		t.Fatal("expected error for 401 response, got nil")
+	}
+}
+
+func TestGetKeycloakAdminToken_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	_, err := getKeycloakAdminToken(context.Background(), srv.URL, "admin", "pass")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response, got nil")
+	}
+}
+
+func TestCreateKeycloakUser_CreateFails(t *testing.T) {
+	// Search returns empty list (user does not exist), create returns 409 Conflict
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+		case http.MethodPost:
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"errorMessage":"User exists with same username"}`))
+		}
+	}))
+	defer srv.Close()
+
+	err := createKeycloakUser(context.Background(), srv.URL, "myrealm", "token", "user", "pass")
+	if err == nil {
+		t.Fatal("expected error for 409 create response, got nil")
+	}
+}
+
+func TestCreateKeycloakUser_SearchReturnsError(t *testing.T) {
+	// Search returns 403 Forbidden (insufficient permissions)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"access_denied"}`))
+	}))
+	defer srv.Close()
+
+	// Non-200 search falls through to create attempt; create also gets 403.
+	// Either way an error should be returned.
+	err := createKeycloakUser(context.Background(), srv.URL, "myrealm", "token", "user", "pass")
+	if err == nil {
+		t.Fatal("expected error when create returns 403, got nil")
+	}
+}
+
+func TestResetKeycloakUserPassword_NonNoContentStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"errorMessage":"Invalid password policy"}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{}
+	err := resetKeycloakUserPassword(context.Background(), srv.URL, "myrealm", "token", "user-id", "newpass", client)
+	if err == nil {
+		t.Fatal("expected error for 400 reset response, got nil")
+	}
+}
+
+func TestCreateKeycloakUser_ExistingUserResetsPassword(t *testing.T) {
+	userID := "abc-123"
+	searchCalled := false
+	resetCalled := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			searchCalled = true
+			w.WriteHeader(http.StatusOK)
+			users := []map[string]interface{}{{"id": userID, "username": "existing-user"}}
+			json.NewEncoder(w).Encode(users)
+		case http.MethodPut:
+			resetCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer srv.Close()
+
+	err := createKeycloakUser(context.Background(), srv.URL, "myrealm", "token", "existing-user", "newpass")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !searchCalled {
+		t.Error("expected search to be called")
+	}
+	if !resetCalled {
+		t.Error("expected password reset to be called for existing user")
+	}
+}

--- a/cmd/internal/verify/keycloak_test.go
+++ b/cmd/internal/verify/keycloak_test.go
@@ -34,6 +34,20 @@ func TestGetKeycloakAdminToken_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestGetKeycloakAdminToken_EmptyAccessToken(t *testing.T) {
+	// A 200 response with valid JSON but no access_token field should return an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	_, err := getKeycloakAdminToken(context.Background(), srv.URL, "admin", "pass")
+	if err == nil {
+		t.Fatal("expected error when access_token is absent from response, got nil")
+	}
+}
+
 func TestCreateKeycloakUser_CreateFails(t *testing.T) {
 	// Search returns empty list, create returns 409, re-search also returns empty list → error.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -16,14 +16,15 @@ const namespace = "posit-team"
 
 // Options contains configuration for the verify command
 type Options struct {
-	Target      string
-	SiteName    string
-	Categories  string
-	LocalMode   bool
-	ConfigOnly  bool
-	Image       string
-	KeycloakURL string // overrides the default https://key.<domain> if set
-	Env         []string
+	Target       string
+	SiteName     string
+	Categories   string
+	LocalMode    bool
+	ConfigOnly   bool
+	Image        string
+	KeycloakURL  string // overrides the default https://key.<domain> if set
+	TestUsername  string // Keycloak test user name (default: vip-test-user)
+	Env          []string
 }
 
 // Run executes the VIP verification process
@@ -63,7 +64,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	// Ensure test user exists
 	slog.Info("Ensuring test user exists in Keycloak")
-	if err := EnsureTestUser(ctx, opts.Env, opts.SiteName, keycloakURL, "posit"); err != nil {
+	if err := EnsureTestUser(ctx, opts.Env, opts.SiteName, keycloakURL, "posit", opts.TestUsername); err != nil {
 		return fmt.Errorf("failed to ensure test user: %w", err)
 	}
 

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -16,13 +16,14 @@ const namespace = "posit-team"
 
 // Options contains configuration for the verify command
 type Options struct {
-	Target     string
-	SiteName   string
-	Categories string
-	LocalMode  bool
-	ConfigOnly bool
-	Image      string
-	Env        []string
+	Target      string
+	SiteName    string
+	Categories  string
+	LocalMode   bool
+	ConfigOnly  bool
+	Image       string
+	KeycloakURL string // overrides the default https://key.<domain> if set
+	Env         []string
 }
 
 // Run executes the VIP verification process
@@ -55,7 +56,10 @@ func Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	keycloakURL := fmt.Sprintf("https://key.%s", site.Spec.Domain)
+	keycloakURL := opts.KeycloakURL
+	if keycloakURL == "" {
+		keycloakURL = fmt.Sprintf("https://key.%s", site.Spec.Domain)
+	}
 
 	// Ensure test user exists
 	slog.Info("Ensuring test user exists in Keycloak")

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -1,0 +1,187 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Options contains configuration for the verify command
+type Options struct {
+	Target     string
+	SiteName   string
+	Categories string
+	LocalMode  bool
+	ConfigOnly bool
+	Image      string
+	Env        []string
+}
+
+// Run executes the VIP verification process
+func Run(ctx context.Context, opts Options) error {
+	slog.Info("Starting VIP verification", "target", opts.Target, "site", opts.SiteName)
+
+	// Get Site CR from Kubernetes
+	slog.Info("Fetching Site CR from Kubernetes")
+	siteYAML, err := getSiteCR(ctx, opts.Env, opts.SiteName)
+	if err != nil {
+		return fmt.Errorf("failed to get Site CR: %w", err)
+	}
+
+	// Generate VIP config
+	slog.Info("Generating VIP configuration")
+	vipConfig, err := GenerateConfig(siteYAML, opts.Target)
+	if err != nil {
+		return fmt.Errorf("failed to generate VIP config: %w", err)
+	}
+
+	// If config-only mode, just print and exit
+	if opts.ConfigOnly {
+		fmt.Println(vipConfig)
+		return nil
+	}
+
+	// Parse Site CR to get Keycloak URL
+	var site SiteCR
+	if err := parseYAML(siteYAML, &site); err != nil {
+		return fmt.Errorf("failed to parse Site CR: %w", err)
+	}
+
+	keycloakURL := fmt.Sprintf("https://key.%s", site.Spec.Domain)
+
+	// Ensure test user exists
+	slog.Info("Ensuring test user exists in Keycloak")
+	if err := EnsureTestUser(ctx, opts.Env, opts.SiteName, keycloakURL, "posit"); err != nil {
+		return fmt.Errorf("failed to ensure test user: %w", err)
+	}
+
+	// Run tests based on mode
+	if opts.LocalMode {
+		return runLocalTests(ctx, vipConfig, opts.Categories)
+	}
+
+	return runKubernetesTests(ctx, opts, vipConfig)
+}
+
+// getSiteCR retrieves the Site CR YAML from Kubernetes
+func getSiteCR(ctx context.Context, env []string, siteName string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "site", siteName,
+		"-n", "posit-team",
+		"-o", "yaml")
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("kubectl get site failed: %s", string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("kubectl get site failed: %w", err)
+	}
+
+	return output, nil
+}
+
+// parseYAML is a helper to unmarshal YAML
+func parseYAML(data []byte, v interface{}) error {
+	// Use the yaml package imported in config.go
+	// This is a simple wrapper to avoid importing yaml again
+	var site SiteCR
+	if err := yaml.Unmarshal(data, &site); err != nil {
+		return err
+	}
+	if siteCR, ok := v.(*SiteCR); ok {
+		*siteCR = site
+	}
+	return nil
+}
+
+// runLocalTests runs VIP tests locally using uv
+func runLocalTests(ctx context.Context, vipConfig string, categories string) error {
+	slog.Info("Running VIP tests locally")
+
+	// Create temporary config file
+	tmpfile, err := os.CreateTemp("", "vip-config-*.toml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString(vipConfig); err != nil {
+		tmpfile.Close()
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	tmpfile.Close()
+
+	// Run pytest with uv
+	args := []string{"run", "pytest", "--config", tmpfile.Name(), "--tb=short", "-v"}
+	if categories != "" {
+		args = append(args, "-m", categories)
+	}
+
+	cmd := exec.CommandContext(ctx, "uv", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("VIP tests failed: %w", err)
+	}
+
+	fmt.Println("\nVIP tests completed successfully")
+	return nil
+}
+
+// runKubernetesTests runs VIP tests as a Kubernetes Job
+func runKubernetesTests(ctx context.Context, opts Options, vipConfig string) error {
+	timestamp := time.Now().Format("20060102150405")
+	jobName := fmt.Sprintf("vip-verify-%s", timestamp)
+	configName := "vip-verify-config"
+
+	slog.Info("Creating ConfigMap", "name", configName)
+	if err := CreateConfigMap(ctx, opts.Env, configName, vipConfig); err != nil {
+		return fmt.Errorf("failed to create ConfigMap: %w", err)
+	}
+
+	// Clean up ConfigMap on exit
+	defer func() {
+		slog.Debug("Cleaning up resources")
+		if err := Cleanup(ctx, opts.Env, jobName, configName); err != nil {
+			slog.Warn("Failed to cleanup resources", "error", err)
+		}
+	}()
+
+	slog.Info("Creating VIP verification Job", "name", jobName)
+	jobOpts := JobOptions{
+		Image:      opts.Image,
+		Categories: opts.Categories,
+		JobName:    jobName,
+		ConfigName: configName,
+	}
+
+	if err := CreateJob(ctx, opts.Env, jobOpts); err != nil {
+		return fmt.Errorf("failed to create Job: %w", err)
+	}
+
+	slog.Info("Streaming Job logs")
+	if err := StreamLogs(ctx, opts.Env, jobName); err != nil {
+		slog.Warn("Failed to stream logs", "error", err)
+	}
+
+	slog.Info("Waiting for Job to complete")
+	success, err := WaitForJob(ctx, opts.Env, jobName)
+	if err != nil {
+		return fmt.Errorf("failed to wait for Job: %w", err)
+	}
+
+	if !success {
+		fmt.Println("\nVIP verification failed")
+		return fmt.Errorf("VIP tests failed")
+	}
+
+	fmt.Println("\nVIP verification completed successfully")
+	return nil
+}

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -181,8 +181,8 @@ func runLocalTests(ctx context.Context, env []string, vipConfig string, categori
 // then appends the provided credentials. Returns an error if credentials contain
 // newline characters.
 func buildLocalEnv(env []string, testUser, testPass string) ([]string, error) {
-	if strings.ContainsAny(testUser, "\n\r") || strings.ContainsAny(testPass, "\n\r") {
-		return nil, fmt.Errorf("test credentials must not contain newline characters")
+	if strings.ContainsAny(testUser, "\n\r\x00") || strings.ContainsAny(testPass, "\n\r\x00") {
+		return nil, fmt.Errorf("test credentials must not contain newline or null characters")
 	}
 	result := make([]string, 0, len(env)+2)
 	for _, e := range env {
@@ -236,6 +236,7 @@ func runKubernetesTests(ctx context.Context, opts Options, vipConfig string, cre
 		ConfigName:           configName,
 		Namespace:            opts.Namespace,
 		CredentialsAvailable: credentialsAvailable,
+		Timeout:              opts.Timeout,
 	}
 
 	if err := CreateJob(ctx, opts.Env, jobOpts); err != nil {

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -11,6 +11,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// namespace is the Kubernetes namespace where PTD resources live.
+const namespace = "posit-team"
+
 // Options contains configuration for the verify command
 type Options struct {
 	Target     string
@@ -71,7 +74,7 @@ func Run(ctx context.Context, opts Options) error {
 // getSiteCR retrieves the Site CR YAML from Kubernetes
 func getSiteCR(ctx context.Context, env []string, siteName string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "kubectl", "get", "site", siteName,
-		"-n", "posit-team",
+		"-n", namespace,
 		"-o", "yaml")
 	cmd.Env = env
 

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -156,6 +157,9 @@ func runLocalTests(ctx context.Context, env []string, vipConfig string, categori
 	cmd := exec.CommandContext(ctx, "uv", args...)
 	cmd.Env = env
 	if credentialsAvailable {
+		if strings.ContainsAny(testUser, "\n\r") || strings.ContainsAny(testPass, "\n\r") {
+			return fmt.Errorf("test credentials must not contain newline characters")
+		}
 		cmd.Env = append(cmd.Env, "VIP_TEST_USERNAME="+testUser, "VIP_TEST_PASSWORD="+testPass)
 	}
 	cmd.Stdout = os.Stdout

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -115,6 +115,9 @@ func deriveKeycloakURL(override, domain string, needsURL bool) (string, error) {
 	if needsURL && domain == "" {
 		return "", fmt.Errorf("site domain is required to derive Keycloak URL; use --keycloak-url to override")
 	}
+	if domain == "" {
+		return "", nil
+	}
 	return fmt.Sprintf("https://key.%s", domain), nil
 }
 

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -142,7 +142,7 @@ func runLocalTests(ctx context.Context, env []string, vipConfig string, categori
 	// Fetch credentials from the K8s Secret so local runs authenticate the same way as K8s Jobs.
 	var testUser, testPass string
 	if credentialsAvailable {
-		testUser, testPass, err = getTestCredentials(ctx, env, namespace)
+		testUser, testPass, err = getKeycloakAdminCreds(ctx, env, vipTestCredentialsSecret, namespace)
 		if err != nil {
 			return fmt.Errorf("failed to get test credentials: %w", err)
 		}

--- a/cmd/internal/verify/verify.go
+++ b/cmd/internal/verify/verify.go
@@ -3,7 +3,9 @@ package verify
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -28,6 +30,7 @@ type Options struct {
 	Realm               string        // Keycloak realm (default: posit)
 	TestUsername        string        // Keycloak test user name (default: vip-test-user)
 	KeycloakAdminSecret string        // overrides the default {siteName}-keycloak-initial-admin
+	InteractiveAuth     bool          // mint credentials via interactive browser login
 	Timeout             time.Duration // WaitForJob timeout (default: 15 minutes)
 	Env                 []string
 }
@@ -62,28 +65,79 @@ func Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	// Only ensure test user if Keycloak is configured for this site
-	credentialsAvailable := site.Spec.Keycloak != nil && site.Spec.Keycloak.Enabled
-	keycloakURL, err := deriveKeycloakURL(opts.KeycloakURL, site.Spec.Domain, credentialsAvailable)
-	if err != nil {
-		return err
-	}
-	if credentialsAvailable {
-		adminSecretName := opts.KeycloakAdminSecret
-		if adminSecretName == "" {
-			adminSecretName = fmt.Sprintf("%s-keycloak-initial-admin", opts.SiteName)
+	// Handle credentials based on authentication mode
+	var credentialsAvailable bool
+	if opts.InteractiveAuth {
+		// Interactive auth mode: mint credentials via VIP CLI and kubectl exec
+		slog.Info("Using interactive authentication mode")
+
+		// Get Connect URL from site
+		connectURL := ""
+		if site.Spec.Connect != nil {
+			connectURL = buildProductURL(site.Spec.Connect, "connect", site.Spec.Domain)
 		}
-		slog.Info("Ensuring test user exists in Keycloak")
-		if err := EnsureTestUser(ctx, opts.Env, keycloakURL, opts.Realm, opts.TestUsername, adminSecretName, opts.Namespace); err != nil {
-			return fmt.Errorf("failed to ensure test user: %w", err)
+		if connectURL == "" {
+			return fmt.Errorf("Connect is not configured for this site; interactive auth requires Connect")
 		}
+
+		// Mint Connect API key via VIP CLI
+		slog.Info("Minting Connect API key via VIP CLI")
+		apiKey, keyName, err := MintConnectKey(ctx, connectURL)
+		if err != nil {
+			return fmt.Errorf("failed to mint Connect API key: %w", err)
+		}
+
+		// Generate Workbench token
+		slog.Info("Generating Workbench API token")
+		workbenchToken, err := GenerateWorkbenchToken(ctx, opts.Env, opts.Namespace, opts.SiteName, opts.TestUsername)
+		if err != nil {
+			return fmt.Errorf("failed to generate Workbench token: %w", err)
+		}
+
+		// Generate Package Manager token
+		slog.Info("Generating Package Manager token")
+		pmToken, err := GeneratePackageManagerToken(ctx, opts.Env, opts.Namespace, opts.SiteName)
+		if err != nil {
+			return fmt.Errorf("failed to generate Package Manager token: %w", err)
+		}
+
+		// Save all credentials to K8s Secret
+		creds := map[string]string{
+			"VIP_CONNECT_API_KEY":     apiKey,
+			"VIP_CONNECT_KEY_NAME":    keyName,
+			"VIP_WORKBENCH_API_KEY":   workbenchToken,
+			"VIP_PM_TOKEN":            pmToken,
+		}
+		slog.Info("Saving credentials to Kubernetes Secret")
+		if err := SaveCredentialsSecret(ctx, opts.Env, opts.Namespace, creds); err != nil {
+			return fmt.Errorf("failed to save credentials secret: %w", err)
+		}
+
+		credentialsAvailable = true
 	} else {
-		slog.Info("Keycloak not configured for this site, skipping test user creation")
+		// Keycloak mode: ensure test user exists
+		credentialsAvailable = site.Spec.Keycloak != nil && site.Spec.Keycloak.Enabled
+		keycloakURL, err := deriveKeycloakURL(opts.KeycloakURL, site.Spec.Domain, credentialsAvailable)
+		if err != nil {
+			return err
+		}
+		if credentialsAvailable {
+			adminSecretName := opts.KeycloakAdminSecret
+			if adminSecretName == "" {
+				adminSecretName = fmt.Sprintf("%s-keycloak-initial-admin", opts.SiteName)
+			}
+			slog.Info("Ensuring test user exists in Keycloak")
+			if err := EnsureTestUser(ctx, opts.Env, keycloakURL, opts.Realm, opts.TestUsername, adminSecretName, opts.Namespace); err != nil {
+				return fmt.Errorf("failed to ensure test user: %w", err)
+			}
+		} else {
+			slog.Info("Keycloak not configured for this site, skipping test user creation")
+		}
 	}
 
 	// Run tests based on mode
 	if opts.LocalMode {
-		return runLocalTests(ctx, opts.Env, vipConfig, opts.Categories, opts.Namespace, credentialsAvailable)
+		return runLocalTests(ctx, opts, vipConfig, credentialsAvailable)
 	}
 
 	return runKubernetesTests(ctx, opts, vipConfig, credentialsAvailable)
@@ -124,7 +178,7 @@ func deriveKeycloakURL(override, domain string, needsURL bool) (string, error) {
 }
 
 // runLocalTests runs VIP tests locally using uv
-func runLocalTests(ctx context.Context, env []string, vipConfig string, categories string, namespace string, credentialsAvailable bool) error {
+func runLocalTests(ctx context.Context, opts Options, vipConfig string, credentialsAvailable bool) error {
 	slog.Info("Running VIP tests locally")
 
 	// Create temporary config file
@@ -140,30 +194,35 @@ func runLocalTests(ctx context.Context, env []string, vipConfig string, categori
 	}
 	tmpfile.Close()
 
-	// Fetch credentials from the K8s Secret so local runs authenticate the same way as K8s Jobs.
-	var testUser, testPass string
-	if credentialsAvailable {
-		testUser, testPass, err = getSecretCredentials(ctx, env, vipTestCredentialsSecret, namespace)
-		if err != nil {
-			return fmt.Errorf("failed to get test credentials: %w", err)
-		}
-	}
-
 	// Run pytest with uv
 	args := []string{"run", "pytest", "--config", tmpfile.Name(), "--tb=short", "-v"}
-	if categories != "" {
-		args = append(args, "-m", categories)
+	if opts.Categories != "" {
+		args = append(args, "-m", opts.Categories)
 	}
 
 	cmd := exec.CommandContext(ctx, "uv", args...)
 	if credentialsAvailable {
-		localEnv, err := buildLocalEnv(env, testUser, testPass)
-		if err != nil {
-			return err
+		if opts.InteractiveAuth {
+			// Interactive auth mode: fetch API tokens from Secret
+			localEnv, err := buildLocalEnvWithTokens(ctx, opts.Env, opts.Namespace)
+			if err != nil {
+				return err
+			}
+			cmd.Env = localEnv
+		} else {
+			// Keycloak mode: fetch username/password from Secret
+			testUser, testPass, err := getSecretCredentials(ctx, opts.Env, vipTestCredentialsSecret, opts.Namespace)
+			if err != nil {
+				return fmt.Errorf("failed to get test credentials: %w", err)
+			}
+			localEnv, err := buildLocalEnv(opts.Env, testUser, testPass)
+			if err != nil {
+				return err
+			}
+			cmd.Env = localEnv
 		}
-		cmd.Env = localEnv
 	} else {
-		cmd.Env = env
+		cmd.Env = opts.Env
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -192,6 +251,66 @@ func buildLocalEnv(env []string, testUser, testPass string) ([]string, error) {
 		}
 	}
 	return append(result, "VIP_TEST_USERNAME="+testUser, "VIP_TEST_PASSWORD="+testPass), nil
+}
+
+// buildLocalEnvWithTokens fetches API tokens from the K8s Secret and constructs
+// the environment for local VIP runs with interactive auth.
+func buildLocalEnvWithTokens(ctx context.Context, env []string, namespace string) ([]string, error) {
+	// Get the Secret
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "secret", vipTestCredentialsSecret,
+		"-n", namespace,
+		"-o", "json")
+	cmd.Env = env
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("kubectl get secret failed: %s", string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("kubectl get secret failed: %w", err)
+	}
+
+	var secret struct {
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(output, &secret); err != nil {
+		return nil, fmt.Errorf("failed to parse secret: %w", err)
+	}
+
+	// Decode and extract tokens
+	tokenKeys := []string{"VIP_CONNECT_API_KEY", "VIP_WORKBENCH_API_KEY", "VIP_PM_TOKEN"}
+	tokens := make(map[string]string)
+	for _, key := range tokenKeys {
+		if b64Value, ok := secret.Data[key]; ok {
+			decoded, err := base64.StdEncoding.DecodeString(b64Value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode %s: %w", key, err)
+			}
+			tokens[key] = string(decoded)
+		}
+	}
+
+	// Strip any pre-existing token env vars from env
+	result := make([]string, 0, len(env)+len(tokens))
+	for _, e := range env {
+		skip := false
+		for key := range tokens {
+			if strings.HasPrefix(e, key+"=") {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			result = append(result, e)
+		}
+	}
+
+	// Append token env vars
+	for key, value := range tokens {
+		result = append(result, key+"="+value)
+	}
+
+	return result, nil
 }
 
 // randomHex returns n random hex-encoded bytes (2n hex characters).
@@ -237,6 +356,7 @@ func runKubernetesTests(ctx context.Context, opts Options, vipConfig string, cre
 		ConfigName:           configName,
 		Namespace:            opts.Namespace,
 		CredentialsAvailable: credentialsAvailable,
+		InteractiveAuth:      opts.InteractiveAuth,
 		Timeout:              opts.Timeout,
 	}
 

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -154,7 +154,7 @@ func TestGenerateConfig_EmptyAuthType(t *testing.T) {
 }
 
 func TestGenerateConfig_EmptyDomain(t *testing.T) {
-	// Empty domain should produce a URL with an empty domain segment, not panic
+	// Empty domain with a configured product should return an error (malformed URL otherwise)
 	site := &SiteCR{
 		Spec: SiteSpec{
 			Domain:  "",
@@ -162,13 +162,9 @@ func TestGenerateConfig_EmptyDomain(t *testing.T) {
 		},
 	}
 
-	config, err := GenerateConfig(site, "test")
-	if err != nil {
-		t.Fatalf("GenerateConfig returned error: %v", err)
-	}
-
-	if !strings.Contains(config, `url = "https://connect."`) {
-		t.Errorf("expected connect URL with empty domain, got:\n%s", config)
+	_, err := GenerateConfig(site, "test")
+	if err == nil {
+		t.Fatal("expected error for empty domain with configured product, got nil")
 	}
 }
 

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -1,0 +1,183 @@
+package verify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateConfig_ConnectOnly(t *testing.T) {
+	site := &SiteCR{
+		Spec: SiteSpec{
+			Domain: "example.com",
+			Connect: &ProductSpec{
+				Auth: &AuthSpec{Type: "saml"},
+			},
+		},
+	}
+
+	config, err := GenerateConfig(site, "my-deployment")
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	if config == "" {
+		t.Fatal("expected non-empty config")
+	}
+
+	// Auth provider should come from Connect when present
+	if !strings.Contains(config, `provider = "saml"`) {
+		t.Errorf("expected saml auth provider, got:\n%s", config)
+	}
+
+	// Connect should be enabled with the correct URL
+	if !strings.Contains(config, `url = "https://connect.example.com"`) {
+		t.Errorf("expected connect URL, got:\n%s", config)
+	}
+
+	// Workbench section should be present (disabled)
+	if !strings.Contains(config, `[workbench]`) {
+		t.Errorf("expected workbench section, got:\n%s", config)
+	}
+}
+
+func TestGenerateConfig_AuthProviderPrecedence(t *testing.T) {
+	// Connect auth takes precedence over Workbench auth
+	site := &SiteCR{
+		Spec: SiteSpec{
+			Domain: "example.com",
+			Connect: &ProductSpec{
+				Auth: &AuthSpec{Type: "saml"},
+			},
+			Workbench: &ProductSpec{
+				Auth: &AuthSpec{Type: "ldap"},
+			},
+		},
+	}
+
+	config, err := GenerateConfig(site, "test")
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	if !strings.Contains(config, `provider = "saml"`) {
+		t.Errorf("expected Connect auth (saml) to win, got:\n%s", config)
+	}
+}
+
+func TestGenerateConfig_WorkbenchAuthFallback(t *testing.T) {
+	// When Connect has no auth spec, fall back to Workbench auth
+	site := &SiteCR{
+		Spec: SiteSpec{
+			Domain: "example.com",
+			Connect: &ProductSpec{},
+			Workbench: &ProductSpec{
+				Auth: &AuthSpec{Type: "ldap"},
+			},
+		},
+	}
+
+	config, err := GenerateConfig(site, "test")
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	if !strings.Contains(config, `provider = "ldap"`) {
+		t.Errorf("expected Workbench auth (ldap) as fallback, got:\n%s", config)
+	}
+}
+
+func TestGenerateConfig_DefaultAuth(t *testing.T) {
+	// When no product has an auth spec, default to oidc
+	site := &SiteCR{
+		Spec: SiteSpec{
+			Domain:  "example.com",
+			Connect: &ProductSpec{},
+		},
+	}
+
+	config, err := GenerateConfig(site, "test")
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	if !strings.Contains(config, `provider = "oidc"`) {
+		t.Errorf("expected default oidc auth, got:\n%s", config)
+	}
+}
+
+func TestGenerateConfig_CustomDomainPrefix(t *testing.T) {
+	site := &SiteCR{
+		Spec: SiteSpec{
+			Domain: "example.com",
+			Connect: &ProductSpec{
+				DomainPrefix: "rsconnect",
+			},
+		},
+	}
+
+	config, err := GenerateConfig(site, "test")
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	if !strings.Contains(config, `url = "https://rsconnect.example.com"`) {
+		t.Errorf("expected custom domain prefix in URL, got:\n%s", config)
+	}
+}
+
+func TestParseJobStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		wantDone    bool
+		wantSuccess bool
+	}{
+		{
+			name:        "job completed successfully",
+			output:      "True ",
+			wantDone:    true,
+			wantSuccess: true,
+		},
+		{
+			name:        "job failed",
+			output:      "False True",
+			wantDone:    true,
+			wantSuccess: false,
+		},
+		{
+			name:        "both conditions set - complete wins",
+			output:      "True True",
+			wantDone:    true,
+			wantSuccess: true,
+		},
+		{
+			name:        "job still running (no conditions yet)",
+			output:      "",
+			wantDone:    false,
+			wantSuccess: false,
+		},
+		{
+			name:        "job still running (False conditions)",
+			output:      "False False",
+			wantDone:    false,
+			wantSuccess: false,
+		},
+		{
+			name:        "whitespace only",
+			output:      "   \n  ",
+			wantDone:    false,
+			wantSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDone, gotSuccess := parseJobStatus(tt.output)
+			if gotDone != tt.wantDone || gotSuccess != tt.wantSuccess {
+				t.Errorf("parseJobStatus(%q) = (%v, %v), want (%v, %v)",
+					tt.output, gotDone, gotSuccess, tt.wantDone, tt.wantSuccess)
+			}
+		})
+	}
+}
+

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -505,12 +505,11 @@ func TestBuildSecretSpec(t *testing.T) {
 
 func TestBuildLocalEnv(t *testing.T) {
 	tests := []struct {
-		name      string
-		env       []string
-		testUser  string
-		testPass  string
-		wantErr   bool
-		wantDedup bool // whether we expect existing creds to be replaced (not duplicated)
+		name     string
+		env      []string
+		testUser string
+		testPass string
+		wantErr  bool
 	}{
 		{
 			name:     "newline in username returns error",
@@ -548,11 +547,10 @@ func TestBuildLocalEnv(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:      "existing cred keys are stripped before appending",
-			env:       []string{"PATH=/usr/bin", "VIP_TEST_USERNAME=old", "VIP_TEST_PASSWORD=old"},
-			testUser:  "newuser",
-			testPass:  "newpass",
-			wantDedup: true,
+			name:     "existing cred keys are stripped before appending",
+			env:      []string{"PATH=/usr/bin", "VIP_TEST_USERNAME=old", "VIP_TEST_PASSWORD=old"},
+			testUser: "newuser",
+			testPass: "newpass",
 		},
 		{
 			name:     "clean env appends credentials",

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -263,11 +263,12 @@ func TestDeriveKeycloakURL(t *testing.T) {
 	}
 
 	// Empty domain with Keycloak disabled is not an error (URL won't be used).
+	// Returns "" rather than a malformed "https://key." URL.
 	got, err = deriveKeycloakURL("", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error when Keycloak disabled: %v", err)
 	}
-	if got != "https://key." {
+	if got != "" {
 		t.Errorf("unexpected URL %q when Keycloak disabled", got)
 	}
 

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -534,6 +534,20 @@ func TestBuildLocalEnv(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "null byte in username returns error",
+			env:      []string{"PATH=/usr/bin"},
+			testUser: "user\x00injected",
+			testPass: "pass",
+			wantErr:  true,
+		},
+		{
+			name:     "null byte in password returns error",
+			env:      []string{"PATH=/usr/bin"},
+			testUser: "user",
+			testPass: "pass\x00injected",
+			wantErr:  true,
+		},
+		{
 			name:      "existing cred keys are stripped before appending",
 			env:       []string{"PATH=/usr/bin", "VIP_TEST_USERNAME=old", "VIP_TEST_PASSWORD=old"},
 			testUser:  "newuser",

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 )
 
+func TestGenerateConfig_NilSite(t *testing.T) {
+	_, err := GenerateConfig(nil, "test")
+	if err == nil {
+		t.Fatal("expected error for nil site, got nil")
+	}
+}
+
 func TestGenerateConfig_ConnectOnly(t *testing.T) {
 	site := &SiteCR{
 		Spec: SiteSpec{
@@ -197,19 +204,25 @@ func TestParseJobStatus(t *testing.T) {
 	}{
 		{
 			name:        "job completed successfully",
-			output:      "True ",
+			output:      "True,",
 			wantDone:    true,
 			wantSuccess: true,
 		},
 		{
-			name:        "job failed",
-			output:      "False True",
+			name:        "job failed - only Failed condition present (was false-positive before fix)",
+			output:      ",True",
+			wantDone:    true,
+			wantSuccess: false,
+		},
+		{
+			name:        "job failed - both conditions present",
+			output:      "False,True",
 			wantDone:    true,
 			wantSuccess: false,
 		},
 		{
 			name:        "both conditions set - complete wins",
-			output:      "True True",
+			output:      "True,True",
 			wantDone:    true,
 			wantSuccess: true,
 		},
@@ -221,7 +234,7 @@ func TestParseJobStatus(t *testing.T) {
 		},
 		{
 			name:        "job still running (False conditions)",
-			output:      "False False",
+			output:      "False,False",
 			wantDone:    false,
 			wantSuccess: false,
 		},

--- a/cmd/internal/verify/verify_test.go
+++ b/cmd/internal/verify/verify_test.go
@@ -249,6 +249,35 @@ func TestGenerateConfig_EmptyDomainAllBaseDomains(t *testing.T) {
 	}
 }
 
+func TestDeriveKeycloakURL(t *testing.T) {
+	// Override takes precedence over domain.
+	got, err := deriveKeycloakURL("https://custom.example.com", "", true)
+	if err != nil || got != "https://custom.example.com" {
+		t.Fatalf("expected override URL, got %q, err %v", got, err)
+	}
+
+	// Empty domain with Keycloak enabled and no override returns an error.
+	_, err = deriveKeycloakURL("", "", true)
+	if err == nil {
+		t.Fatal("expected error for empty domain when Keycloak is enabled, got nil")
+	}
+
+	// Empty domain with Keycloak disabled is not an error (URL won't be used).
+	got, err = deriveKeycloakURL("", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error when Keycloak disabled: %v", err)
+	}
+	if got != "https://key." {
+		t.Errorf("unexpected URL %q when Keycloak disabled", got)
+	}
+
+	// Domain is used when no override is set and Keycloak is enabled.
+	got, err = deriveKeycloakURL("", "example.com", true)
+	if err != nil || got != "https://key.example.com" {
+		t.Fatalf("expected derived URL, got %q, err %v", got, err)
+	}
+}
+
 func TestBuildProductURL_BaseDomainOverride(t *testing.T) {
 	spec := &ProductSpec{
 		BaseDomain: "custom.org",

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/posit-dev/ptd/cmd/internal"
 	"github.com/posit-dev/ptd/cmd/internal/legacy"
@@ -96,6 +97,10 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 	if err != nil {
 		slog.Error("Failed to setup kubeconfig", "error", err)
 		os.Exit(1)
+	}
+
+	if strings.HasSuffix(verifyImage, ":latest") {
+		slog.Warn("Using ':latest' image tag is non-deterministic; consider pinning a specific version", "image", verifyImage)
 	}
 
 	// Prepare environment variables for kubectl (inherit from current env)

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -23,15 +23,19 @@ func init() {
 	verifyCmd.Flags().BoolVar(&verifyConfigOnly, "config-only", false, "Generate config only, don't run tests")
 	verifyCmd.Flags().StringVar(&verifyImage, "image", "ghcr.io/posit-dev/vip:latest", "VIP container image to use")
 	verifyCmd.Flags().StringVar(&verifyKeycloakURL, "keycloak-url", "", "Keycloak URL (defaults to https://key.<domain> from Site CR)")
+	verifyCmd.Flags().StringVar(&verifyRealm, "realm", "posit", "Keycloak realm name")
+	verifyCmd.Flags().StringVar(&verifyTestUsername, "test-username", "vip-test-user", "Keycloak test user name")
 }
 
 var (
-	verifySiteName    string
-	verifyCategories  string
-	verifyLocal       bool
-	verifyConfigOnly  bool
-	verifyImage       string
-	verifyKeycloakURL string
+	verifySiteName     string
+	verifyCategories   string
+	verifyLocal        bool
+	verifyConfigOnly   bool
+	verifyImage        string
+	verifyKeycloakURL  string
+	verifyRealm        string
+	verifyTestUsername string
 )
 
 var verifyCmd = &cobra.Command{
@@ -121,7 +125,8 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 		ConfigOnly:   verifyConfigOnly,
 		Image:        verifyImage,
 		KeycloakURL:  verifyKeycloakURL,
-		TestUsername: "vip-test-user",
+		Realm:        verifyRealm,
+		TestUsername: verifyTestUsername,
 		Env:          env,
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/posit-dev/ptd/cmd/internal"
 	"github.com/posit-dev/ptd/cmd/internal/legacy"
@@ -25,17 +26,23 @@ func init() {
 	verifyCmd.Flags().StringVar(&verifyKeycloakURL, "keycloak-url", "", "Keycloak URL (defaults to https://key.<domain> from Site CR)")
 	verifyCmd.Flags().StringVar(&verifyRealm, "realm", "posit", "Keycloak realm name")
 	verifyCmd.Flags().StringVar(&verifyTestUsername, "test-username", "vip-test-user", "Keycloak test user name")
+	verifyCmd.Flags().StringVar(&verifyNamespace, "namespace", "posit-team", "Kubernetes namespace where PTD resources live")
+	verifyCmd.Flags().StringVar(&verifyKeycloakAdminSecret, "keycloak-admin-secret", "", "Name of the K8s secret holding Keycloak admin credentials (defaults to {site}-keycloak-initial-admin)")
+	verifyCmd.Flags().DurationVar(&verifyTimeout, "timeout", 15*time.Minute, "Timeout for waiting for the VIP verification Job to complete")
 }
 
 var (
-	verifySiteName     string
-	verifyCategories   string
-	verifyLocal        bool
-	verifyConfigOnly   bool
-	verifyImage        string
-	verifyKeycloakURL  string
-	verifyRealm        string
-	verifyTestUsername string
+	verifySiteName           string
+	verifyCategories         string
+	verifyLocal              bool
+	verifyConfigOnly         bool
+	verifyImage              string
+	verifyKeycloakURL        string
+	verifyRealm              string
+	verifyTestUsername       string
+	verifyNamespace          string
+	verifyKeycloakAdminSecret string
+	verifyTimeout            time.Duration
 )
 
 var verifyCmd = &cobra.Command{
@@ -118,16 +125,19 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 
 	// Run verification
 	opts := verify.Options{
-		Target:       target,
-		SiteName:     verifySiteName,
-		Categories:   verifyCategories,
-		LocalMode:    verifyLocal,
-		ConfigOnly:   verifyConfigOnly,
-		Image:        verifyImage,
-		KeycloakURL:  verifyKeycloakURL,
-		Realm:        verifyRealm,
-		TestUsername: verifyTestUsername,
-		Env:          env,
+		Target:              target,
+		SiteName:            verifySiteName,
+		Namespace:           verifyNamespace,
+		Categories:          verifyCategories,
+		LocalMode:           verifyLocal,
+		ConfigOnly:          verifyConfigOnly,
+		Image:               verifyImage,
+		KeycloakURL:         verifyKeycloakURL,
+		Realm:               verifyRealm,
+		TestUsername:        verifyTestUsername,
+		KeycloakAdminSecret: verifyKeycloakAdminSecret,
+		Timeout:             verifyTimeout,
+		Env:                 env,
 	}
 
 	if err := verify.Run(ctx, opts); err != nil {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -112,7 +112,7 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 		os.Exit(1)
 	}
 
-	if cmd.Flags().Changed("image") && strings.HasSuffix(verifyImage, ":latest") {
+	if strings.HasSuffix(verifyImage, ":latest") {
 		slog.Warn("Using ':latest' image tag is non-deterministic; consider pinning a specific version", "image", verifyImage)
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -114,14 +114,15 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 
 	// Run verification
 	opts := verify.Options{
-		Target:      target,
-		SiteName:    verifySiteName,
-		Categories:  verifyCategories,
-		LocalMode:   verifyLocal,
-		ConfigOnly:  verifyConfigOnly,
-		Image:       verifyImage,
-		KeycloakURL: verifyKeycloakURL,
-		Env:         env,
+		Target:       target,
+		SiteName:     verifySiteName,
+		Categories:   verifyCategories,
+		LocalMode:    verifyLocal,
+		ConfigOnly:   verifyConfigOnly,
+		Image:        verifyImage,
+		KeycloakURL:  verifyKeycloakURL,
+		TestUsername: "vip-test-user",
+		Env:          env,
 	}
 
 	if err := verify.Run(ctx, opts); err != nil {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -112,7 +112,7 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 		os.Exit(1)
 	}
 
-	if strings.HasSuffix(verifyImage, ":latest") {
+	if cmd.Flags().Changed("image") && strings.HasSuffix(verifyImage, ":latest") {
 		slog.Warn("Using ':latest' image tag is non-deterministic; consider pinning a specific version", "image", verifyImage)
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path"
+
+	"github.com/posit-dev/ptd/cmd/internal"
+	"github.com/posit-dev/ptd/cmd/internal/legacy"
+	"github.com/posit-dev/ptd/cmd/internal/verify"
+	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(verifyCmd)
+
+	verifyCmd.Flags().StringVar(&verifySiteName, "site", "main", "Name of the Site CR to verify")
+	verifyCmd.Flags().StringVar(&verifyCategories, "categories", "", "Test categories to run (pytest -m marker)")
+	verifyCmd.Flags().BoolVar(&verifyLocal, "local", false, "Run tests locally instead of in Kubernetes")
+	verifyCmd.Flags().BoolVar(&verifyConfigOnly, "config-only", false, "Generate config only, don't run tests")
+	verifyCmd.Flags().StringVar(&verifyImage, "image", "ghcr.io/posit-dev/vip:latest", "VIP container image to use")
+}
+
+var (
+	verifySiteName    string
+	verifyCategories  string
+	verifyLocal       bool
+	verifyConfigOnly  bool
+	verifyImage       string
+)
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify <target>",
+	Short: "Verify a PTD deployment with VIP tests",
+	Long: `Verify a PTD deployment by running VIP (Verified Installation of Posit) tests.
+
+This command:
+1. Fetches the Site CR from Kubernetes
+2. Generates a VIP configuration from the Site CR
+3. Ensures a test user exists in Keycloak
+4. Runs VIP tests either locally or as a Kubernetes Job
+
+Examples:
+  # Run all VIP tests against ganso01-staging
+  ptd verify ganso01-staging
+
+  # Run only smoke tests
+  ptd verify ganso01-staging --categories smoke
+
+  # Generate config only without running tests
+  ptd verify ganso01-staging --config-only
+
+  # Run tests locally instead of in Kubernetes
+  ptd verify ganso01-staging --local
+
+  # Verify a specific site (for multi-site deployments)
+  ptd verify ganso01-staging --site secondary`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: legacy.ValidTargetArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		target := args[0]
+		runVerify(cmd.Context(), cmd, target)
+	},
+}
+
+func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
+	// Load target configuration
+	t, err := legacy.TargetFromName(target)
+	if err != nil {
+		slog.Error("Could not load target", "error", err)
+		return
+	}
+
+	// Get credentials
+	creds, err := t.Credentials(ctx)
+	if err != nil {
+		slog.Error("Failed to get credentials", "error", err)
+		return
+	}
+
+	credEnvVars := creds.EnvVars()
+
+	// Start proxy if needed (non-fatal)
+	proxyFile := path.Join(internal.DataDir(), "proxy.json")
+	stopProxy, err := kube.StartProxy(ctx, t, proxyFile)
+	if err != nil {
+		slog.Warn("Failed to start proxy", "error", err)
+	} else {
+		defer stopProxy()
+	}
+
+	// Set up kubeconfig
+	kubeconfigPath, err := kube.SetupKubeConfig(ctx, t, creds)
+	if err != nil {
+		slog.Error("Failed to setup kubeconfig", "error", err)
+		return
+	}
+
+	// Prepare environment variables for kubectl (inherit from current env)
+	env := os.Environ()
+	for k, v := range credEnvVars {
+		env = append(env, k+"="+v)
+	}
+	env = append(env, "KUBECONFIG="+kubeconfigPath)
+
+	// Run verification
+	opts := verify.Options{
+		Target:     target,
+		SiteName:   verifySiteName,
+		Categories: verifyCategories,
+		LocalMode:  verifyLocal,
+		ConfigOnly: verifyConfigOnly,
+		Image:      verifyImage,
+		Env:        env,
+	}
+
+	if err := verify.Run(ctx, opts); err != nil {
+		slog.Error("Verification failed", "error", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -22,6 +22,7 @@ func init() {
 	verifyCmd.Flags().BoolVar(&verifyLocal, "local", false, "Run tests locally instead of in Kubernetes")
 	verifyCmd.Flags().BoolVar(&verifyConfigOnly, "config-only", false, "Generate config only, don't run tests")
 	verifyCmd.Flags().StringVar(&verifyImage, "image", "ghcr.io/posit-dev/vip:latest", "VIP container image to use")
+	verifyCmd.Flags().StringVar(&verifyKeycloakURL, "keycloak-url", "", "Keycloak URL (defaults to https://key.<domain> from Site CR)")
 }
 
 var (
@@ -30,6 +31,7 @@ var (
 	verifyLocal       bool
 	verifyConfigOnly  bool
 	verifyImage       string
+	verifyKeycloakURL string
 )
 
 var verifyCmd = &cobra.Command{
@@ -112,13 +114,14 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 
 	// Run verification
 	opts := verify.Options{
-		Target:     target,
-		SiteName:   verifySiteName,
-		Categories: verifyCategories,
-		LocalMode:  verifyLocal,
-		ConfigOnly: verifyConfigOnly,
-		Image:      verifyImage,
-		Env:        env,
+		Target:      target,
+		SiteName:    verifySiteName,
+		Categories:  verifyCategories,
+		LocalMode:   verifyLocal,
+		ConfigOnly:  verifyConfigOnly,
+		Image:       verifyImage,
+		KeycloakURL: verifyKeycloakURL,
+		Env:         env,
 	}
 
 	if err := verify.Run(ctx, opts); err != nil {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -70,14 +70,14 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 	t, err := legacy.TargetFromName(target)
 	if err != nil {
 		slog.Error("Could not load target", "error", err)
-		return
+		os.Exit(1)
 	}
 
 	// Get credentials
 	creds, err := t.Credentials(ctx)
 	if err != nil {
 		slog.Error("Failed to get credentials", "error", err)
-		return
+		os.Exit(1)
 	}
 
 	credEnvVars := creds.EnvVars()
@@ -95,7 +95,7 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 	kubeconfigPath, err := kube.SetupKubeConfig(ctx, t, creds)
 	if err != nil {
 		slog.Error("Failed to setup kubeconfig", "error", err)
-		return
+		os.Exit(1)
 	}
 
 	// Prepare environment variables for kubectl (inherit from current env)

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -13,10 +15,12 @@ import (
 	"github.com/posit-dev/ptd/cmd/internal/verify"
 	"github.com/posit-dev/ptd/lib/kube"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
 	rootCmd.AddCommand(verifyCmd)
+	verifyCmd.AddCommand(cleanupCmd)
 
 	verifyCmd.Flags().StringVar(&verifySiteName, "site", "main", "Name of the Site CR to verify")
 	verifyCmd.Flags().StringVar(&verifyCategories, "categories", "", "Test categories to run (pytest -m marker)")
@@ -28,6 +32,7 @@ func init() {
 	verifyCmd.Flags().StringVar(&verifyTestUsername, "test-username", "vip-test-user", "Keycloak test user name")
 	verifyCmd.Flags().StringVar(&verifyNamespace, "namespace", "posit-team", "Kubernetes namespace where PTD resources live")
 	verifyCmd.Flags().StringVar(&verifyKeycloakAdminSecret, "keycloak-admin-secret", "", "Name of the K8s secret holding Keycloak admin credentials (defaults to {site}-keycloak-initial-admin)")
+	verifyCmd.Flags().BoolVar(&verifyInteractiveAuth, "interactive-auth", false, "Mint credentials via interactive browser login (requires VIP CLI)")
 	verifyCmd.Flags().DurationVar(&verifyTimeout, "timeout", 15*time.Minute, "Timeout for waiting for the VIP verification Job to complete")
 }
 
@@ -42,6 +47,7 @@ var (
 	verifyTestUsername       string
 	verifyNamespace          string
 	verifyKeycloakAdminSecret string
+	verifyInteractiveAuth    bool
 	verifyTimeout            time.Duration
 )
 
@@ -77,6 +83,131 @@ Examples:
 		target := args[0]
 		runVerify(cmd.Context(), cmd, target)
 	},
+}
+
+var cleanupCmd = &cobra.Command{
+	Use:   "cleanup <target>",
+	Short: "Delete VIP test credentials and resources",
+	Long: `Delete VIP test credentials and resources created by the verify command.
+
+This command:
+1. Reads the vip-test-credentials K8s Secret
+2. Deletes the Connect API key via the Connect API
+3. Deletes the vip-test-credentials K8s Secret
+
+Examples:
+  # Clean up test credentials for ganso01-staging
+  ptd verify cleanup ganso01-staging
+
+  # Clean up test credentials for a specific site
+  ptd verify cleanup ganso01-staging --site secondary`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: legacy.ValidTargetArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		target := args[0]
+		runCleanup(cmd.Context(), cmd, target)
+	},
+}
+
+func runCleanup(ctx context.Context, cmd *cobra.Command, target string) {
+	// Load target configuration
+	t, err := legacy.TargetFromName(target)
+	if err != nil {
+		slog.Error("Could not load target", "error", err)
+		os.Exit(1)
+	}
+
+	// Get credentials
+	creds, err := t.Credentials(ctx)
+	if err != nil {
+		slog.Error("Failed to get credentials", "error", err)
+		os.Exit(1)
+	}
+
+	credEnvVars := creds.EnvVars()
+
+	// Start proxy if needed (non-fatal)
+	proxyFile := path.Join(internal.DataDir(), "proxy.json")
+	stopProxy, err := kube.StartProxy(ctx, t, proxyFile)
+	if err != nil {
+		slog.Warn("Failed to start proxy", "error", err)
+	} else {
+		defer stopProxy()
+	}
+
+	// Set up kubeconfig
+	kubeconfigPath, err := kube.SetupKubeConfig(ctx, t, creds)
+	if err != nil {
+		slog.Error("Failed to setup kubeconfig", "error", err)
+		os.Exit(1)
+	}
+
+	// Prepare environment variables for kubectl
+	keysToSet := make(map[string]bool, len(credEnvVars)+1)
+	for k := range credEnvVars {
+		keysToSet[k] = true
+	}
+	keysToSet["KUBECONFIG"] = true
+
+	base := os.Environ()
+	env := make([]string, 0, len(base)+len(keysToSet))
+	for _, e := range base {
+		if idx := strings.Index(e, "="); idx >= 0 {
+			if !keysToSet[e[:idx]] {
+				env = append(env, e)
+			}
+		} else {
+			env = append(env, e)
+		}
+	}
+	for k, v := range credEnvVars {
+		env = append(env, k+"="+v)
+	}
+	env = append(env, "KUBECONFIG="+kubeconfigPath)
+
+	// Get Site CR to fetch Connect URL
+	slog.Info("Fetching Site CR from Kubernetes")
+	cmd2 := exec.CommandContext(ctx, "kubectl", "get", "site", verifySiteName,
+		"-n", verifyNamespace,
+		"-o", "yaml")
+	cmd2.Env = env
+
+	siteYAML, err := cmd2.Output()
+	if err != nil {
+		slog.Error("Failed to get Site CR", "error", err)
+		os.Exit(1)
+	}
+
+	var site verify.SiteCR
+	if err := yaml.Unmarshal(siteYAML, &site); err != nil {
+		slog.Error("Failed to parse Site CR", "error", err)
+		os.Exit(1)
+	}
+
+	// Get Connect URL
+	connectURL := ""
+	if site.Spec.Connect != nil {
+		connectURL = fmt.Sprintf("https://connect.%s", site.Spec.Domain)
+		if site.Spec.Connect.DomainPrefix != "" {
+			connectURL = fmt.Sprintf("https://%s.%s", site.Spec.Connect.DomainPrefix, site.Spec.Domain)
+		}
+		if site.Spec.Connect.BaseDomain != "" {
+			prefix := "connect"
+			if site.Spec.Connect.DomainPrefix != "" {
+				prefix = site.Spec.Connect.DomainPrefix
+			}
+			connectURL = fmt.Sprintf("https://%s.%s", prefix, site.Spec.Connect.BaseDomain)
+		}
+	}
+
+	// Run cleanup
+	slog.Info("Cleaning up VIP test credentials")
+	if err := verify.CleanupCredentials(ctx, env, verifyNamespace, connectURL); err != nil {
+		slog.Error("Cleanup failed", "error", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("\nCleanup completed successfully")
 }
 
 func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
@@ -154,6 +285,7 @@ func runVerify(ctx context.Context, cmd *cobra.Command, target string) {
 		Realm:               verifyRealm,
 		TestUsername:        verifyTestUsername,
 		KeycloakAdminSecret: verifyKeycloakAdminSecret,
+		InteractiveAuth:     verifyInteractiveAuth,
 		Timeout:             verifyTimeout,
 		Env:                 env,
 	}

--- a/docs/cli/PTD_CLI_REFERENCE.md
+++ b/docs/cli/PTD_CLI_REFERENCE.md
@@ -344,6 +344,47 @@ ptd ensure testing01-staging --dry-run
 
 ---
 
+### `ptd verify`
+
+Run VIP (Verified Installation of Posit) tests against a deployment to validate that products are functioning correctly. See [verify.md](verify.md) for full documentation including authentication modes.
+
+**Usage:**
+```bash
+ptd verify <target> [flags]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--site` | string | `main` | Name of the Site CR to verify |
+| `--categories` | string | (all) | Test categories to run (pytest `-m` marker) |
+| `--local` | bool | false | Run tests locally instead of as a K8s Job |
+| `--config-only` | bool | false | Generate and print `vip.toml` without running tests |
+| `--image` | string | `ghcr.io/posit-dev/vip:latest` | VIP container image for K8s Job mode |
+| `--keycloak-url` | string | (derived) | Override Keycloak URL |
+| `--realm` | string | `posit` | Keycloak realm name |
+| `--test-username` | string | `vip-test-user` | Keycloak test user name |
+
+**Examples:**
+```bash
+# Run all tests as a K8s Job
+ptd verify ganso01-staging
+
+# Generate config only
+ptd verify ganso01-staging --config-only
+
+# Run locally with interactive browser auth (for Okta deployments)
+ptd verify ganso01-staging --local --interactive-auth
+
+# Run specific test categories
+ptd verify ganso01-staging --categories prerequisites
+```
+
+**Implementation:** `/cmd/verify.go`, `/cmd/internal/verify/`
+
+---
+
 ### `ptd workon`
 
 Start an interactive shell or run a one-shot command with credentials, kubeconfig, and environment configured for a target. Optionally, work within a specific Pulumi stack directory.

--- a/docs/cli/verify.md
+++ b/docs/cli/verify.md
@@ -1,0 +1,93 @@
+# ptd verify
+
+Run VIP (Verified Installation of Posit) tests against a PTD deployment to validate that products are installed correctly and functioning.
+
+## Usage
+
+```bash
+ptd verify <target> [flags]
+```
+
+## How it works
+
+1. Fetches the Site CR from the target cluster
+2. Generates a `vip.toml` configuration from the Site CR (product URLs, auth provider)
+3. Provisions a test user in Keycloak (if Keycloak is configured)
+4. Runs VIP tests either as a Kubernetes Job (default) or locally
+5. Streams test output and exits with an appropriate code
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--site` | `main` | Name of the Site CR to verify |
+| `--categories` | (all) | Test categories to run (pytest `-m` marker) |
+| `--local` | `false` | Run tests locally instead of as a K8s Job |
+| `--config-only` | `false` | Generate and print `vip.toml` without running tests |
+| `--image` | `ghcr.io/posit-dev/vip:latest` | VIP container image for K8s Job mode |
+| `--keycloak-url` | (derived from Site CR) | Override Keycloak URL |
+| `--realm` | `posit` | Keycloak realm name |
+| `--test-username` | `vip-test-user` | Keycloak test user name |
+
+## Examples
+
+```bash
+# Run all VIP tests (K8s Job mode)
+ptd verify ganso01-staging
+
+# Run only prerequisite checks
+ptd verify ganso01-staging --categories prerequisites
+
+# Generate config to inspect without running tests
+ptd verify ganso01-staging --config-only
+
+# Run locally (requires VIP + Python installed)
+ptd verify ganso01-staging --local
+
+# Verify a non-default site
+ptd verify ganso01-staging --site secondary
+```
+
+## Authentication modes
+
+VIP tests require authenticated access to Connect and Workbench. How credentials are provided depends on the deployment's identity provider.
+
+### Keycloak deployments (automatic)
+
+When the Site CR has Keycloak enabled, `ptd verify` automatically:
+
+1. Reads Keycloak admin credentials from the `{site}-keycloak-initial-admin` Secret
+2. Creates a test user via the Keycloak Admin API
+3. Stores credentials in a `vip-test-credentials` Secret
+4. Passes credentials to VIP via environment variables
+
+Subsequent runs skip user creation if the Secret already exists.
+
+### Okta / external IdP deployments (interactive)
+
+Deployments using external identity providers (Okta, Azure AD, etc.) cannot provision test users programmatically. Use **local mode with interactive auth**:
+
+```bash
+ptd verify ganso01-staging --local --interactive-auth
+```
+
+This launches a visible browser window where you authenticate through the IdP's login flow. After login, VIP captures the session state and runs the remaining tests headlessly.
+
+> **Note**: `--interactive-auth` requires `--local` mode. It cannot be used with the K8s Job mode since there is no browser available in-cluster.
+
+For automated/CI verification of Okta deployments, you can pre-create a `vip-test-credentials` Secret manually:
+
+```bash
+kubectl create secret generic vip-test-credentials \
+  --from-literal=username=<your-test-user> \
+  --from-literal=password=<your-test-password> \
+  -n posit-team
+```
+
+### Summary
+
+| Mode | Auth method | Use case |
+|------|-------------|----------|
+| K8s Job (default) | Programmatic (Keycloak or pre-existing Secret) | CI, automated checks |
+| `--local --interactive-auth` | Browser popup (Okta, Azure AD) | Developer validation |
+| `--local` | Pre-existing Secret or env vars | Local automated runs |


### PR DESCRIPTION
## Summary
- Add `ptd verify <target>` command that runs VIP tests against a PTD deployment
- Auto-generates `vip.toml` config from the Kubernetes Site CR
- Provisions test user in Keycloak automatically
- Runs tests as a K8s Job (default) or locally (`--local`)
- **NEW**: `--interactive-auth` flag for OIDC deployments (Okta, Azure AD, etc.)
- **NEW**: `ptd verify cleanup <target>` subcommand

## Interactive Auth (`--interactive-auth`)

For deployments using external identity providers (Okta, SAML, etc.) where Keycloak isn't available:

```bash
ptd verify ganso01-staging --interactive-auth
```

Flow:
1. Calls `vip auth mint-connect-key` to open a browser for OIDC login and mint a Connect API key
2. Generates Workbench API token via `kubectl exec`
3. Generates Package Manager token via `kubectl exec`
4. Saves all tokens to `vip-test-credentials` K8s Secret
5. Launches K8s Job that consumes the Secret

Requires VIP CLI installed locally (`pip install /path/to/vip`).

## Cleanup

```bash
ptd verify cleanup ganso01-staging
```

Deletes:
- Connect API key via REST API (using stored key name)
- `vip-test-credentials` K8s Secret

## Details

### Existing files:
- `cmd/verify.go` — Cobra command with flags
- `cmd/internal/verify/config.go` — Parses Site CR, generates vip.toml
- `cmd/internal/verify/job.go` — Creates K8s ConfigMap + Job, streams logs
- `cmd/internal/verify/verify.go` — Orchestrates the verification flow
- `cmd/internal/verify/keycloak.go` — Auto-provisions test user via Keycloak

### New files:
- `cmd/internal/verify/credentials.go` — Token generation (VIP CLI, kubectl exec)
- `cmd/internal/verify/cleanup.go` — Credential and resource cleanup

## Usage

```bash
ptd verify ganso01-staging                          # Keycloak: auto-provision user
ptd verify ganso01-staging --interactive-auth        # OIDC: browser login + token minting
ptd verify ganso01-staging --categories connect      # Run specific category
ptd verify ganso01-staging --config-only             # Print generated vip.toml
ptd verify ganso01-staging --local                   # Run locally with uv
ptd verify cleanup ganso01-staging                   # Delete credentials and resources
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Existing tests pass (`go test ./internal/verify/`)
- [x] `ptd verify ganso01-staging --config-only` generates valid vip.toml
- [ ] `ptd verify ganso01-staging` creates Job and streams logs
- [ ] `ptd verify ganso01-staging --interactive-auth` mints credentials and runs Job
- [ ] `ptd verify cleanup ganso01-staging` deletes credentials
- [ ] Test user is created in Keycloak on first run, skipped on subsequent runs