### PR TITLE
fix: remove force_update_version from EKS Cluster args

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -128,6 +128,7 @@ class AWSEKSCluster(pulumi.ComponentResource):
         self.iam_permissions_boundary = iam_permissions_boundary
         self.tailscale_enabled = tailscale_enabled
         self.customer_managed_bastion_id = customer_managed_bastion_id
+        self.force_update_version = force_update_version
 
         # ──────────────────────────────────────────────────────────────────────
         # Method Ordering Dependencies (for with_*() methods):
@@ -240,10 +241,6 @@ class AWSEKSCluster(pulumi.ComponentResource):
             "version": version,
             "tags": {"Name": name} | tags,
         }
-
-        # ForceUpdateVersion overrides upgrade-blocking readiness checks (EKS Insights validations)
-        if force_update_version:
-            cluster_args["force_update_version"] = True
 
         # Configure cluster options based on whether it exists and its auth mode
         cluster_opts = pulumi.ResourceOptions(parent=self)


### PR DESCRIPTION
# Description

`force_update_version` is a valid parameter on `aws.eks.NodeGroup` but not `aws.eks.Cluster`. It was incorrectly being injected into `cluster_args` and unpacked into the `Cluster` constructor, causing a `TypeError: Cluster._internal_init() got an unexpected keyword argument 'force_update_version'` on any workload with `force_maintenance: true`.

The value is now stored on `self` for future use by node groups.

## Code Flow

Removed the conditional `cluster_args["force_update_version"] = True` block (lines 244-246) and instead store `self.force_update_version` as an instance attribute alongside the other constructor params.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about