### PR TITLE
chore: bump default team-operator chart version and subsequent operator version

### DIFF
--- a/python-pulumi/src/ptd/pulumi_resources/team_operator.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_operator.py
@@ -8,7 +8,7 @@ import ptd
 import ptd.workload
 
 # Default Helm chart version (OCI charts require explicit version, no "latest")
-DEFAULT_CHART_VERSION = "v1.16.2"
+DEFAULT_CHART_VERSION = "v1.23.1"
 
 
 class TeamOperator(pulumi.ComponentResource):

--- a/python-pulumi/src/ptd/pulumi_resources/team_operator.py
+++ b/python-pulumi/src/ptd/pulumi_resources/team_operator.py
@@ -8,7 +8,7 @@ import ptd
 import ptd.workload
 
 # Default Helm chart version (OCI charts require explicit version, no "latest")
-DEFAULT_CHART_VERSION = "v1.23.1"
+DEFAULT_CHART_VERSION = "v1.23.0"
 
 
 class TeamOperator(pulumi.ComponentResource):


### PR DESCRIPTION
# Description

Upgrades the default team-operator helm chart version to 1.23.0. Unless specified otherwise in ptd.yaml configuration, the team-operator version will follow the chart version and will default to 1.23.0 as well.

## Code Flow

<!--
Explain how the code works at a high level. Walk through the key paths, data flow, or control flow introduced or changed by this PR. If you discussed the implementation with an AI assistant, include the relevant architectural explanations here.

Delete this section if the change is trivial (typo fix, version bump, etc.).
-->

## Category of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
