### PR TITLE
Fix Azure proxy creating spurious "None/" directory

### DIFF
--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -145,7 +145,13 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		"-i", p.sshKeyPath)
 
 	// set the environment variables for the command
-	// add each az env var to command
+	// HOME is required by the az CLI (Python) to locate ~/.azure config and cache directories.
+	// Without it, Python's os.environ.get("HOME") returns None, which gets stringified
+	// into a literal "None/" directory in the working directory.
+	if home, ok := os.LookupEnv("HOME"); ok {
+		p.tunnelCommand.Env = append(p.tunnelCommand.Env, "HOME="+home)
+		p.socksCommand.Env = append(p.socksCommand.Env, "HOME="+home)
+	}
 	for k, v := range azCreds.EnvVars() {
 		p.tunnelCommand.Env = append(p.tunnelCommand.Env, fmt.Sprintf("%s=%s", k, v))
 		p.socksCommand.Env = append(p.socksCommand.Env, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
# Description

Running `ptd workon` against an Azure target created a `None/` directory (containing `.cache/Microsoft/DeveloperTools/deviceid`) in the working directory.

The Azure proxy subprocess (`az network bastion tunnel`) was started with only Azure credential env vars — no `HOME`. In Go, once `Cmd.Env` is non-nil it replaces the entire inherited environment. The `az` CLI is Python-based, so `os.environ.get("HOME")` returned Python's `None`, which the Azure SDK stringified into a literal `"None/"` cache directory path relative to the working directory.

The fix passes `HOME` from the parent process into the tunnel and socks proxy subprocess environments.

## Code Flow

In `lib/azure/proxy.go`, `ProxySession.Start()` builds subprocess environments by appending to a nil `Cmd.Env` slice. Once non-nil, Go uses it as the complete environment. The fix adds `HOME` before the credential vars so the `az` CLI can locate `~/.azure` config and cache directories.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about