### PR TITLE
feat(eject): metadata, README, and config copy for bundle assembly

### DIFF
--- a/cmd/eject.go
+++ b/cmd/eject.go
@@ -79,9 +79,11 @@ func runEject(cmd *cobra.Command, targetName string) {
 	}
 
 	opts := eject.Options{
-		TargetName: targetName,
-		OutputDir:  outputDir,
-		DryRun:     ejectDryRun,
+		TargetName:   targetName,
+		OutputDir:    outputDir,
+		DryRun:       ejectDryRun,
+		CLIVersion:   Version,
+		WorkloadPath: legacy.WorkloadPathFromTargetName(targetName),
 	}
 
 	if err := eject.Run(ctx, t, opts); err != nil {

--- a/lib/eject/eject.go
+++ b/lib/eject/eject.go
@@ -40,6 +40,7 @@ func Run(ctx context.Context, t types.Target, opts Options) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
+	// TODO: serialize bundle to disk once all steps (inventory, secrets, state export) are wired
 	bundle := &Bundle{}
 
 	config, err := opts.configLoader()(t)
@@ -65,13 +66,17 @@ func Run(ctx context.Context, t types.Target, opts Options) error {
 		slog.Info("Copied workload config", "from", opts.WorkloadPath)
 	}
 
-	metadata := CollectMetadata(config, opts, time.Now())
+	metadata, err := CollectMetadata(config, opts, time.Now())
+	if err != nil {
+		return fmt.Errorf("failed to collect metadata: %w", err)
+	}
 	if err := WriteMetadata(metadata, opts.OutputDir); err != nil {
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}
 	slog.Info("Wrote metadata.json")
 
-	if err := WriteReadme(metadata, opts.OutputDir); err != nil {
+	hasConfig := opts.WorkloadPath != ""
+	if err := WriteReadme(metadata, hasConfig, opts.OutputDir); err != nil {
 		return fmt.Errorf("failed to write README: %w", err)
 	}
 	slog.Info("Wrote README.md")

--- a/lib/eject/eject.go
+++ b/lib/eject/eject.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/types"
@@ -16,6 +17,8 @@ type Options struct {
 	TargetName   string
 	OutputDir    string
 	DryRun       bool
+	CLIVersion   string
+	WorkloadPath string
 	ConfigLoader ConfigLoaderFunc // nil defaults to helpers.ConfigForTarget
 }
 
@@ -54,6 +57,24 @@ func Run(ctx context.Context, t types.Target, opts Options) error {
 		"domain", crDetails.Domain,
 		"connections", len(crDetails.Connections),
 	)
+
+	if opts.WorkloadPath != "" {
+		if err := CopyWorkloadConfig(opts.WorkloadPath, opts.OutputDir); err != nil {
+			return fmt.Errorf("failed to copy workload config: %w", err)
+		}
+		slog.Info("Copied workload config", "from", opts.WorkloadPath)
+	}
+
+	metadata := CollectMetadata(config, opts, time.Now())
+	if err := WriteMetadata(metadata, opts.OutputDir); err != nil {
+		return fmt.Errorf("failed to write metadata: %w", err)
+	}
+	slog.Info("Wrote metadata.json")
+
+	if err := WriteReadme(metadata, opts.OutputDir); err != nil {
+		return fmt.Errorf("failed to write README: %w", err)
+	}
+	slog.Info("Wrote README.md")
 
 	slog.Info("Eject bundle generated", "path", opts.OutputDir)
 	return nil

--- a/lib/eject/eject_test.go
+++ b/lib/eject/eject_test.go
@@ -83,6 +83,75 @@ func TestRun_CollectsControlRoomDetails(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRun_WritesMetadataJSON(t *testing.T) {
+	target := newWorkloadTarget("test-workload")
+	outputDir := filepath.Join(t.TempDir(), "eject-output")
+
+	config := types.AWSWorkloadConfig{
+		AccountID: "123456789012",
+		Region:    "us-east-2",
+	}
+
+	err := Run(context.Background(), target, Options{
+		TargetName:   "test-workload",
+		OutputDir:    outputDir,
+		DryRun:       true,
+		CLIVersion:   "1.2.3",
+		ConfigLoader: mockConfigLoader(config),
+	})
+
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(outputDir, "metadata.json"))
+}
+
+func TestRun_WritesReadme(t *testing.T) {
+	target := newWorkloadTarget("test-workload")
+	outputDir := filepath.Join(t.TempDir(), "eject-output")
+
+	err := Run(context.Background(), target, Options{
+		TargetName:   "test-workload",
+		OutputDir:    outputDir,
+		DryRun:       true,
+		ConfigLoader: mockConfigLoader(types.AWSWorkloadConfig{}),
+	})
+
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(outputDir, "README.md"))
+}
+
+func TestRun_CopiesWorkloadConfig(t *testing.T) {
+	workloadPath := setupWorkloadDir(t)
+	target := newWorkloadTarget("test-workload")
+	outputDir := filepath.Join(t.TempDir(), "eject-output")
+
+	err := Run(context.Background(), target, Options{
+		TargetName:   "test-workload",
+		OutputDir:    outputDir,
+		DryRun:       true,
+		WorkloadPath: workloadPath,
+		ConfigLoader: mockConfigLoader(types.AWSWorkloadConfig{}),
+	})
+
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(outputDir, "config", "ptd.yaml"))
+	assert.FileExists(t, filepath.Join(outputDir, "config", "site_main", "site.yaml"))
+}
+
+func TestRun_SkipsConfigCopyWhenNoWorkloadPath(t *testing.T) {
+	target := newWorkloadTarget("test-workload")
+	outputDir := filepath.Join(t.TempDir(), "eject-output")
+
+	err := Run(context.Background(), target, Options{
+		TargetName:   "test-workload",
+		OutputDir:    outputDir,
+		DryRun:       true,
+		ConfigLoader: mockConfigLoader(types.AWSWorkloadConfig{}),
+	})
+
+	require.NoError(t, err)
+	assert.NoDirExists(t, filepath.Join(outputDir, "config"))
+}
+
 func newWorkloadTarget(name string) *typestest.MockTarget {
 	mt := &typestest.MockTarget{}
 	mt.On("Name").Return(name)

--- a/lib/eject/metadata.go
+++ b/lib/eject/metadata.go
@@ -1,0 +1,52 @@
+package eject
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/posit-dev/ptd/lib/types"
+)
+
+type Metadata struct {
+	EjectTimestamp string `json:"eject_timestamp"`
+	CLIVersion     string `json:"cli_version"`
+	TargetName     string `json:"target_name"`
+	CloudProvider  string `json:"cloud_provider"`
+	Region         string `json:"region"`
+	AccountID      string `json:"account_id"`
+	DryRun         bool   `json:"dry_run"`
+}
+
+func CollectMetadata(config interface{}, opts Options, now time.Time) *Metadata {
+	m := &Metadata{
+		EjectTimestamp: now.UTC().Format(time.RFC3339),
+		CLIVersion:     opts.CLIVersion,
+		TargetName:     opts.TargetName,
+		DryRun:         opts.DryRun,
+	}
+
+	switch cfg := config.(type) {
+	case types.AWSWorkloadConfig:
+		m.CloudProvider = string(types.AWS)
+		m.Region = cfg.Region
+		m.AccountID = cfg.AccountID
+	case types.AzureWorkloadConfig:
+		m.CloudProvider = string(types.Azure)
+		m.Region = cfg.Region
+		m.AccountID = cfg.SubscriptionID
+	}
+
+	return m
+}
+
+func WriteMetadata(metadata *Metadata, outputDir string) error {
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(filepath.Join(outputDir, "metadata.json"), data, 0644)
+}

--- a/lib/eject/metadata.go
+++ b/lib/eject/metadata.go
@@ -20,7 +20,7 @@ type Metadata struct {
 	DryRun         bool   `json:"dry_run"`
 }
 
-func CollectMetadata(config interface{}, opts Options, now time.Time) *Metadata {
+func CollectMetadata(config interface{}, opts Options, now time.Time) (*Metadata, error) {
 	m := &Metadata{
 		EjectTimestamp: now.UTC().Format(time.RFC3339),
 		CLIVersion:     opts.CLIVersion,
@@ -37,9 +37,11 @@ func CollectMetadata(config interface{}, opts Options, now time.Time) *Metadata 
 		m.CloudProvider = string(types.Azure)
 		m.Region = cfg.Region
 		m.AccountID = cfg.SubscriptionID
+	default:
+		return nil, fmt.Errorf("unsupported config type for metadata: %T", config)
 	}
 
-	return m
+	return m, nil
 }
 
 func WriteMetadata(metadata *Metadata, outputDir string) error {

--- a/lib/eject/metadata_test.go
+++ b/lib/eject/metadata_test.go
@@ -1,0 +1,112 @@
+package eject
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/posit-dev/ptd/lib/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testTime = time.Date(2026, 4, 15, 14, 30, 0, 0, time.UTC)
+
+func TestCollectMetadata_AWSWorkload(t *testing.T) {
+	config := types.AWSWorkloadConfig{
+		AccountID: "123456789012",
+		Region:    "us-east-2",
+	}
+	opts := Options{
+		TargetName: "acme01-production",
+		DryRun:     true,
+		CLIVersion: "1.2.3",
+	}
+
+	m := CollectMetadata(config, opts, testTime)
+
+	assert.Equal(t, "2026-04-15T14:30:00Z", m.EjectTimestamp)
+	assert.Equal(t, "1.2.3", m.CLIVersion)
+	assert.Equal(t, "acme01-production", m.TargetName)
+	assert.Equal(t, "aws", m.CloudProvider)
+	assert.Equal(t, "us-east-2", m.Region)
+	assert.Equal(t, "123456789012", m.AccountID)
+	assert.True(t, m.DryRun)
+}
+
+func TestCollectMetadata_AzureWorkload(t *testing.T) {
+	config := types.AzureWorkloadConfig{
+		SubscriptionID: "sub-abc-123",
+		Region:         "eastus",
+	}
+	opts := Options{
+		TargetName: "contoso01-staging",
+		DryRun:     false,
+		CLIVersion: "2.0.0",
+	}
+
+	m := CollectMetadata(config, opts, testTime)
+
+	assert.Equal(t, "azure", m.CloudProvider)
+	assert.Equal(t, "eastus", m.Region)
+	assert.Equal(t, "sub-abc-123", m.AccountID)
+	assert.False(t, m.DryRun)
+}
+
+func TestCollectMetadata_TimestampIsUTC(t *testing.T) {
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	localTime := time.Date(2026, 4, 15, 10, 30, 0, 0, eastern)
+
+	m := CollectMetadata(types.AWSWorkloadConfig{}, Options{}, localTime)
+
+	assert.Equal(t, "2026-04-15T14:30:00Z", m.EjectTimestamp)
+}
+
+func TestWriteMetadata(t *testing.T) {
+	outputDir := t.TempDir()
+	metadata := &Metadata{
+		EjectTimestamp: "2026-04-15T14:30:00Z",
+		CLIVersion:     "1.2.3",
+		TargetName:     "test-workload",
+		CloudProvider:  "aws",
+		Region:         "us-east-2",
+		AccountID:      "123456789012",
+		DryRun:         true,
+	}
+
+	err := WriteMetadata(metadata, outputDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "metadata.json"))
+	require.NoError(t, err)
+
+	var parsed Metadata
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, *metadata, parsed)
+}
+
+func TestWriteMetadata_JSONFormat(t *testing.T) {
+	outputDir := t.TempDir()
+	metadata := &Metadata{
+		EjectTimestamp: "2026-04-15T14:30:00Z",
+		CLIVersion:     "1.0.0",
+		TargetName:     "test",
+		CloudProvider:  "aws",
+		Region:         "us-east-1",
+		AccountID:      "111222333444",
+		DryRun:         false,
+	}
+
+	require.NoError(t, WriteMetadata(metadata, outputDir))
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "metadata.json"))
+	require.NoError(t, err)
+
+	content := string(data)
+	assert.Contains(t, content, "\"dry_run\": false")
+	assert.Contains(t, content, "\"cloud_provider\": \"aws\"")
+	assert.True(t, content[len(content)-1] == '\n', "should end with newline")
+}

--- a/lib/eject/metadata_test.go
+++ b/lib/eject/metadata_test.go
@@ -25,7 +25,8 @@ func TestCollectMetadata_AWSWorkload(t *testing.T) {
 		CLIVersion: "1.2.3",
 	}
 
-	m := CollectMetadata(config, opts, testTime)
+	m, err := CollectMetadata(config, opts, testTime)
+	require.NoError(t, err)
 
 	assert.Equal(t, "2026-04-15T14:30:00Z", m.EjectTimestamp)
 	assert.Equal(t, "1.2.3", m.CLIVersion)
@@ -47,7 +48,8 @@ func TestCollectMetadata_AzureWorkload(t *testing.T) {
 		CLIVersion: "2.0.0",
 	}
 
-	m := CollectMetadata(config, opts, testTime)
+	m, err := CollectMetadata(config, opts, testTime)
+	require.NoError(t, err)
 
 	assert.Equal(t, "azure", m.CloudProvider)
 	assert.Equal(t, "eastus", m.Region)
@@ -60,7 +62,8 @@ func TestCollectMetadata_TimestampIsUTC(t *testing.T) {
 	require.NoError(t, err)
 	localTime := time.Date(2026, 4, 15, 10, 30, 0, 0, eastern)
 
-	m := CollectMetadata(types.AWSWorkloadConfig{}, Options{}, localTime)
+	m, err := CollectMetadata(types.AWSWorkloadConfig{}, Options{}, localTime)
+	require.NoError(t, err)
 
 	assert.Equal(t, "2026-04-15T14:30:00Z", m.EjectTimestamp)
 }

--- a/lib/eject/readme.go
+++ b/lib/eject/readme.go
@@ -1,0 +1,38 @@
+package eject
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func WriteReadme(metadata *Metadata, outputDir string) error {
+	content := generateReadme(metadata)
+	return os.WriteFile(filepath.Join(outputDir, "README.md"), []byte(content), 0644)
+}
+
+func generateReadme(m *Metadata) string {
+	dryRunNote := ""
+	if m.DryRun {
+		dryRunNote = `
+> **Dry-run mode**: This bundle was generated without modifying any infrastructure.
+> No control room connections were severed.
+`
+	}
+
+	return fmt.Sprintf(`# Eject Bundle: %s
+%s
+Generated on %s by PTD CLI %s.
+
+## Directory Layout
+
+| Path | Description |
+|------|-------------|
+| README.md | This file |
+| metadata.json | Machine-readable context about this eject run |
+| config/ | Workload configuration files |
+| config/ptd.yaml | Main workload configuration (control_room fields annotated for severance) |
+| config/site_*/site.yaml | Per-site product configuration |
+| config/customizations/ | Custom Pulumi steps (source + manifest) |
+`, m.TargetName, dryRunNote, m.EjectTimestamp, m.CLIVersion)
+}

--- a/lib/eject/readme.go
+++ b/lib/eject/readme.go
@@ -6,17 +6,26 @@ import (
 	"path/filepath"
 )
 
-func WriteReadme(metadata *Metadata, outputDir string) error {
-	content := generateReadme(metadata)
+func WriteReadme(metadata *Metadata, hasConfig bool, outputDir string) error {
+	content := generateReadme(metadata, hasConfig)
 	return os.WriteFile(filepath.Join(outputDir, "README.md"), []byte(content), 0644)
 }
 
-func generateReadme(m *Metadata) string {
+func generateReadme(m *Metadata, hasConfig bool) string {
 	dryRunNote := ""
 	if m.DryRun {
 		dryRunNote = `
 > **Dry-run mode**: This bundle was generated without modifying any infrastructure.
 > No control room connections were severed.
+`
+	}
+
+	configRows := ""
+	if hasConfig {
+		configRows = `| config/ | Workload configuration files |
+| config/ptd.yaml | Main workload configuration (control_room fields annotated for severance) |
+| config/site_*/site.yaml | Per-site product configuration |
+| config/customizations/ | Custom Pulumi steps (source + manifest) |
 `
 	}
 
@@ -30,9 +39,5 @@ Generated on %s by PTD CLI %s.
 |------|-------------|
 | README.md | This file |
 | metadata.json | Machine-readable context about this eject run |
-| config/ | Workload configuration files |
-| config/ptd.yaml | Main workload configuration (control_room fields annotated for severance) |
-| config/site_*/site.yaml | Per-site product configuration |
-| config/customizations/ | Custom Pulumi steps (source + manifest) |
-`, m.TargetName, dryRunNote, m.EjectTimestamp, m.CLIVersion)
+%s`, m.TargetName, dryRunNote, m.EjectTimestamp, m.CLIVersion, configRows)
 }

--- a/lib/eject/readme_test.go
+++ b/lib/eject/readme_test.go
@@ -21,7 +21,7 @@ func TestWriteReadme(t *testing.T) {
 		DryRun:         true,
 	}
 
-	err := WriteReadme(metadata, outputDir)
+	err := WriteReadme(metadata, true, outputDir)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
@@ -44,7 +44,7 @@ func TestGenerateReadme_ContainsDirectoryLayout(t *testing.T) {
 		DryRun:         false,
 	}
 
-	content := generateReadme(m)
+	content := generateReadme(m, true)
 
 	assert.Contains(t, content, "config/ptd.yaml")
 	assert.Contains(t, content, "config/site_*/site.yaml")
@@ -52,10 +52,23 @@ func TestGenerateReadme_ContainsDirectoryLayout(t *testing.T) {
 	assert.Contains(t, content, "metadata.json")
 }
 
+func TestGenerateReadme_NoConfigRows(t *testing.T) {
+	m := &Metadata{
+		TargetName:     "test-workload",
+		EjectTimestamp: "2026-04-15T14:30:00Z",
+		CLIVersion:     "1.0.0",
+	}
+
+	content := generateReadme(m, false)
+
+	assert.NotContains(t, content, "config/")
+	assert.Contains(t, content, "metadata.json")
+}
+
 func TestGenerateReadme_DryRunNote(t *testing.T) {
 	dryRun := &Metadata{DryRun: true}
 	notDryRun := &Metadata{DryRun: false}
 
-	assert.Contains(t, generateReadme(dryRun), "Dry-run mode")
-	assert.NotContains(t, generateReadme(notDryRun), "Dry-run mode")
+	assert.Contains(t, generateReadme(dryRun, false), "Dry-run mode")
+	assert.NotContains(t, generateReadme(notDryRun, false), "Dry-run mode")
 }

--- a/lib/eject/readme_test.go
+++ b/lib/eject/readme_test.go
@@ -1,0 +1,61 @@
+package eject
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReadme(t *testing.T) {
+	outputDir := t.TempDir()
+	metadata := &Metadata{
+		EjectTimestamp: "2026-04-15T14:30:00Z",
+		CLIVersion:     "1.2.3",
+		TargetName:     "acme01-production",
+		CloudProvider:  "aws",
+		Region:         "us-east-2",
+		AccountID:      "123456789012",
+		DryRun:         true,
+	}
+
+	err := WriteReadme(metadata, outputDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, "# Eject Bundle: acme01-production")
+	assert.Contains(t, content, "PTD CLI 1.2.3")
+	assert.Contains(t, content, "2026-04-15T14:30:00Z")
+}
+
+func TestGenerateReadme_ContainsDirectoryLayout(t *testing.T) {
+	m := &Metadata{
+		TargetName:     "test-workload",
+		EjectTimestamp: "2026-04-15T14:30:00Z",
+		CLIVersion:     "1.0.0",
+		CloudProvider:  "aws",
+		Region:         "us-east-1",
+		AccountID:      "111222333444",
+		DryRun:         false,
+	}
+
+	content := generateReadme(m)
+
+	assert.Contains(t, content, "config/ptd.yaml")
+	assert.Contains(t, content, "config/site_*/site.yaml")
+	assert.Contains(t, content, "config/customizations/")
+	assert.Contains(t, content, "metadata.json")
+}
+
+func TestGenerateReadme_DryRunNote(t *testing.T) {
+	dryRun := &Metadata{DryRun: true}
+	notDryRun := &Metadata{DryRun: false}
+
+	assert.Contains(t, generateReadme(dryRun), "Dry-run mode")
+	assert.NotContains(t, generateReadme(notDryRun), "Dry-run mode")
+}


### PR DESCRIPTION
## Summary

- Wire `CopyWorkloadConfig`, `WriteMetadata`, and `WriteReadme` into the eject `Run()` flow
- `ptd eject <target> --dry-run` now produces a bundle with:
  - `config/` — full copy of the workload infra directory (ptd.yaml with control_room fields annotated, site_*/site.yaml, customizations/)
  - `metadata.json` — eject timestamp, CLI version, target name, cloud provider, region, account ID, dry-run flag
  - `README.md` — directory layout overview
- Adds `CLIVersion` and `WorkloadPath` to eject `Options`, passed from `cmd/eject.go`

Closes #219

## Test plan

- [x] Unit tests for metadata collection (AWS + Azure configs, UTC normalization, JSON round-trip)
- [x] Unit tests for README generation (layout table, dry-run note toggle)
- [x] Integration tests in `eject_test.go` (metadata.json written, README.md written, config copied, config skipped when no workload path)
- [x] All existing eject tests continue to pass
- [x] `just test-cmd` and `just test-lib` pass