### PR TITLE
Revert "fix: stop overriding team-operator image when not explicitly configured"

### DIFF
--- a/python-pulumi/src/ptd/__init__.py
+++ b/python-pulumi/src/ptd/__init__.py
@@ -409,7 +409,7 @@ class Toleration:
 
 @dataclasses.dataclass(frozen=True)
 class WorkloadClusterConfig:
-    team_operator_image: str | None = None
+    team_operator_image: str = "latest"
     # Overrides team_operator_image when set. Can be a tag (e.g., "test", "dev")
     # or a full image reference. For adhoc images from posit-dev/team-operator PRs:
     #   ghcr.io/posit-dev/team-operator:adhoc-{branch}-{version}

--- a/python-pulumi/src/ptd/aws_workload.py
+++ b/python-pulumi/src/ptd/aws_workload.py
@@ -408,10 +408,8 @@ class AWSWorkload(ptd.workload.AbstractWorkload):
         for key in list(cluster_spec.keys()):
             cluster_spec[key.replace("-", "_")] = cluster_spec.pop(key)
 
-        team_operator_image = cluster_spec.pop("team_operator_image", None)
-        if team_operator_image is not None:
-            team_operator_image = team_operator_image.strip().lower() or None
-        cluster_spec["team_operator_image"] = team_operator_image
+        team_operator_image = cluster_spec.pop("team_operator_image", "latest").strip().lower()
+        cluster_spec["team_operator_image"] = {"": "latest"}.get(team_operator_image, team_operator_image)
 
         ptd_controller_image = cluster_spec.pop("ptd_controller_image", "latest").strip().lower()
 

--- a/python-pulumi/src/ptd/azure_workload.py
+++ b/python-pulumi/src/ptd/azure_workload.py
@@ -178,10 +178,8 @@ class AzureWorkload(ptd.workload.AbstractWorkload):
         for key in list(cluster_spec.keys()):
             cluster_spec[key.replace("-", "_")] = cluster_spec.pop(key)
 
-        team_operator_image = cluster_spec.pop("team_operator_image", None)
-        if team_operator_image is not None:
-            team_operator_image = team_operator_image.strip().lower() or None
-        cluster_spec["team_operator_image"] = team_operator_image
+        team_operator_image = cluster_spec.pop("team_operator_image", "latest").strip().lower()
+        cluster_spec["team_operator_image"] = {"": "latest"}.get(team_operator_image, team_operator_image)
 
         # Handle user_node_pools if present
         if cluster_spec.get("user_node_pools"):

--- a/python-pulumi/src/ptd/pulumi_resources/team_operator.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_operator.py
@@ -71,13 +71,9 @@ class TeamOperator(pulumi.ComponentResource):
         self._define_helm_release()
 
     def _define_image(self):
-        # Use adhoc_team_operator_image if set, otherwise use team_operator_image if explicitly set.
-        # If neither is set (team_operator_image is None), self.image stays None so the Helm chart
-        # defaults to its appVersion.
+        # Use adhoc_team_operator_image if set, otherwise use team_operator_image
+        # adhoc images can be tags like "test", "dev", or full image references
         image_config = self.cluster_cfg.adhoc_team_operator_image or self.cluster_cfg.team_operator_image
-        if image_config is None:
-            self.image = None
-            return
         self.image = ptd.define_component_image(
             image_config=image_config,
             component_image=ptd.ComponentImages.TEAM_OPERATOR,
@@ -248,19 +244,17 @@ echo "Migration complete - Helm will now create fresh resources"
     def _define_helm_release(self):
         # Parse self.image (from _define_image) into repository and tag
         # Format is either "repo@sha256:digest" or "repo:tag"
-        # If self.image is None, we skip image configuration to let the Helm chart use its default appVersion
-        if self.image is not None:
-            if "@" in self.image:
-                # Image with digest: "hostname/repo@sha256:abc123"
-                image_repository, image_tag = self.image.rsplit("@", 1)
-                image_tag = f"@{image_tag}"  # Helm needs the @ prefix for digests
-            elif ":" in self.image.split("/")[-1]:
-                # Image with tag: "hostname/repo:tag"
-                image_repository, image_tag = self.image.rsplit(":", 1)
-            else:
-                # No tag specified, use latest
-                image_repository = self.image
-                image_tag = "latest"
+        if "@" in self.image:
+            # Image with digest: "hostname/repo@sha256:abc123"
+            image_repository, image_tag = self.image.rsplit("@", 1)
+            image_tag = f"@{image_tag}"  # Helm needs the @ prefix for digests
+        elif ":" in self.image.split("/")[-1]:
+            # Image with tag: "hostname/repo:tag"
+            image_repository, image_tag = self.image.rsplit(":", 1)
+        else:
+            # No tag specified, use latest
+            image_repository = self.image
+            image_tag = "latest"
 
         # Build environment variables
         env_vars = {
@@ -271,19 +265,17 @@ echo "Migration complete - Helm will now create fresh resources"
         if self.workload.cfg.region:
             env_vars["AWS_REGION"] = self.workload.cfg.region
 
-        # Build container config - only include image if explicitly set
-        container_config = {"env": env_vars}
-        if self.image is not None:
-            container_config["image"] = {
-                "repository": image_repository,
-                "tag": image_tag,
-            }
-
         # Helm values for the team-operator chart
         helm_values = {
             "controllerManager": {
                 "replicas": 1,
-                "container": container_config,
+                "container": {
+                    "image": {
+                        "repository": image_repository,
+                        "tag": image_tag,
+                    },
+                    "env": env_vars,
+                },
                 # Use default serviceAccountName from chart (team-operator-controller-manager)
                 # to match existing kustomize resources for seamless migration
                 "serviceAccount": {

--- a/python-pulumi/tests/test_workload_cluster_config.py
+++ b/python-pulumi/tests/test_workload_cluster_config.py
@@ -10,7 +10,7 @@ def test_workload_cluster_config_default_initialization():
     config = ptd.WorkloadClusterConfig()
 
     # Test default values
-    assert config.team_operator_image is None
+    assert config.team_operator_image == "latest"
     assert config.ptd_controller_image == "latest"
     assert config.eks_access_entries.enabled is True
     assert config.eks_access_entries.additional_entries == []
@@ -175,7 +175,7 @@ def test_workload_cluster_config_dataclass_fields():
 
     # team_operator_image field
     team_op_field = field_dict["team_operator_image"]
-    assert team_op_field.default is None
+    assert team_op_field.default == "latest"
 
     # ptd_controller_image field
     ptd_ctrl_field = field_dict["ptd_controller_image"]


### PR DESCRIPTION
This change to stop overriding the team-operator image when not explicitly configured, exposed two bugs in the team-operator Helm chart. Reverting to apply a cleaner fix next week.

1. Wrong default repository: Chart defaults to posit/team-operator but the actual image is published to posit/ptd-team-operator (note the ptd-prefix)
2. appVersion/Docker tag mismatch: [PR #107 ](https://github.com/posit-dev/team-operator/pull/107) changed the chart to use appVersion as the default image tag (e.g., 1.15.0), but Docker Hub only has tags in git-describe format (e.g., v1.15.0-1-g101dab1) and latest. There is no 1.15.0 or v1.15.0 tag.