### PR TITLE
fix: alloy instance duplication bug

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/grafana_alloy.py
+++ b/python-pulumi/src/ptd/pulumi_resources/grafana_alloy.py
@@ -493,9 +493,24 @@ class AlloyConfig(pulumi.ComponentResource):
 
                 prometheus.scrape "blackbox" {{
                     targets    = prometheus.exporter.blackbox.front_door.targets
-                    forward_to = [prometheus.relabel.default.receiver]
+                    forward_to = [prometheus.relabel.blackbox.receiver]
                     clustering {{
                         enabled = true
+                    }}
+                }}
+
+                // Normalize instance label for blackbox metrics to deduplicate across Alloy pods.
+                // Each pod runs its own blackbox exporter, producing metrics with different
+                // instance labels (node hostnames). Replacing instance with a static value
+                // ensures Mimir deduplicates them, preventing duplicate alerts.
+                // See: https://github.com/grafana/alloy/issues/1009
+                prometheus.relabel "blackbox" {{
+                    forward_to = [prometheus.relabel.default.receiver]
+
+                    rule {{
+                        action       = "replace"
+                        target_label = "instance"
+                        replacement  = "blackbox"
                     }}
                 }}
 


### PR DESCRIPTION
# Description

**Problem**
Healthcheck alerts were firing multiple times for the same failing endpoint, with different instance labels corresponding to different Alloy pod node hostnames (e.g., ip-10-85-131-143.us-east-2.compute.internal and ip-10-85-21-223.us-east-2.compute.internal).

**Root Cause**                                                                                                               
When Alloy runs prometheus.exporter.blackbox in clustering mode, each pod's exporter sets the instance label to its node hostname. This creates duplicate metric series that trigger separate alerts for the same health check failure.                                                          
**This is a known Alloy limitation:** https://github.com/grafana/alloy/issues/1009

**Solution**
Added a prometheus.relabel "blackbox" component that normalizes the instance label to the static value "blackbox" before forwarding to Mimir. This ensures all blackbox metrics from all Alloy pods have identical labels, allowing Mimir to deduplicate them and preventing duplicate alerts.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
