### PR TITLE
docs: fix Get Started and ensure-flow based on integrator feedback

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -21,6 +21,8 @@ This guide walks you through setting up PTD to deploy Posit Team products on AWS
 - [AWS CLI](https://aws.amazon.com/cli/) v2
 - [AWS Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 - AWS credentials configured (via `aws configure` or environment variables)
+- **Route 53 hosted zone** for your deployment domain (e.g., `example.posit.team`). PTD uses ExternalDNS to manage DNS records automatically, and it requires an existing hosted zone in the target AWS account. Create one in the [Route 53 console](https://console.aws.amazon.com/route53/) before running `ptd ensure`.
+- **`admin.posit.team` IAM role** deployed to each AWS account PTD will manage. See [`ptd admin generate-role`](cli/PTD_CLI_REFERENCE.md#ptd-admin-generate-role) and [IAM Permissions](cli/PTD_CLI_REFERENCE.md#iam-permissions-for-adminpositteam) for details.
 
 **For Azure:**
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
@@ -49,7 +51,7 @@ This installs:
 ### 3. Build the CLI
 
 ```bash
-just build-cmd
+just cli
 ```
 
 The CLI binary is created at `.local/bin/ptd`.
@@ -130,6 +132,8 @@ ptd ensure my-control-room
 # Then deploy the workload
 ptd ensure my-workload
 ```
+
+> **Note:** For workloads, the first step (`bootstrap`) creates the Pulumi state backend (S3 bucket and KMS key on AWS, storage account on Azure) and initializes secrets. If you use `--start-at-step` or `--only-steps` to skip bootstrap on a fresh deployment, subsequent steps will fail because the state backend does not exist. Use `-v` (verbose) to see the expected resource names if you encounter state backend errors. See [Ensure Command Flow](cli/ensure-flow.md) for details on each step.
 
 ## Architecture Overview
 

--- a/docs/cli/PTD_CLI_REFERENCE.md
+++ b/docs/cli/PTD_CLI_REFERENCE.md
@@ -267,26 +267,23 @@ Common workload steps (in order):
     - Updates workload secrets and control room mimir passwords
 
 Common control room steps (in order):
-1. `bootstrap` - Initial infrastructure setup
-   - Creates Pulumi state storage (S3 bucket or Azure blob storage)
-   - Creates encryption keys (KMS for AWS, Key Vault for Azure)
-   - Creates admin policy resources (if enabled)
-   - Initializes vault secrets for control room
-2. `workspaces` - Workspace configuration
+1. `workspaces` - Workspace configuration
    - Creates workspaces infrastructure for control room
    - Configures workspace resources via Pulumi
-3. `persistent` - Persistent resources (storage, databases)
+2. `persistent` - Persistent resources (storage, databases)
    - Creates RDS/Azure Database instances
    - Creates file systems and storage resources
    - Outputs: Database URLs and connection information
-4. `postgres_config` - PostgreSQL database configuration
+3. `postgres_config` - PostgreSQL database configuration
    - Configures PostgreSQL databases and users for control room
    - Requires: Database endpoints from persistent step
    - Requires: Proxy connection (if Tailscale not enabled)
-5. `cluster` - Cluster setup
+4. `cluster` - Cluster setup
    - Creates and configures control room Kubernetes cluster
    - Deploys cluster infrastructure and Helm charts
    - Requires: Proxy connection
+
+> **Note:** Control rooms do not have a `bootstrap` step. The `bootstrap` step only applies to workloads.
 
 **Examples:**
 
@@ -619,6 +616,50 @@ aws cloudformation create-stack \
 
 ---
 
+### IAM Permissions for `admin.posit.team`
+
+The `admin.posit.team` IAM role is used by PTD to manage infrastructure in each AWS account. This role must exist in every AWS account that PTD manages (both control room and workload accounts). The role name is hardcoded — PTD always assumes `admin.posit.team` unless a `custom_role` is configured in the workload's `ptd.yaml`.
+
+**Setup steps:**
+
+1. Generate the CloudFormation template:
+   ```bash
+   ptd admin generate-role <control-room-target> > template.yaml
+   ```
+2. **Review the generated template.** The exact permissions are defined in code (`lib/aws/iam.go`) and may change between PTD versions. Always inspect the template before deploying.
+3. Deploy to each AWS account that PTD will manage (control room and workload accounts):
+   ```bash
+   aws cloudformation create-stack \
+     --stack-name ptd-admin-role \
+     --template-body file://template.yaml \
+     --capabilities CAPABILITY_NAMED_IAM \
+     --parameters ParameterKey=TrustedPrincipals,ParameterValue="<principal-arns>"
+   ```
+4. Add the deploying principals to `trusted_principals` in the control room's `ptd.yaml`.
+
+**What the template creates:**
+
+- **`PositTeamDedicatedAdminPolicy`** — a managed policy granting permissions across AWS services used by PTD (EC2, EKS, S3, RDS, Route 53, IAM, KMS, Secrets Manager, ACM, SSM, ECR, and others). The policy is self-constraining:
+  - IAM operations are scoped to resources matching `*.posit.team` naming patterns
+  - S3 operations are scoped to buckets prefixed with `posit-*` or `ptd-*`
+  - The role cannot modify the `PositTeamDedicatedAdminPolicy` itself (prevents privilege escalation)
+  - All IAM roles PTD creates during deployment must use this policy as a permissions boundary
+- **`admin.posit.team`** — an IAM role with the above policy attached and set as its permissions boundary. The trust policy allows assumption by the principals specified in the `TrustedPrincipals` parameter.
+
+**Custom roles:**
+
+If your organization cannot use the standard `admin.posit.team` role, you can configure an alternative via `custom_role` in the workload's `ptd.yaml`:
+
+```yaml
+custom_role:
+  role_arn: "arn:aws:iam::123456789012:role/my-custom-role"
+  external_id: "optional-external-id"
+```
+
+The custom role must have equivalent permissions to `PositTeamDedicatedAdminPolicy`. Generate the template and use it as a reference when building your custom policy.
+
+---
+
 ## Target Auto-Completion
 
 Many commands support auto-completion for `<target>` arguments. This is powered by the `ValidTargetArgs` function which reads available targets from `ptd.yaml` files.
@@ -704,7 +745,7 @@ Azure: Uses Azure Bastion proxy connection (`az network bastion tunnel`)
 ### Building
 
 ```bash
-just build-cmd
+just cli
 ```
 
 ### Testing

--- a/docs/cli/ensure-flow.md
+++ b/docs/cli/ensure-flow.md
@@ -110,6 +110,10 @@ Workloads host the Posit Team products (Connect, Workbench, Package Manager) for
 - Create storage account and blob container
 - Initialize site secrets in Key Vault (one secret per field)
 
+> **Important:** The bootstrap step **must** complete successfully before subsequent steps can run. Later steps (starting with `persistent`) use the Pulumi state backend created by bootstrap (S3 bucket on AWS, storage account on Azure). If you skip bootstrap or it fails, subsequent steps will error because the state backend does not exist.
+>
+> If you encounter an error stating that the S3 bucket or storage account is unavailable, run `ptd ensure <target> --only-steps bootstrap` first, or re-run `ptd ensure <target>` without `--start-at-step` to ensure bootstrap runs. Use the `-v` (verbose) flag to surface the expected bucket or storage account name in the error output.
+
 ### 2. persistent
 
 **Purpose**: Create persistent infrastructure resources


### PR DESCRIPTION
# Description

Fixes five documentation issues reported by an integrator testing PTD on AWS EKS.

## Code Flow

N/A — documentation-only changes.

## Category of change

- [x] Documentation: documentation changes

## Changes

- **Fix build command**: `just build-cmd` → `just cli` in GETTING_STARTED.md and PTD_CLI_REFERENCE.md Development section
- **Reconcile control room step count**: Removed incorrect `bootstrap` step from control room steps in PTD_CLI_REFERENCE.md (code only registers bootstrap for workloads, not control rooms)
- **Clarify bootstrap requirement**: Added warning in ensure-flow.md that bootstrap must complete before later steps run (creates S3 bucket / storage account for Pulumi state), and that `-v` surfaces expected resource names on failure
- **Document IAM permissions**: Added section in PTD_CLI_REFERENCE.md explaining `admin.posit.team` role setup via `ptd admin generate-role`, self-constraining policy guardrails, and `custom_role` escape hatch
- **Add AWS prerequisites**: Added Route 53 hosted zone and `admin.posit.team` IAM role as explicit prerequisites in the Get Started guide

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about