### PR TITLE
feat: write raw Pulumi stack exports to eject bundle

### DIFF
--- a/lib/eject/stack_export.go
+++ b/lib/eject/stack_export.go
@@ -1,0 +1,37 @@
+package eject
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriteStackExport writes raw Pulumi state bytes to the exports directory.
+// stateKey is the S3/Blob path like ".pulumi/stacks/ptd-aws-workload-persistent/prod.json"
+// and is used to derive the output filename.
+func WriteStackExport(outputDir string, stateKey string, data []byte) error {
+	exportDir := filepath.Join(outputDir, "state", "pulumi-exports")
+	if err := os.MkdirAll(exportDir, 0755); err != nil {
+		return fmt.Errorf("failed to create pulumi-exports directory: %w", err)
+	}
+
+	filename := ExportFileName(stateKey)
+	path := filepath.Join(exportDir, filename)
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write stack export %s: %w", filename, err)
+	}
+
+	return nil
+}
+
+// ExportFileName derives "project-name.json" from a state key path.
+// e.g. ".pulumi/stacks/ptd-aws-workload-persistent/prod.json" → "ptd-aws-workload-persistent.json"
+func ExportFileName(stateKey string) string {
+	parts := strings.Split(stateKey, "/")
+	if len(parts) >= 4 {
+		return parts[2] + ".json"
+	}
+	return filepath.Base(stateKey)
+}

--- a/lib/eject/stack_export_test.go
+++ b/lib/eject/stack_export_test.go
@@ -1,0 +1,72 @@
+package eject
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteStackExport(t *testing.T) {
+	outputDir := t.TempDir()
+	stateKey := ".pulumi/stacks/ptd-aws-workload-persistent/prod.json"
+	data := []byte(`{"version":3,"checkpoint":{}}`)
+
+	err := WriteStackExport(outputDir, stateKey, data)
+
+	require.NoError(t, err)
+
+	exportPath := filepath.Join(outputDir, "state", "pulumi-exports", "ptd-aws-workload-persistent.json")
+	assert.FileExists(t, exportPath)
+
+	written, err := os.ReadFile(exportPath)
+	require.NoError(t, err)
+	assert.Equal(t, data, written)
+}
+
+func TestWriteStackExport_MultipleStacks(t *testing.T) {
+	outputDir := t.TempDir()
+	stacks := map[string][]byte{
+		".pulumi/stacks/ptd-aws-workload-persistent/prod.json": []byte(`{"step":"persistent"}`),
+		".pulumi/stacks/ptd-aws-workload-eks/prod.json":        []byte(`{"step":"eks"}`),
+		".pulumi/stacks/ptd-aws-workload-helm/prod.json":       []byte(`{"step":"helm"}`),
+	}
+
+	for key, data := range stacks {
+		require.NoError(t, WriteStackExport(outputDir, key, data))
+	}
+
+	exportDir := filepath.Join(outputDir, "state", "pulumi-exports")
+	entries, err := os.ReadDir(exportDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+}
+
+func TestWriteStackExport_CreatesDirectoryStructure(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "nested", "output")
+
+	err := WriteStackExport(outputDir, ".pulumi/stacks/proj/stack.json", []byte("{}"))
+
+	require.NoError(t, err)
+	assert.DirExists(t, filepath.Join(outputDir, "state", "pulumi-exports"))
+}
+
+func TestExportFileName(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{".pulumi/stacks/ptd-aws-workload-persistent/prod.json", "ptd-aws-workload-persistent.json"},
+		{".pulumi/stacks/ptd-aws-workload-eks/staging.json", "ptd-aws-workload-eks.json"},
+		{".pulumi/stacks/ptd-azure-workload-aks/prod.json", "ptd-azure-workload-aks.json"},
+		{"short.json", "short.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.want, ExportFileName(tt.key))
+		})
+	}
+}


### PR DESCRIPTION
# Description

Add the ability to write raw Pulumi state JSON files to the eject artifact bundle at `state/pulumi-exports/<project-name>.json`. These serve as authoritative backups customers can use to continue managing infrastructure with Pulumi directly.

## Issue

Closes #213 (parent: #207, epic: #206)

## Code Flow

1. `WriteStackExport(outputDir, stateKey, data)` creates the `state/pulumi-exports/` directory and writes raw state bytes
2. `ExportFileName(stateKey)` derives the output filename from the S3/Blob state key path (e.g. `.pulumi/stacks/ptd-aws-workload-persistent/prod.json` → `ptd-aws-workload-persistent.json`)
3. The bundle assembly task (#219) will call `WriteStackExport` for each state file fetched from S3/Azure Blob — the fetching infrastructure already exists in `lib/aws` and `lib/azure`

## Category of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about