### PR TITLE
fix: change azure metric names and give better alert descriptions

### DIFF
--- a/python-pulumi/src/ptd/grafana_alerts/azure_netapp.yaml
+++ b/python-pulumi/src/ptd/grafana_alerts/azure_netapp.yaml
@@ -34,7 +34,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage{job="integrations/azure"}
+                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -73,8 +73,25 @@ groups:
           execErrState: Error
           for: 10m
           annotations:
-            description: "Azure NetApp Files volume has more than 80% capacity utilization for more than 10 minutes. Note: on new cluster deployments where Azure Monitor scraping has not yet initialized, noDataState=Alerting may produce a false positive after the for:10m window; this is expected during provisioning."
-            summary: High capacity utilization on Azure NetApp Files volume {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure NetApp Files Capacity High"
+            description: |
+              NetApp Files volume capacity utilization is above 80%
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Volume Capacity
+              Current:     > 80%
+              Threshold:   80%
+              Duration:    10 minutes
+
+              Note: On new deployments, noDataState=Alerting may produce
+              a false positive during Azure Monitor initialization (first 10m)
+
           labels:
             opsgenie: "1"
           isPaused: false
@@ -89,7 +106,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency{job="integrations/azure"}
+                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -128,8 +145,23 @@ groups:
           execErrState: Error
           for: 10m
           annotations:
-            description: Azure NetApp Files volume read latency is above 10ms for more than 10 minutes, indicating potential performance degradation.
-            summary: High read latency on Azure NetApp Files volume {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure NetApp Files Read Latency High"
+            description: |
+              NetApp Files volume read latency is above 10ms
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Read Latency
+              Current:     > 10ms
+              Threshold:   10ms
+              Duration:    10 minutes
+              Baseline:    Sub-millisecond typical
+
           labels:
             opsgenie: "1"
           isPaused: false
@@ -144,7 +176,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagewritelatency{job="integrations/azure"}
+                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagewritelatency_average_milliseconds{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -183,8 +215,23 @@ groups:
           execErrState: Error
           for: 10m
           annotations:
-            description: Azure NetApp Files volume write latency is above 10ms for more than 10 minutes, indicating potential performance degradation.
-            summary: High write latency on Azure NetApp Files volume {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure NetApp Files Write Latency High"
+            description: |
+              NetApp Files volume write latency is above 10ms
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Write Latency
+              Current:     > 10ms
+              Threshold:   10ms
+              Duration:    10 minutes
+              Baseline:    Sub-millisecond typical
+
           labels:
             opsgenie: "1"
           isPaused: false

--- a/python-pulumi/src/ptd/grafana_alerts/azure_postgres.yaml
+++ b/python-pulumi/src/ptd/grafana_alerts/azure_postgres.yaml
@@ -23,6 +23,9 @@
 # If Alloy is not running or relabeling is misconfigured, the label will be absent and
 # the annotation will render as "in cluster " (blank).
 apiVersion: 1
+deleteRules:
+  - orgId: 1
+    uid: azure_postgres_deadlocks
 groups:
     - orgId: 1
       name: Azure PostgreSQL
@@ -40,7 +43,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_dbforpostgresql_flexibleservers_cpu_percent{job="integrations/azure"}
+                expr: azure_microsoft_dbforpostgresql_flexibleservers_cpu_percent_average_percent{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -79,8 +82,22 @@ groups:
           execErrState: Error
           for: 10m
           annotations:
-            description: Azure PostgreSQL Flexible Server CPU utilization is above 80% for more than 10 minutes.
-            summary: High CPU utilization on Azure PostgreSQL server {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure PostgreSQL CPU High"
+            description: |
+              PostgreSQL Flexible Server CPU utilization is above 80%
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      CPU Utilization
+              Current:     > 80%
+              Threshold:   80%
+              Duration:    10 minutes
+
           labels:
             opsgenie: "1"
           isPaused: false
@@ -95,7 +112,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_dbforpostgresql_flexibleservers_storage_percent{job="integrations/azure"}
+                expr: azure_microsoft_dbforpostgresql_flexibleservers_storage_percent_average_percent{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -134,8 +151,25 @@ groups:
           execErrState: Error
           for: 5m
           annotations:
-            description: "Azure PostgreSQL Flexible Server has more than 80% storage utilization for more than 5 minutes. Note: on new cluster deployments where Azure Monitor scraping has not yet initialized, noDataState=Alerting may produce a false positive after the for:5m window; this is expected during provisioning."
-            summary: High storage utilization on Azure PostgreSQL server {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure PostgreSQL Storage High"
+            description: |
+              PostgreSQL Flexible Server storage utilization is above 80%
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Storage Utilization
+              Current:     > 80%
+              Threshold:   80%
+              Duration:    5 minutes
+
+              Note: On new deployments, noDataState=Alerting may produce
+              a false positive during Azure Monitor initialization (first 5m)
+
           labels:
             opsgenie: "1"
           isPaused: false
@@ -150,7 +184,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_dbforpostgresql_flexibleservers_memory_percent{job="integrations/azure"}
+                expr: azure_microsoft_dbforpostgresql_flexibleservers_memory_percent_average_percent{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -189,8 +223,22 @@ groups:
           execErrState: Error
           for: 10m
           annotations:
-            description: Azure PostgreSQL Flexible Server has more than 80% memory utilization for more than 10 minutes.
-            summary: High memory utilization on Azure PostgreSQL server {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure PostgreSQL Memory High"
+            description: |
+              PostgreSQL Flexible Server memory utilization is above 80%
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Memory Utilization
+              Current:     > 80%
+              Threshold:   80%
+              Duration:    10 minutes
+
           labels:
             opsgenie: "1"
           isPaused: false
@@ -205,7 +253,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_dbforpostgresql_flexibleservers_active_connections{job="integrations/azure"}
+                expr: azure_microsoft_dbforpostgresql_flexibleservers_active_connections_average_count{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -244,8 +292,25 @@ groups:
           execErrState: Error
           for: 5m
           annotations:
-            description: "Azure PostgreSQL Flexible Server has more than 500 active database connections for more than 5 minutes. Note: this threshold is calibrated for mid-size SKUs; it may need adjustment for smaller or larger instance sizes."
-            summary: High database connections on Azure PostgreSQL server {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure PostgreSQL Connections High"
+            description: |
+              PostgreSQL Flexible Server has more than 500 active connections
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Active Connections
+              Current:     > 500
+              Threshold:   500
+              Duration:    5 minutes
+
+              Note: Threshold calibrated for mid-size SKUs; may need
+              adjustment for smaller or larger instance sizes
+
           labels:
             opsgenie: "1"
             instance_size_dependent: "true"  # Silence this label for known-small instance classes
@@ -261,7 +326,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_dbforpostgresql_flexibleservers_connections_failed{job="integrations/azure"}
+                expr: azure_microsoft_dbforpostgresql_flexibleservers_connections_failed_total_count{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -300,63 +365,23 @@ groups:
           execErrState: Error
           for: 5m
           annotations:
-            description: Azure PostgreSQL Flexible Server has more than 10 failed connection attempts for over 5 minutes, indicating potential authentication or connectivity issues.
-            summary: Failed connections on Azure PostgreSQL server {{$labels.resource}} in cluster {{$labels.cluster}}
-          labels:
-            opsgenie: "1"
-          isPaused: false
-        - uid: azure_postgres_deadlocks
-          title: Azure PostgreSQL Deadlocks
-          condition: B
-          data:
-            - refId: A
-              relativeTimeRange:
-                from: 600
-                to: 0
-              datasourceUid: mimir
-              model:
-                editorMode: code
-                expr: azure_microsoft_dbforpostgresql_flexibleservers_deadlocks{job="integrations/azure"}
-                instant: true
-                intervalMs: 1000
-                legendFormat: __auto
-                maxDataPoints: 43200
-                range: false
-                refId: A
-            - refId: B
-              relativeTimeRange:
-                from: 600
-                to: 0
-              datasourceUid: __expr__
-              model:
-                conditions:
-                    - evaluator:
-                        params:
-                            - 0
-                        type: gt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                            - A
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                datasource:
-                    type: __expr__
-                    uid: __expr__
-                expression: A
-                intervalMs: 1000
-                maxDataPoints: 43200
-                refId: B
-                type: threshold
-          noDataState: NoData
-          execErrState: Error
-          for: 5m
-          annotations:
-            description: Azure PostgreSQL Flexible Server is experiencing deadlocks, indicating potential application-level locking issues that may require investigation.
-            summary: Deadlocks detected on Azure PostgreSQL server {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure PostgreSQL Failed Connections"
+            description: |
+              PostgreSQL Flexible Server has more than 10 failed connection attempts
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Failed Connections
+              Current:     > 10
+              Threshold:   10
+              Duration:    5 minutes
+              Impact:      Potential authentication or connectivity issues
+
           labels:
             opsgenie: "1"
           isPaused: false

--- a/python-pulumi/src/ptd/grafana_alerts/azure_storage.yaml
+++ b/python-pulumi/src/ptd/grafana_alerts/azure_storage.yaml
@@ -32,7 +32,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_storage_storageaccounts_availability{job="integrations/azure"}
+                expr: azure_microsoft_storage_storageaccounts_availability_average_percent{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -71,8 +71,22 @@ groups:
           execErrState: Error
           for: 5m
           annotations:
-            description: Azure Storage Account availability is below 99.9% for over 5 minutes, indicating potential service degradation or outages.
-            summary: Low availability on Azure Storage Account {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🔴 CRITICAL: Azure Storage Availability Low"
+            description: |
+              Storage account availability is below 99.9%
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      Availability
+              Current:     < 99.9%
+              Threshold:   99.9%
+              Duration:    5 minutes
+
           labels:
             opsgenie: "1"
           isPaused: false
@@ -87,7 +101,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_storage_storageaccounts_successe2elatency{job="integrations/azure"}
+                expr: azure_microsoft_storage_storageaccounts_successe2elatency_average_milliseconds{job="integrations/azure"}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -126,8 +140,22 @@ groups:
           execErrState: Error
           for: 10m
           annotations:
-            description: Azure Storage Account end-to-end latency is above 1000ms for more than 10 minutes, indicating performance degradation.
-            summary: High latency on Azure Storage Account {{$labels.resource}} in cluster {{$labels.cluster}}
+            summary: "🟡 WARNING: Azure Storage Latency High"
+            description: |
+              Storage account end-to-end latency is above 1000ms
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Resource:    {{ $labels.resource }}
+              Location:    {{ $labels.location }}
+
+              ─── DETAILS ─────────────────────────
+              Metric:      End-to-End Latency
+              Current:     > 1000ms (1 second)
+              Threshold:   1000ms
+              Duration:    10 minutes
+
           labels:
             opsgenie: "1"
           isPaused: false


### PR DESCRIPTION
# Description

Improves Azure Monitor Grafana alert definitions with better metrics and standardized alert formatting.


## Code Flow
  Updated several Azure alert files to use the right metrics:

  ### Azure Storage:
  - availability → availability_average_percent
  - successe2elatency → successe2elatency_average_milliseconds

  ### Azure NetApp Files:
  - volumeconsumedsizepercentage → volumeconsumedsizepercentage_average_percent
  - averagereadlatency → averagereadlatency_average_milliseconds
  - averagewritelatency → averagewritelatency_average_milliseconds

  ### Azure PostgreSQL:
  - cpu_percent → cpu_percent_average_percent
  - storage_percent → storage_percent_average_percent
  - memory_percent → memory_percent_average_percent
  - active_connections → active_connections_average_count
  - connections_failed → connections_failed_total_count
  - removed `azure_postgres_deadlocks` alert, invalid metric name for Azure Monitor

  ## Alert Description Standardization

  Reformatted all alert descriptions from single-line to structured multi-line format:
  - Added emoji severity indicators (🔴 CRITICAL, 🟡 WARNING)
  - Organized into consistent sections: WHERE (tenant, cluster, resource, location) and DETAILS (metric, thresholds, duration)
  - Improved readability for on-call responders

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
