### PR TITLE
fix: solve intermittent no data result with netapp latency alerts

### DIFF
--- a/python-pulumi/src/ptd/grafana_alerts/azure_netapp.yaml
+++ b/python-pulumi/src/ptd/grafana_alerts/azure_netapp.yaml
@@ -106,7 +106,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}
+                expr: last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}[5m])
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -122,7 +122,7 @@ groups:
                 conditions:
                     - evaluator:
                         params:
-                            - 10  # 10ms threshold; Azure NetApp Files typically has sub-millisecond latency
+                            - 50 # 50ms threshold
                         type: gt
                       operator:
                         type: and
@@ -147,7 +147,7 @@ groups:
           annotations:
             summary: "🟡 WARNING: Azure NetApp Files Read Latency High"
             description: |
-              NetApp Files volume read latency is above 10ms
+              NetApp Files volume read latency is above 50ms
 
               ─── WHERE ───────────────────────────
               Tenant:      {{ $labels.tenant_name }}
@@ -157,8 +157,8 @@ groups:
 
               ─── DETAILS ─────────────────────────
               Metric:      Read Latency
-              Current:     > 10ms
-              Threshold:   10ms
+              Current:     > 50ms
+              Threshold:   50ms
               Duration:    10 minutes
               Baseline:    Sub-millisecond typical
 
@@ -176,7 +176,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagewritelatency_average_milliseconds{job="integrations/azure"}
+                expr: last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagewritelatency_average_milliseconds{job="integrations/azure"}[5m])
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -192,7 +192,7 @@ groups:
                 conditions:
                     - evaluator:
                         params:
-                            - 10  # 10ms threshold; Azure NetApp Files typically has sub-millisecond latency
+                            - 50 # 50ms threshold
                         type: gt
                       operator:
                         type: and
@@ -217,7 +217,7 @@ groups:
           annotations:
             summary: "🟡 WARNING: Azure NetApp Files Write Latency High"
             description: |
-              NetApp Files volume write latency is above 10ms
+              NetApp Files volume write latency is above 50ms
 
               ─── WHERE ───────────────────────────
               Tenant:      {{ $labels.tenant_name }}
@@ -227,8 +227,8 @@ groups:
 
               ─── DETAILS ─────────────────────────
               Metric:      Write Latency
-              Current:     > 10ms
-              Threshold:   10ms
+              Current:     > 50ms
+              Threshold:   50ms
               Duration:    10 minutes
               Baseline:    Sub-millisecond typical
 


### PR DESCRIPTION
# Description

Fixes intermittent "no data" issues in Azure NetApp Files latency alerts and adjusts alert thresholds based on current workloads.


## Code Flow
  **Problem:** The read and write latency alert queries were returning data inconsistently when queried with the same time range. The queries would work one minute, then fail the next, even when searching historical
  data over several hours.

  **Root Cause:** The PromQL queries used instant lookups without a lookback window:
  ```promql
  azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}
```

  Each evaluation timestamp searched for samples at that exact moment. If the Azure Monitor scrape was delayed or offset by seconds, the query returned no data.

  Fix: Added last_over_time(...[5m]) to both latency queries:

```
last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}[5m])
```

  This matches the pattern already used by the capacity alert and searches a 5-minute window for the most recent sample, making queries resilient to scrape timing variations.

  Threshold Adjustment: Increased latency alert thresholds from 10ms to 50ms to reduce false positives based on observed operational patterns.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
