### PR TITLE
ci: add helm chart verification to version update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,31 +49,6 @@ ptd/
 
 - [Team Operator](https://github.com/posit-dev/team-operator) - Kubernetes operator for Posit Team products
 
-## Automated Version Updates
-
-PTD automatically receives version updates from the [Team Operator](https://github.com/posit-dev/team-operator) repository when new releases are published.
-
-### How It Works
-
-1. Team Operator's release workflow triggers `.github/workflows/update-team-operator-version.yml`
-2. The workflow verifies the Helm chart exists at `oci://ghcr.io/posit-dev/charts/team-operator`
-3. Updates `DEFAULT_CHART_VERSION` in `python-pulumi/src/ptd/pulumi_resources/team_operator.py`
-4. Creates a PR for review
-
-### Manual Trigger
-
-You can also trigger the workflow manually:
-
-```bash
-gh workflow run update-team-operator-version.yml --field version=v1.16.2
-```
-
-Or via the Actions UI with the `workflow_dispatch` trigger.
-
-### Authentication
-
-The incoming dispatch is authenticated via a PAT stored in the Team Operator repository (`PTD_REPO_TOKEN` secret). See the [Team Operator README](https://github.com/posit-dev/team-operator#release-automation) for token management details.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.


### PR DESCRIPTION
# Description

  - Add Helm chart verification before updating version (fails fast if chart doesn't exist)                                                       
  - Remove unused repository_dispatch trigger (only workflow_dispatch is used)                                                                    
  - Simplify version extraction logic

## Category of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
