### PR TITLE
fix: stop overriding team-operator image when not explicitly configured

### DIFF
--- a/python-pulumi/src/ptd/__init__.py
+++ b/python-pulumi/src/ptd/__init__.py
@@ -409,7 +409,7 @@ class Toleration:
 
 @dataclasses.dataclass(frozen=True)
 class WorkloadClusterConfig:
-    team_operator_image: str = "latest"
+    team_operator_image: str | None = None
     # Overrides team_operator_image when set. Can be a tag (e.g., "test", "dev")
     # or a full image reference. For adhoc images from posit-dev/team-operator PRs:
     #   ghcr.io/posit-dev/team-operator:adhoc-{branch}-{version}

--- a/python-pulumi/src/ptd/aws_workload.py
+++ b/python-pulumi/src/ptd/aws_workload.py
@@ -408,8 +408,10 @@ class AWSWorkload(ptd.workload.AbstractWorkload):
         for key in list(cluster_spec.keys()):
             cluster_spec[key.replace("-", "_")] = cluster_spec.pop(key)
 
-        team_operator_image = cluster_spec.pop("team_operator_image", "latest").strip().lower()
-        cluster_spec["team_operator_image"] = {"": "latest"}.get(team_operator_image, team_operator_image)
+        team_operator_image = cluster_spec.pop("team_operator_image", None)
+        if team_operator_image is not None:
+            team_operator_image = team_operator_image.strip().lower() or None
+        cluster_spec["team_operator_image"] = team_operator_image
 
         ptd_controller_image = cluster_spec.pop("ptd_controller_image", "latest").strip().lower()
 

--- a/python-pulumi/src/ptd/azure_workload.py
+++ b/python-pulumi/src/ptd/azure_workload.py
@@ -183,8 +183,10 @@ class AzureWorkload(ptd.workload.AbstractWorkload):
         for key in list(cluster_spec.keys()):
             cluster_spec[key.replace("-", "_")] = cluster_spec.pop(key)
 
-        team_operator_image = cluster_spec.pop("team_operator_image", "latest").strip().lower()
-        cluster_spec["team_operator_image"] = {"": "latest"}.get(team_operator_image, team_operator_image)
+        team_operator_image = cluster_spec.pop("team_operator_image", None)
+        if team_operator_image is not None:
+            team_operator_image = team_operator_image.strip().lower() or None
+        cluster_spec["team_operator_image"] = team_operator_image
 
         # Handle user_node_pools if present
         if cluster_spec.get("user_node_pools"):

--- a/python-pulumi/tests/test_workload_cluster_config.py
+++ b/python-pulumi/tests/test_workload_cluster_config.py
@@ -10,7 +10,7 @@ def test_workload_cluster_config_default_initialization():
     config = ptd.WorkloadClusterConfig()
 
     # Test default values
-    assert config.team_operator_image == "latest"
+    assert config.team_operator_image is None
     assert config.ptd_controller_image == "latest"
     assert config.eks_access_entries.enabled is True
     assert config.eks_access_entries.additional_entries == []
@@ -175,7 +175,7 @@ def test_workload_cluster_config_dataclass_fields():
 
     # team_operator_image field
     team_op_field = field_dict["team_operator_image"]
-    assert team_op_field.default == "latest"
+    assert team_op_field.default is None
 
     # ptd_controller_image field
     ptd_ctrl_field = field_dict["ptd_controller_image"]


### PR DESCRIPTION
## Description

When `team_operator_image` is not set in `ptd.yaml`, PTD now passes no image
override to the Helm chart, allowing the chart to use its `appVersion` default
(introduced in posit-dev/team-operator#88).

Previously, `WorkloadClusterConfig.team_operator_image` defaulted to `"latest"`
and was always forwarded to Helm values, defeating the chart's own default.

## Behavior after this change

- `team_operator_image` not set → chart uses `appVersion` (tracks chart release)
- `team_operator_image: latest` → explicitly passes `latest` to Helm
- `team_operator_image: v1.9.0` → pins to that version
- `adhoc_team_operator_image` set → unchanged, takes priority as before

## Issue

posit-dev/team-operator#88

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)