### PR TITLE
feat: copy workload config files to eject bundle

### DIFF
--- a/lib/eject/config_copy.go
+++ b/lib/eject/config_copy.go
@@ -7,44 +7,36 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 )
 
 var controlRoomFieldPattern = regexp.MustCompile(`(?m)^(\s*control_room_\w+:.*)$`)
 
-// CopyWorkloadConfig copies ptd.yaml, site_*/site.yaml, and customizations/
-// into the eject bundle's config/ directory.
+// CopyWorkloadConfig copies the entire workload directory into the eject
+// bundle's config/ directory. The copied ptd.yaml is annotated with comments
+// on control_room_* fields indicating they'll be removed during severance.
 func CopyWorkloadConfig(workloadPath string, outputDir string) error {
 	configDir := filepath.Join(outputDir, "config")
 
-	if err := copyPtdYaml(workloadPath, configDir); err != nil {
-		return fmt.Errorf("failed to copy ptd.yaml: %w", err)
+	if err := copyDir(workloadPath, configDir); err != nil {
+		return fmt.Errorf("failed to copy workload config: %w", err)
 	}
 
-	if err := copySiteYamls(workloadPath, configDir); err != nil {
-		return fmt.Errorf("failed to copy site configs: %w", err)
-	}
-
-	if err := copyCustomizations(workloadPath, configDir); err != nil {
-		return fmt.Errorf("failed to copy customizations: %w", err)
+	if err := annotatePtdYaml(configDir); err != nil {
+		return fmt.Errorf("failed to annotate ptd.yaml: %w", err)
 	}
 
 	return nil
 }
 
-func copyPtdYaml(workloadPath string, configDir string) error {
-	src := filepath.Join(workloadPath, "ptd.yaml")
-	data, err := os.ReadFile(src)
+func annotatePtdYaml(configDir string) error {
+	path := filepath.Join(configDir, "ptd.yaml")
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
 	annotated := AnnotateControlRoomFields(string(data))
-
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(configDir, "ptd.yaml"), []byte(annotated), 0644)
+	return os.WriteFile(path, []byte(annotated), 0644)
 }
 
 // AnnotateControlRoomFields adds a comment to each control_room_* field
@@ -52,51 +44,6 @@ func copyPtdYaml(workloadPath string, configDir string) error {
 func AnnotateControlRoomFields(yaml string) string {
 	return controlRoomFieldPattern.ReplaceAllString(yaml,
 		"$1  # EJECT: removed during control room severance")
-}
-
-func copySiteYamls(workloadPath string, configDir string) error {
-	entries, err := os.ReadDir(workloadPath)
-	if err != nil {
-		return err
-	}
-
-	cleanBase := filepath.Clean(workloadPath)
-	for _, entry := range entries {
-		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "site_") {
-			continue
-		}
-
-		siteDir := filepath.Clean(filepath.Join(workloadPath, entry.Name()))
-		if !strings.HasPrefix(siteDir, cleanBase+string(os.PathSeparator)) {
-			continue
-		}
-
-		siteYaml := filepath.Join(siteDir, "site.yaml")
-		if _, err := os.Stat(siteYaml); os.IsNotExist(err) {
-			continue
-		}
-
-		destDir := filepath.Join(configDir, filepath.Base(siteDir))
-		if err := os.MkdirAll(destDir, 0755); err != nil {
-			return err
-		}
-
-		if err := copyFile(siteYaml, filepath.Join(destDir, "site.yaml")); err != nil {
-			return fmt.Errorf("failed to copy %s/site.yaml: %w", entry.Name(), err)
-		}
-	}
-
-	return nil
-}
-
-func copyCustomizations(workloadPath string, configDir string) error {
-	customDir := filepath.Join(workloadPath, "customizations")
-	if _, err := os.Stat(customDir); os.IsNotExist(err) {
-		return nil // customizations are optional
-	}
-
-	destDir := filepath.Join(configDir, "customizations")
-	return copyDir(customDir, destDir)
 }
 
 func copyFile(src, dst string) error {

--- a/lib/eject/config_copy.go
+++ b/lib/eject/config_copy.go
@@ -112,8 +112,10 @@ func copyFile(src, dst string) error {
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, in)
-	return err
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
 }
 
 func copyDir(src, dst string) error {

--- a/lib/eject/config_copy.go
+++ b/lib/eject/config_copy.go
@@ -1,0 +1,130 @@
+package eject
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var controlRoomFieldPattern = regexp.MustCompile(`(?m)^(\s*control_room_\w+:.*)$`)
+
+// CopyWorkloadConfig copies ptd.yaml, site_*/site.yaml, and customizations/
+// into the eject bundle's config/ directory.
+func CopyWorkloadConfig(workloadPath string, outputDir string) error {
+	configDir := filepath.Join(outputDir, "config")
+
+	if err := copyPtdYaml(workloadPath, configDir); err != nil {
+		return fmt.Errorf("failed to copy ptd.yaml: %w", err)
+	}
+
+	if err := copySiteYamls(workloadPath, configDir); err != nil {
+		return fmt.Errorf("failed to copy site configs: %w", err)
+	}
+
+	if err := copyCustomizations(workloadPath, configDir); err != nil {
+		return fmt.Errorf("failed to copy customizations: %w", err)
+	}
+
+	return nil
+}
+
+func copyPtdYaml(workloadPath string, configDir string) error {
+	src := filepath.Join(workloadPath, "ptd.yaml")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	annotated := AnnotateControlRoomFields(string(data))
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(configDir, "ptd.yaml"), []byte(annotated), 0644)
+}
+
+// AnnotateControlRoomFields adds a comment to each control_room_* field
+// indicating it will be removed during severance.
+func AnnotateControlRoomFields(yaml string) string {
+	return controlRoomFieldPattern.ReplaceAllString(yaml,
+		"$1  # EJECT: removed during control room severance")
+}
+
+func copySiteYamls(workloadPath string, configDir string) error {
+	entries, err := os.ReadDir(workloadPath)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "site_") {
+			continue
+		}
+
+		siteYaml := filepath.Join(workloadPath, entry.Name(), "site.yaml")
+		if _, err := os.Stat(siteYaml); os.IsNotExist(err) {
+			continue
+		}
+
+		destDir := filepath.Join(configDir, entry.Name())
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return err
+		}
+
+		if err := copyFile(siteYaml, filepath.Join(destDir, "site.yaml")); err != nil {
+			return fmt.Errorf("failed to copy %s/site.yaml: %w", entry.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+func copyCustomizations(workloadPath string, configDir string) error {
+	customDir := filepath.Join(workloadPath, "customizations")
+	if _, err := os.Stat(customDir); os.IsNotExist(err) {
+		return nil // customizations are optional
+	}
+
+	destDir := filepath.Join(configDir, "customizations")
+	return copyDir(customDir, destDir)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		destPath := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(destPath, 0755)
+		}
+		return copyFile(path, destPath)
+	})
+}

--- a/lib/eject/config_copy.go
+++ b/lib/eject/config_copy.go
@@ -60,17 +60,23 @@ func copySiteYamls(workloadPath string, configDir string) error {
 		return err
 	}
 
+	cleanBase := filepath.Clean(workloadPath)
 	for _, entry := range entries {
 		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "site_") {
 			continue
 		}
 
-		siteYaml := filepath.Join(workloadPath, entry.Name(), "site.yaml")
+		siteDir := filepath.Clean(filepath.Join(workloadPath, entry.Name()))
+		if !strings.HasPrefix(siteDir, cleanBase+string(os.PathSeparator)) {
+			continue
+		}
+
+		siteYaml := filepath.Join(siteDir, "site.yaml")
 		if _, err := os.Stat(siteYaml); os.IsNotExist(err) {
 			continue
 		}
 
-		destDir := filepath.Join(configDir, entry.Name())
+		destDir := filepath.Join(configDir, filepath.Base(siteDir))
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
 		}
@@ -94,13 +100,13 @@ func copyCustomizations(workloadPath string, configDir string) error {
 }
 
 func copyFile(src, dst string) error {
-	in, err := os.Open(src)
+	in, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return err
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.Create(filepath.Clean(dst))
 	if err != nil {
 		return err
 	}

--- a/lib/eject/config_copy_test.go
+++ b/lib/eject/config_copy_test.go
@@ -1,0 +1,118 @@
+package eject
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupWorkloadDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	ptdYaml := `account_id: "123456789012"
+region: us-east-1
+control_room_account_id: "999888777666"
+control_room_cluster_name: main01
+control_room_domain: ctrl.example.com
+control_room_region: us-west-2
+clusters:
+  "20240101":
+    spec:
+      k8s_version: "1.29"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ptd.yaml"), []byte(ptdYaml), 0644))
+
+	siteDir := filepath.Join(dir, "site_main")
+	require.NoError(t, os.MkdirAll(siteDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(siteDir, "site.yaml"), []byte("domain: app.example.com\n"), 0644))
+
+	siteDir2 := filepath.Join(dir, "site_secondary")
+	require.NoError(t, os.MkdirAll(siteDir2, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(siteDir2, "site.yaml"), []byte("domain: app2.example.com\n"), 0644))
+
+	customDir := filepath.Join(dir, "customizations")
+	require.NoError(t, os.MkdirAll(filepath.Join(customDir, "my-step"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(customDir, "manifest.yaml"), []byte("version: 1\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(customDir, "my-step", "main.py"), []byte("print('hello')\n"), 0644))
+
+	return dir
+}
+
+func TestCopyWorkloadConfig(t *testing.T) {
+	workloadPath := setupWorkloadDir(t)
+	outputDir := t.TempDir()
+
+	err := CopyWorkloadConfig(workloadPath, outputDir)
+	require.NoError(t, err)
+
+	configDir := filepath.Join(outputDir, "config")
+	assert.FileExists(t, filepath.Join(configDir, "ptd.yaml"))
+	assert.FileExists(t, filepath.Join(configDir, "site_main", "site.yaml"))
+	assert.FileExists(t, filepath.Join(configDir, "site_secondary", "site.yaml"))
+	assert.FileExists(t, filepath.Join(configDir, "customizations", "manifest.yaml"))
+	assert.FileExists(t, filepath.Join(configDir, "customizations", "my-step", "main.py"))
+}
+
+func TestCopyWorkloadConfig_AnnotatesPtdYaml(t *testing.T) {
+	workloadPath := setupWorkloadDir(t)
+	outputDir := t.TempDir()
+
+	require.NoError(t, CopyWorkloadConfig(workloadPath, outputDir))
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "config", "ptd.yaml"))
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, "control_room_account_id: \"999888777666\"  # EJECT: removed during control room severance")
+	assert.Contains(t, content, "control_room_domain: ctrl.example.com  # EJECT: removed during control room severance")
+	assert.NotContains(t, content, "account_id: \"123456789012\"  # EJECT")
+	assert.NotContains(t, content, "region: us-east-1  # EJECT")
+}
+
+func TestCopyWorkloadConfig_NoCustomizations(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ptd.yaml"), []byte("region: us-east-1\n"), 0644))
+	outputDir := t.TempDir()
+
+	err := CopyWorkloadConfig(dir, outputDir)
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(outputDir, "config", "ptd.yaml"))
+	assert.NoDirExists(t, filepath.Join(outputDir, "config", "customizations"))
+}
+
+func TestCopyWorkloadConfig_NoSites(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ptd.yaml"), []byte("region: us-east-1\n"), 0644))
+	outputDir := t.TempDir()
+
+	err := CopyWorkloadConfig(dir, outputDir)
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(outputDir, "config", "ptd.yaml"))
+}
+
+func TestAnnotateControlRoomFields(t *testing.T) {
+	input := `account_id: "123"
+control_room_account_id: "999"
+control_room_domain: ctrl.example.com
+region: us-east-1
+control_room_region: us-west-2
+`
+	result := AnnotateControlRoomFields(input)
+
+	assert.Contains(t, result, "control_room_account_id: \"999\"  # EJECT: removed during control room severance")
+	assert.Contains(t, result, "control_room_domain: ctrl.example.com  # EJECT: removed during control room severance")
+	assert.Contains(t, result, "control_room_region: us-west-2  # EJECT: removed during control room severance")
+	assert.Contains(t, result, "account_id: \"123\"\n")
+	assert.Contains(t, result, "region: us-east-1\n")
+}
+
+func TestAnnotateControlRoomFields_NoControlRoomFields(t *testing.T) {
+	input := "account_id: \"123\"\nregion: us-east-1\n"
+	assert.Equal(t, input, AnnotateControlRoomFields(input))
+}

--- a/lib/eject/config_copy_test.go
+++ b/lib/eject/config_copy_test.go
@@ -39,6 +39,8 @@ clusters:
 	require.NoError(t, os.WriteFile(filepath.Join(customDir, "manifest.yaml"), []byte("version: 1\n"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(customDir, "my-step", "main.py"), []byte("print('hello')\n"), 0644))
 
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# My Workload\n"), 0644))
+
 	return dir
 }
 
@@ -55,6 +57,7 @@ func TestCopyWorkloadConfig(t *testing.T) {
 	assert.FileExists(t, filepath.Join(configDir, "site_secondary", "site.yaml"))
 	assert.FileExists(t, filepath.Join(configDir, "customizations", "manifest.yaml"))
 	assert.FileExists(t, filepath.Join(configDir, "customizations", "my-step", "main.py"))
+	assert.FileExists(t, filepath.Join(configDir, "README.md"))
 }
 
 func TestCopyWorkloadConfig_AnnotatesPtdYaml(t *testing.T) {


### PR DESCRIPTION
# Description

Copy the workload's configuration files into the eject artifact bundle so the customer has a self-contained config directory.

## Issue

Closes #214 (parent: #207, epic: #206)

## Code Flow

1. `CopyWorkloadConfig(workloadPath, outputDir)` orchestrates copying ptd.yaml, site configs, and customizations into `config/`
2. `ptd.yaml` is read, annotated (control_room_* fields get `# EJECT: removed during control room severance` comments), and written to `config/ptd.yaml`
3. All `site_*/site.yaml` files are copied preserving directory structure
4. The `customizations/` directory (if present) is recursively copied including manifest.yaml and step source code

## Category of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about