### PR TITLE
chore: bump default team-operator chart version to v1.23.0

### DIFF
--- a/lib/steps/clusters.go
+++ b/lib/steps/clusters.go
@@ -16,7 +16,7 @@ const (
 	// clustersTeamOperatorServiceAccount is the Helm chart default service account name.
 	clustersTeamOperatorServiceAccount = "team-operator-controller-manager"
 	// clustersDefaultTeamOperatorChartVersion is used when no chart version is configured.
-	clustersDefaultTeamOperatorChartVersion = "v1.16.2"
+	clustersDefaultTeamOperatorChartVersion = "v1.23.0"
 	// clustersTraefikForwardAuthSA matches the Python Roles.TRAEFIK_FORWARD_AUTH value.
 	clustersTraefikForwardAuthSA = "traefik-forward-auth.posit.team"
 


### PR DESCRIPTION
# Description

Bumps the default team-operator Helm chart version to v1.23.0 in the Go clusters step, matching the Python default set in posit-dev/ptd#234.

## Category of change

- [x] Version upgrade (upgrading the version of a service or product)