### PR TITLE
feat: add Claude auto-review and PR assistant workflows

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,0 +1,57 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened]
+
+env:
+  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+
+jobs:
+  auto-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
+          role-session-name: gha-claude-code-action
+          aws-region: us-east-2
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@beta
+        if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
+        with:
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          use_bedrock: true
+          model: "us.anthropic.claude-opus-4-6-v1"
+          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          timeout_minutes: "60"
+          direct_prompt: |
+            Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
+
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+
+            Review priorities from guidelines:
+            - **Simplicity**: Code should be explicit, not clever. Functions do one thing. Names reveal intent.
+            - **Maintainability**: Follow existing patterns. New code should look like it belongs.
+            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
+
+            Use the area-specific checklists from the guidelines for Go CLI, Python/Pulumi, and infrastructure changes.
+
+            Provide constructive feedback with specific suggestions for improvement.
+            Don't be overly complimentary; focus on actionable insights and keep your comments concise.
+            Use inline comments to highlight specific areas of concern.
+
+            IMPORTANT: Do NOT post any additional comments after submitting the review. The GitHub review itself is sufficient and any additional summary comments will be redundant.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,74 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+env:
+  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+
+jobs:
+  claude-code-action:
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude')
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@claude')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Check actor has write permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERMISSION=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "::error::Actor ${{ github.actor }} has '$PERMISSION' permission, requires 'write' or 'admin'"
+            exit 1
+          fi
+          echo "Actor ${{ github.actor }} authorized with '$PERMISSION' permission"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
+          role-session-name: gha-claude-code-action
+          aws-region: us-east-2
+
+      - name: Run Claude Code Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          model: "us.anthropic.claude-opus-4-6-v1"
+          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          timeout_minutes: "60"
+          use_bedrock: true
+          branch_prefix: "claude-"
+          additional_permissions: "actions: read"
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          custom_instructions: |
+            You are a helpful AI assistant for code reviews and issue triage.
+            Respond to comments and issues that mention you with relevant code suggestions or triage actions.
+            If you cannot assist, politely inform the user. In your responses, don't be overly complimentary.
+            Stick to the facts and provide actionable advice.


### PR DESCRIPTION
## Summary

- Adds `claude-auto-review.yml` — automatic code review when a PR is opened, using Claude via Bedrock
- Adds `claude.yml` — interactive `@claude` assistant triggered by mentions in issues/PR comments

Both workflows mirror the patterns from `posit-dev/team-operator`, including:
- AWS Bedrock authentication via `PTD_AWS_ACCOUNT` secret
- Claude Opus 4.6 with Sonnet fallback
- Write-permission check for interactive mentions
- Non-blocking COMMENT reviews (not REQUEST_CHANGES)

## Prerequisites

- `PTD_AWS_ACCOUNT` secret (or variable) must be configured in this repo's GitHub settings
- The `claude-code` IAM role's trust policy must allow OIDC from `posit-dev/ptd`

## Test plan

- [x] Verify `PTD_AWS_ACCOUNT` is set in repo settings
- [x] Verify IAM trust policy includes this repo
- [ ] Open a test PR and confirm auto-review triggers
- [ ] Comment `@claude` on a PR and confirm the assistant responds