### PR TITLE
feat: upgrade AWS control room Traefik from v2 to v3

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -70,6 +70,20 @@ With this setting disabled, the infrastructure will deploy successfully without 
 
 
 
+### Traefik v3 CRD Migration
+
+**Background:**
+PTD upgraded the Traefik ingress controller from v2 (Helm chart `24.x`) to v3 (Helm chart `33.x`). Traefik v3 ships updated CRD schemas for `IngressRoute`, `Middleware`, `TLSOption`, and related resources.
+
+**Risk:**
+If any workloads use Traefik v2-style CRD fields that were removed or renamed in v3 (e.g., `ServersTransport` → `ServersTransports`, changed TLS store/options schemas, modified middleware CRD fields), those resources may fail to reconcile after the Helm upgrade without producing obvious errors.
+
+**Before rolling out to production clusters:**
+1. Audit existing `IngressRoute`, `Middleware`, `TLSOption`, and `ServersTransport` resources against the [Traefik v3 migration guide](https://doc.traefik.io/traefik/migration/v2-to-v3/).
+2. Pay particular attention to `ServersTransport` → `ServersTransports` rename and any middleware fields your workloads rely on.
+3. Test the upgrade in a staging cluster before applying to production.
+
+
 ## Workarounds and Best Practices
 
 ### Direct Pulumi Stack Access with `ptd workon`

--- a/python-pulumi/src/ptd/aws_control_room.py
+++ b/python-pulumi/src/ptd/aws_control_room.py
@@ -71,7 +71,7 @@ class AWSControlRoomConfig:
     tailscale_enabled: bool = True
     tigera_operator_version: str = "3.27.2"
     traefik_forward_auth_version: str = "0.0.14"
-    traefik_version: str = "24.0.0"
+    traefik_version: str = "33.2.1"
     ebs_csi_addon_version: str = "v1.41.0-eksbuild.1"
 
 

--- a/python-pulumi/src/ptd/pulumi_resources/aws_control_room_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_control_room_cluster.py
@@ -218,6 +218,7 @@ class AWSControlRoomCluster(pulumi.ComponentResource):
             "",
             cert,
             deployment_replicas=self.control_room.cfg.traefik_deployment_replicas,
+            version=self.control_room.cfg.traefik_version,
             opts=pulumi.ResourceOptions(
                 parent=self.eks,
                 provider=self.eks.provider,

--- a/python-pulumi/src/ptd/pulumi_resources/traefik.py
+++ b/python-pulumi/src/ptd/pulumi_resources/traefik.py
@@ -156,11 +156,11 @@ class Traefik(pulumi.ComponentResource):
             f"{self.cluster.name}-traefik",
             k8s.helm.v3.ReleaseArgs(
                 chart="traefik",
-                version="24.0.0",
+                version="33.2.1",
                 namespace=self.namespace,
                 name="traefik",
                 repository_opts=k8s.helm.v3.RepositoryOptsArgs(
-                    repo="https://helm.traefik.io/traefik/",
+                    repo="https://traefik.github.io/charts",
                 ),
                 values={
                     "service": {
@@ -184,7 +184,13 @@ class Traefik(pulumi.ComponentResource):
                     },
                     "ports": {
                         "web": {
-                            "redirectTo": "websecure",
+                            "redirections": {
+                                "entryPoint": {
+                                    "to": "websecure",
+                                    "scheme": "https",
+                                    "permanent": True,
+                                }
+                            },
                         },
                         "websecure": {
                             "tls": {
@@ -226,7 +232,7 @@ class Traefik(pulumi.ComponentResource):
                     },
                     "ingressClass": {
                         "enabled": True,
-                        "default": True,
+                        "isDefaultClass": True,
                     },
                     "ingressRoute": {
                         "dashboard": {

--- a/python-pulumi/src/ptd/pulumi_resources/traefik.py
+++ b/python-pulumi/src/ptd/pulumi_resources/traefik.py
@@ -43,6 +43,7 @@ class Traefik(pulumi.ComponentResource):
         node_selector: str = "",
         cert: aws.acm.Certificate | None = None,
         deployment_replicas: int = 3,
+        version: str = "33.2.1",
         *args,
         **kwargs,
     ):
@@ -63,6 +64,7 @@ class Traefik(pulumi.ComponentResource):
         self.cluster = cluster
         self.node_selector: str = node_selector
         self.deployment_replicas = deployment_replicas
+        self.version = version
         self.traefik: k8s.helm.v3.Release | None = None
         self._deploy(cert)
 
@@ -156,7 +158,7 @@ class Traefik(pulumi.ComponentResource):
             f"{self.cluster.name}-traefik",
             k8s.helm.v3.ReleaseArgs(
                 chart="traefik",
-                version="33.2.1",
+                version=self.version,
                 namespace=self.namespace,
                 name="traefik",
                 repository_opts=k8s.helm.v3.RepositoryOptsArgs(


### PR DESCRIPTION
## Summary

- Upgrade Traefik Helm chart from v24.0.0 to v33.2.1 for AWS control rooms
- Migrate Helm values to v3 format (redirections, isDefaultClass)
- Update default version in AWSControlRoomConfig
- Workload Traefik already on v3 (37.1.2) — no changes needed

AWS-specific config preserved: NLB annotations, SSL cert handling, TLS termination at NLB.

## Part of

Cloud-agnostic team-operator epic — prerequisite for Gateway API migration.

## Test plan

- [ ] Deploy to staging control room
- [ ] Verify Traefik starts and routes traffic
- [ ] Verify HTTP→HTTPS redirect works
- [ ] Verify NLB health checks pass