### PR TITLE
Add force_node_group_upgrade option for EKS clusters

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,6 +113,7 @@ spec:
         mp_instance_type: r6a.2xlarge
         root_disk_size: 200
         routing_weight: "100"  # For blue/green: 0-255
+        # force_node_group_upgrade: false  # Force version updates even when PDBs block pod eviction
         components:
           traefik_forward_auth_version: "0.0.14"
 

--- a/examples/workload/ptd.yaml
+++ b/examples/workload/ptd.yaml
@@ -69,6 +69,9 @@ spec:
         # Traffic routing weight (for blue/green deployments)
         routing_weight: "100"
 
+        # Force node group version updates even when PDBs block pod eviction (default: false)
+        # force_node_group_upgrade: true
+
         # Component versions
         components:
           traefik_forward_auth_version: "0.0.14"

--- a/examples/workload/ptd.yaml
+++ b/examples/workload/ptd.yaml
@@ -70,7 +70,7 @@ spec:
         routing_weight: "100"
 
         # Force node group version updates even when PDBs block pod eviction (default: false)
-        # force_node_group_upgrade: true
+        # force_node_group_upgrade: false
 
         # Component versions
         components:

--- a/python-pulumi/src/ptd/aws_workload.py
+++ b/python-pulumi/src/ptd/aws_workload.py
@@ -258,6 +258,7 @@ class AWSWorkloadClusterConfig(ptd.WorkloadClusterConfig):
     enable_efs_csi_driver: bool = False
     efs_config: ptd.EFSConfig | None = None
     karpenter_config: KarpenterConfig | None = None
+    force_node_group_upgrade: bool = False
 
 
 @dataclasses.dataclass(frozen=True)

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -527,6 +527,7 @@ class AWSEKSCluster(pulumi.ComponentResource):
         ami_type: str = "AL2_x86_64",
         taints: list[aws.eks.NodeGroupTaintArgs] | None = None,
         depends_on: list[pulumi.Resource] | None = None,
+        force_update_version: bool = False,
         *,
         use_name: bool = False,
     ):
@@ -552,6 +553,7 @@ class AWSEKSCluster(pulumi.ComponentResource):
         :param max_unavailable: Optional. The maximum number of unavailable nodes during an update. Default 1
         :param taints: Optional. The Kubernetes taints to be applied to the nodes in the node group
         :param depends_on: Optional. Resources that must be created before the node group (e.g., CNI)
+        :param force_update_version: Optional. Force version update even when PDBs block pod eviction. Default False
         :param opts: Optional. Resource options.
         :return: The AWSEKSCluster component resource
         """
@@ -601,6 +603,7 @@ class AWSEKSCluster(pulumi.ComponentResource):
             ),
             update_config=aws.eks.NodeGroupUpdateConfigArgs(max_unavailable=max_unavailable),
             taints=taints,
+            force_update_version=force_update_version,
             opts=pulumi.ResourceOptions(parent=self.eks, depends_on=depends_on),
         )
 

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -527,8 +527,8 @@ class AWSEKSCluster(pulumi.ComponentResource):
         ami_type: str = "AL2_x86_64",
         taints: list[aws.eks.NodeGroupTaintArgs] | None = None,
         depends_on: list[pulumi.Resource] | None = None,
-        force_update_version: bool = False,
         *,
+        force_update_version: bool = False,
         use_name: bool = False,
     ):
         # TODO: what typing should we have for subnets? Consistency?

--- a/python-pulumi/src/ptd/pulumi_resources/aws_workload_eks.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_workload_eks.py
@@ -248,6 +248,7 @@ class AWSWorkloadEKS(pulumi.ComponentResource):
             version=cluster_cfg.cluster_version,
             taints=eks_taints,
             depends_on=depends_on,
+            force_update_version=cluster_cfg.force_node_group_upgrade,
         )
 
     def _define_tigera_operator(

--- a/python-pulumi/tests/test_workload_cluster_config.py
+++ b/python-pulumi/tests/test_workload_cluster_config.py
@@ -3,6 +3,7 @@ import dataclasses
 import pytest
 
 import ptd
+import ptd.aws_workload
 
 
 def test_workload_cluster_config_default_initialization():
@@ -308,3 +309,15 @@ def test_workload_cluster_config_custom_k8s_resources_in_workload():
 
     assert workload_config.clusters["20250328"].custom_k8s_resources == ["storage", "common"]
     assert workload_config.clusters["20250415"].custom_k8s_resources == ["monitoring"]
+
+
+def test_aws_workload_cluster_config_force_node_group_upgrade_default():
+    """Test that force_node_group_upgrade defaults to False."""
+    config = ptd.aws_workload.AWSWorkloadClusterConfig()
+    assert config.force_node_group_upgrade is False
+
+
+def test_aws_workload_cluster_config_force_node_group_upgrade_enabled():
+    """Test that force_node_group_upgrade can be set to True."""
+    config = ptd.aws_workload.AWSWorkloadClusterConfig(force_node_group_upgrade=True)
+    assert config.force_node_group_upgrade is True


### PR DESCRIPTION
## Description

Per-cluster opt-in flag (`force_node_group_upgrade`, default `false`) that passes `force_update_version` to the EKS `NodeGroup` resource, allowing version updates even when Pod Disruption Budgets block pod eviction.

This was needed because EKS node group upgrades on ganso01-staging were failing due to Workbench session PDBs with `maxUnavailable: 0`.

### Usage

```yaml
clusters:
  "20250328":
    spec:
      cluster_version: 1.33
      force_node_group_upgrade: true
```

## Category of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested in [`ganso01-staging`](https://ganso.lab.staging.posit.team/) and confirmed my change works
- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about