### PR TITLE
fix(sites): use exec plugin kubeconfig to eliminate token-rotation state diffs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -198,7 +198,7 @@ test-e2e URL="":
 cli:
   mkdir -p .local/bin
   goreleaser build --single-target --snapshot --clean -o .local/bin/ptd
-  @codesign --force --sign - .local/bin/ptd 2>/dev/null
+  {{ if os() == "macos" { "codesign --force --sign - .local/bin/ptd 2>/dev/null" } else { "true" } }}
 
 #############################################################################
 # Check targets

--- a/lib/kube/config.go
+++ b/lib/kube/config.go
@@ -50,7 +50,16 @@ type NamedUser struct {
 
 // User represents user configuration
 type User struct {
-	Token string `yaml:"token"`
+	Token string      `yaml:"token,omitempty"`
+	Exec  *ExecConfig `yaml:"exec,omitempty"`
+}
+
+// ExecConfig represents a client-go exec credential plugin
+type ExecConfig struct {
+	APIVersion      string   `yaml:"apiVersion"`
+	Command         string   `yaml:"command"`
+	Args            []string `yaml:"args,omitempty"`
+	InteractiveMode string   `yaml:"interactiveMode,omitempty"`
 }
 
 // BuildEKSKubeConfig builds a KubeConfig for an EKS cluster
@@ -82,6 +91,49 @@ func BuildEKSKubeConfig(endpoint, caCert, token, clusterName string) KubeConfig 
 				Name: clusterName,
 				User: User{
 					Token: token,
+				},
+			},
+		},
+	}
+}
+
+// BuildEKSKubeConfigWithExec builds a KubeConfig that uses the AWS CLI exec
+// credential plugin to obtain fresh tokens on every API call. The resulting
+// kubeconfig contains no embedded token, so it is stable across runs and
+// produces no Pulumi state diff on token rotation.
+func BuildEKSKubeConfigWithExec(endpoint, caCert, clusterName, region string) KubeConfig {
+	return KubeConfig{
+		APIVersion: "v1",
+		Kind:       "Config",
+		Clusters: []NamedCluster{
+			{
+				Name: clusterName,
+				Cluster: Cluster{
+					Server:                   endpoint,
+					CertificateAuthorityData: caCert,
+				},
+			},
+		},
+		Contexts: []NamedContext{
+			{
+				Name: clusterName,
+				Context: Context{
+					Cluster: clusterName,
+					User:    clusterName,
+				},
+			},
+		},
+		CurrentContext: clusterName,
+		Users: []NamedUser{
+			{
+				Name: clusterName,
+				User: User{
+					Exec: &ExecConfig{
+						APIVersion:      "client.authentication.k8s.io/v1beta1",
+						Command:         "aws",
+						Args:            []string{"--region", region, "eks", "get-token", "--cluster-name", clusterName},
+						InteractiveMode: "Never",
+					},
 				},
 			},
 		},

--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -116,7 +116,10 @@ func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials,
 		return fmt.Errorf("sites: failed to parse workload secret: %w", err)
 	}
 
-	// Build kubeconfig string per release.
+	// Build kubeconfig per release using the exec credential plugin so no token
+	// is embedded. The kubeconfig is stable across runs — no Pulumi state diff
+	// on token rotation. The AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN env vars
+	// set by prepareEnvVarsForPulumi are inherited by the aws subprocess.
 	kubeconfigsByRelease := make(map[string]string, len(cfg.Clusters))
 	for release := range cfg.Clusters {
 		clusterName := s.DstTarget.Name() + "-" + release
@@ -124,11 +127,7 @@ func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials,
 		if err != nil {
 			return fmt.Errorf("sites: failed to get cluster info for %s: %w", clusterName, err)
 		}
-		token, err := aws.GetEKSToken(ctx, awsCreds, s.DstTarget.Region(), clusterName)
-		if err != nil {
-			return fmt.Errorf("sites: failed to get EKS token for %s: %w", clusterName, err)
-		}
-		config := kube.BuildEKSKubeConfig(endpoint, caCert, token, clusterName)
+		config := kube.BuildEKSKubeConfigWithExec(endpoint, caCert, clusterName, s.DstTarget.Region())
 		if !cfg.TailscaleEnabled {
 			config.Clusters[0].Cluster.ProxyURL = "socks5://localhost:1080"
 		}
@@ -191,13 +190,9 @@ func awsSitesDeploy(ctx *pulumi.Context, _ types.Target, params awsSiteParams) e
 		kubeconfig := params.kubeconfigsByRelease[release]
 		providerName := params.compoundName + "-" + release + "-k8s"
 
-		// IgnoreChanges on kubeconfig prevents dirty diffs on every run caused by EKS
-		// token rotation — STS tokens expire after 15 minutes, so the token embedded
-		// in the kubeconfig will always differ from the one stored in Pulumi state.
-		// The provider is still initialized with a fresh token on each run.
 		provider, err := kubernetes.NewProvider(ctx, providerName, &kubernetes.ProviderArgs{
 			Kubeconfig: pulumi.String(kubeconfig),
-		}, pulumi.IgnoreChanges([]string{"kubeconfig"}))
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What

Replace the embedded STS bearer token in the sites step kubeconfig with an exec credential plugin (`aws eks get-token`). Two changes:

- `lib/kube/config.go`: add `ExecConfig` struct and `BuildEKSKubeConfigWithExec` function; make `User.Token` omitempty
- `lib/steps/sites.go`: switch to `BuildEKSKubeConfigWithExec`; remove `IgnoreChanges(["kubeconfig"])`

## Why

The old approach embedded a short-lived STS token directly in the kubeconfig. This caused two problems:

1. **Noisy Pulumi diffs** — the token in state expired every 15 minutes, so every `ptd ensure sites` preview showed the provider as changed. `IgnoreChanges` was added as a workaround.

2. **Apply failures** — `IgnoreChanges` caused Pulumi to initialize the Kubernetes provider from the *stored* (expired) token rather than the freshly-generated one. Any apply against the running cluster would 401.

With the exec plugin, the kubeconfig contains no token. `aws eks get-token` is called fresh on each Kubernetes API call, inheriting `AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN` set by `prepareEnvVarsForPulumi`. The kubeconfig is stable across runs — no state diff, no `IgnoreChanges` needed.

## Test plan

- [x] `ptd ensure demo01-staging --only-steps sites --dry-run` — 8 unchanged, clean diff (one-time migration from token→exec plugin already settled in state)
- [x] `ptd ensure demo01-staging --only-steps sites --auto-apply` — no changes, apply succeeded
- [x] `just test-lib` — all pass
- [x] `just build` — compiles cleanly