### PR TITLE
feat: add automation for assigning aks rbac role

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -29,6 +29,7 @@ const (
 	AzKeyName                    = "posit-team-dedicated"
 	KeyVaultAdminRoleId          = "00482a5a-887f-4fb3-b363-3b7fe8e74483" // Key Vault Administrator built-in role
 	StorageBlobDataContribRoleId = "ba92f5b4-2d11-453d-a403-e96b0029c9fe" // Storage Blob Data Contributor built-in role
+	AksRbacClusterAdminRoleId    = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b" // Azure Kubernetes Service RBAC Cluster Admin built-in role
 
 	// Tags
 	POSIT_TEAM_ENVIRONMENT    = "posit.team/environment"

--- a/lib/steps/bootstrap.go
+++ b/lib/steps/bootstrap.go
@@ -227,6 +227,19 @@ func (s *BootstrapStep) runAzure(ctx context.Context, c types.Credentials, _ str
 		}
 	}
 
+	// Ensure AKS RBAC Cluster Admin role assignment exists for admin group
+	s.Log.Info("Ensuring AKS RBAC Cluster Admin role assignment exists", "adminGroupId", azureTarget.AdminGroupID())
+	aksRbacExists, err := azure.RoleAssignmentExists(ctx, azureCreds, azureTarget.SubscriptionID(), azureTarget.ResourceGroupName(), azureTarget.AdminGroupID(), consts.AksRbacClusterAdminRoleId)
+	if err != nil {
+		return err
+	}
+	if !aksRbacExists {
+		err = azure.CreateRoleAssignment(ctx, azureCreds, azureTarget.SubscriptionID(), azureTarget.ResourceGroupName(), azureTarget.AdminGroupID(), consts.AksRbacClusterAdminRoleId)
+		if err != nil {
+			return err
+		}
+	}
+
 	// create site secrets, certain site secret values are populated in later steps rather than here
 	for siteName := range s.DstTarget.Sites() {
 		s.Log.Info("Creating site secrets if they don't exist", "site", siteName)


### PR DESCRIPTION
# Description

Adds the AKS RBAC Cluster Admin role assignment to the resource group scope, for the ptd admin group specified in the ptd.yaml config. Follows existing role assignment patterns for Azure.

## Code Flow

<!--
Explain how the code works at a high level. Walk through the key paths, data flow, or control flow introduced or changed by this PR. If you discussed the implementation with an AI assistant, include the relevant architectural explanations here.

Delete this section if the change is trivial (typo fix, version bump, etc.).
-->

## Category of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
