### PR TITLE
docs: add PR self-review norms and code flow section

### DIFF
--- a/.claude/review-guidelines.md
+++ b/.claude/review-guidelines.md
@@ -1,0 +1,50 @@
+# PTD Code Review Guidelines
+
+## Reviewer Responsibilities
+
+Your job is to review the **code itself**, not just the description or intent. In a world of agentic coding, the author may not have hand-written every line. That means:
+
+- Read the actual diff, not just the PR summary
+- Verify the code does what the description claims
+- Look for correctness issues, not just style preferences
+
+### What to Focus On
+
+**Correctness and safety:**
+- Does the code handle edge cases?
+- Are error paths handled appropriately?
+- Could this introduce security issues (credential handling, injection, RBAC)?
+
+**Code quality fundamentals:**
+- **Encapsulation**: Is internal state properly hidden? Are interfaces clean?
+- **DRY**: Is there duplicated logic that should be extracted? But don't over-abstract — three similar lines can be better than a premature helper
+- **Naming**: Do names reveal intent? Would a future reader understand this?
+- **Complexity**: Is this more complicated than it needs to be?
+
+**Patterns and consistency:**
+- Does new code follow the existing patterns in the codebase?
+- Are Pulumi resources structured consistently with existing ones?
+- Are Go and Python conventions followed?
+
+### What NOT to Focus On
+
+- Style issues handled by formatters (`just format`)
+- Personal preferences without clear benefit
+- Theoretical concerns without concrete impact
+- Micro-optimizing code that runs once during infrastructure provisioning
+
+## Comment Format
+
+Use clear, actionable language:
+- **Critical**: "This will break X because Y. Consider Z."
+- **Important**: "This pattern differs from existing code in A. Recommend B for consistency."
+- **Suggestion**: "Consider X for improved Y."
+
+## Self-Review Norm
+
+PR authors are expected to review their own diff before opening the PR and add inline comments to draw attention to:
+- Lines they don't fully understand
+- Areas of concern or uncertainty
+- Key decision points reviewers should weigh in on
+
+This balances effort between author and reviewer. If the author hasn't commented their PR, ask them to.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,14 @@ Please include a summary of the changes and the related issue. Please also inclu
 Link to GitHub or JIRA issue tracking this work; if it exists.
 -->
 
+## Code Flow
+
+<!--
+Explain how the code works at a high level. Walk through the key paths, data flow, or control flow introduced or changed by this PR. If you discussed the implementation with an AI assistant, include the relevant architectural explanations here.
+
+Delete this section if the change is trivial (typo fix, version bump, etc.).
+-->
+
 ## Category of change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
@@ -18,3 +26,7 @@ Link to GitHub or JIRA issue tracking this work; if it exists.
 - [ ] Refactor: a code change that neither fixes a bug nor adds a feature
 - [ ] Documentation: documentation changes
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about


### PR DESCRIPTION
## Summary

- Adds a **Code Flow** section to the PR template for authors to explain key data/control flow and AI-assisted architectural decisions
- Adds a self-review checklist item requiring authors to comment their own diff before opening the PR
- Creates `.claude/review-guidelines.md` with reviewer responsibilities, code quality fundamentals (encapsulation, DRY, naming, complexity), and the self-review norm

These changes reflect new team norms for balancing PR effort between author and reviewer in an agentic coding workflow.

## Test plan

- [ ] Verify the PR template renders correctly when opening a new PR
- [ ] Verify `.claude/review-guidelines.md` is accessible to Claude Code sessions