### PR TITLE
feat: tolerate nil control room target in ensure steps

### DIFF
--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -136,6 +136,9 @@ func runEnsure(ctx context.Context, target string) {
 			slog.Error("Could not load relevant ptd.yaml file", "error", err)
 			return
 		}
+		if controlRoomTarget == nil {
+			slog.Info("No control room configured for workload, skipping control room operations")
+		}
 	}
 
 	// set options on each step before checking if proxy is required

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -142,6 +142,7 @@ func runEnsure(ctx context.Context, target string) {
 	}
 
 	// set options on each step before checking if proxy is required
+	// controlRoomTarget may be nil for ejected workloads — steps must tolerate this
 	for _, step := range stepsToRun {
 		step.Set(t, controlRoomTarget, steps.StepOptions{
 			DryRun:            DryRun,

--- a/cmd/internal/legacy/ptd_config.go
+++ b/cmd/internal/legacy/ptd_config.go
@@ -164,26 +164,34 @@ func ControlRoomTargetFromName(target string) (t types.Target, err error) {
 	case types.AWSControlRoomConfig:
 		return nil, fmt.Errorf("cannot create control room target from control room config")
 	case types.AzureWorkloadConfig:
+		c := conf.(types.AzureWorkloadConfig)
+		if c.ControlRoomClusterName == "" {
+			return nil, nil
+		}
 		return aws.NewTarget(
-			conf.(types.AzureWorkloadConfig).ControlRoomClusterName,
-			conf.(types.AzureWorkloadConfig).ControlRoomAccountID,
+			c.ControlRoomClusterName,
+			c.ControlRoomAccountID,
 			"",  // profile is not relevant for control room targets
 			nil, // customRole is not relevant for control room targets
-			conf.(types.AzureWorkloadConfig).ControlRoomRegion,
+			c.ControlRoomRegion,
 			true,  // isControlRoom
 			false, // tailscaleEnabled isn't relevant for control room.
 			false, // createAdminPolicyAsResource is not relevant for control room targets
 			nil,
 			nil), nil
 	case types.AWSWorkloadConfig:
+		c := conf.(types.AWSWorkloadConfig)
+		if c.ControlRoomClusterName == "" {
+			return nil, nil
+		}
 		return aws.NewTarget(
-			conf.(types.AWSWorkloadConfig).ControlRoomClusterName,
-			conf.(types.AWSWorkloadConfig).ControlRoomAccountID,
+			c.ControlRoomClusterName,
+			c.ControlRoomAccountID,
 			"",  // profile is not used for control room targets
 			nil, // customRole is not used for control room targets
-			conf.(types.AWSWorkloadConfig).ControlRoomRegion,
+			c.ControlRoomRegion,
 			true, // isControlRoom
-			conf.(types.AWSWorkloadConfig).TailscaleEnabled,
+			c.TailscaleEnabled,
 			false, // createAdminPolicyAsResource is not relevant for control room targets
 			nil,
 			nil), nil

--- a/lib/steps/persistent.go
+++ b/lib/steps/persistent.go
@@ -131,7 +131,7 @@ func (s *PersistentStep) Run(ctx context.Context) error {
 	}
 
 	// if we're working on a workload, this password may have changed, update if so.
-	if !s.DstTarget.ControlRoom() {
+	if !s.DstTarget.ControlRoom() && s.SrcTarget != nil {
 		newMimirPassword, ok := result.Outputs["mimir_password"].Value.(string)
 		if !ok {
 			return fmt.Errorf("mimir_password not found in outputs")


### PR DESCRIPTION
## Summary
- `ControlRoomTargetFromName` returns `(nil, nil)` when `ControlRoomClusterName` is empty (both AWS and Azure)
- `persistent.go` skips Mimir password sync when `SrcTarget` is nil
- `ensure.go` logs when no control room is configured

Enables ejected workloads (with empty `control_room_*` fields) to run `ptd ensure` without panicking.

Closes #239