### PR TITLE
feat: add ppm-oidc-client-secret to site secret provisioning

### DIFF
--- a/lib/secrets/secrets.go
+++ b/lib/secrets/secrets.go
@@ -8,23 +8,24 @@ import (
 )
 
 type SiteSecret struct {
-	DevAdminToken      string `json:"dev-admin-token"` // likely to be removed
-	DevClientSecret    string `json:"dev-client-secret"`
-	DevDBPassword      string `json:"dev-db-password"`
-	DevLicense         string `json:"dev-license"`
-	DevUserToken       string `json:"dev-user-token"` // likely to be removed
-	DevChronicleApiKey string `json:"dev-chronicle-api-key"`
-	HomeAuthMap        string `json:"home-auth-map"`
-	KeycloakDBUser     string `json:"keycloak-db-user"`
-	KeycloakDBPassword string `json:"keycloak-db-password"`
-	PkgDBPassword      string `json:"pkg-db-password"`
-	PkgLicense         string `json:"pkg-license"`
-	PkgSecretKey       string `json:"pkg-secret-key"`
-	PubClientSecret    string `json:"pub-client-secret"`
-	PubDBPassword      string `json:"pub-db-password"`
-	PubLicense         string `json:"pub-license"`
-	PubSecretKey       string `json:"pub-secret-key"`
-	PubChronicleApiKey string `json:"pub-chronicle-api-key"`
+	DevAdminToken       string `json:"dev-admin-token"` // likely to be removed
+	DevClientSecret     string `json:"dev-client-secret"`
+	DevDBPassword       string `json:"dev-db-password"`
+	DevLicense          string `json:"dev-license"`
+	DevUserToken        string `json:"dev-user-token"` // likely to be removed
+	DevChronicleApiKey  string `json:"dev-chronicle-api-key"`
+	HomeAuthMap         string `json:"home-auth-map"`
+	KeycloakDBUser      string `json:"keycloak-db-user"`
+	KeycloakDBPassword  string `json:"keycloak-db-password"`
+	PkgDBPassword       string `json:"pkg-db-password"`
+	PkgLicense          string `json:"pkg-license"`
+	PkgSecretKey        string `json:"pkg-secret-key"`
+	PpmOidcClientSecret string `json:"ppm-oidc-client-secret"`
+	PubClientSecret     string `json:"pub-client-secret"`
+	PubDBPassword       string `json:"pub-db-password"`
+	PubLicense          string `json:"pub-license"`
+	PubSecretKey        string `json:"pub-secret-key"`
+	PubChronicleApiKey  string `json:"pub-chronicle-api-key"`
 }
 
 func NewSiteSecret(siteName string) SiteSecret {

--- a/python-pulumi/src/ptd/secrecy.py
+++ b/python-pulumi/src/ptd/secrecy.py
@@ -112,6 +112,7 @@ SiteSecret = typing.TypedDict(
         "pkg-db-password": str,
         "pkg-license": str,
         "pkg-secret-key": str,
+        "ppm-oidc-client-secret": str,
         "pub-client-secret": str,
         "pub-db-password": str,
         "pub-license": str,


### PR DESCRIPTION
## Summary
- Adds `ppm-oidc-client-secret` key to `SiteSecret` struct (Go) and TypedDict (Python)
- Supports PPM's OpenID Connect integration in the team-operator ([PR #112](https://github.com/posit-dev/team-operator/pull/112))
- Field is empty by default — users set it manually after configuring their OIDC provider

## Context

The team-operator now supports PPM OIDC authentication and Identity Federation for authenticated package repos (PTDC-222, PTDC-223, PTDC-224). The operator's `SecretProviderClass` expects a `ppm-oidc-client-secret` key in the site vault to mount into the PPM container at `/etc/rstudio-pm/oidc-client-secret`.

This PR adds the key to the PTD secret provisioning so that:
1. New workloads get the key created during bootstrap (empty, ready to be populated)
2. Existing workloads get the key added via `aws_ensure_secret()` merge on next bootstrap run

## Test plan
- [ ] Verify `just cli` builds successfully
- [ ] Verify `just check` passes