### PR TITLE
feat: add config strip and snapshot for eject severance

### DIFF
--- a/lib/eject/config.go
+++ b/lib/eject/config.go
@@ -9,16 +9,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ControlRoomSnapshot captures all control_room_* fields from ptd.yaml.
+// Fields are discovered dynamically so new control_room_* fields are
+// automatically included without code changes.
 type ControlRoomSnapshot struct {
-	AccountID   string `json:"account_id"`
-	ClusterName string `json:"cluster_name"`
-	Domain      string `json:"domain"`
-	Region      string `json:"region"`
+	Fields map[string]string `json:"fields"`
+}
+
+func (s *ControlRoomSnapshot) Get(key string) string {
+	return s.Fields[key]
 }
 
 type specEnvelope struct {
 	Spec yaml.Node `yaml:"spec"`
 }
+
+const controlRoomPrefix = "control_room_"
 
 func SnapshotControlRoomFields(ptdYamlPath string) (*ControlRoomSnapshot, error) {
 	data, err := os.ReadFile(ptdYamlPath)
@@ -36,21 +42,18 @@ func SnapshotControlRoomFields(ptdYamlPath string) (*ControlRoomSnapshot, error)
 		return nil, fmt.Errorf("failed to decode spec: %w", err)
 	}
 
-	getString := func(key string) string {
-		if v, ok := specMap[key]; ok {
-			return fmt.Sprintf("%v", v)
+	fields := make(map[string]string)
+	for k, v := range specMap {
+		if strings.HasPrefix(k, controlRoomPrefix) {
+			if s, ok := v.(string); ok {
+				fields[k] = s
+			} else {
+				fields[k] = fmt.Sprintf("%v", v)
+			}
 		}
-		return ""
 	}
 
-	snapshot := &ControlRoomSnapshot{
-		AccountID:   getString("control_room_account_id"),
-		ClusterName: getString("control_room_cluster_name"),
-		Domain:      getString("control_room_domain"),
-		Region:      getString("control_room_region"),
-	}
-
-	return snapshot, nil
+	return &ControlRoomSnapshot{Fields: fields}, nil
 }
 
 var controlRoomValuePattern = regexp.MustCompile(`(?m)^(\s*control_room_\w+:\s*)(.+)$`)

--- a/lib/eject/config.go
+++ b/lib/eject/config.go
@@ -1,0 +1,81 @@
+package eject
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ControlRoomSnapshot struct {
+	AccountID   string `json:"account_id"`
+	ClusterName string `json:"cluster_name"`
+	Domain      string `json:"domain"`
+	Region      string `json:"region"`
+}
+
+type specEnvelope struct {
+	Spec yaml.Node `yaml:"spec"`
+}
+
+func SnapshotControlRoomFields(ptdYamlPath string) (*ControlRoomSnapshot, error) {
+	data, err := os.ReadFile(ptdYamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ptd.yaml: %w", err)
+	}
+
+	var env specEnvelope
+	if err := yaml.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("failed to parse ptd.yaml: %w", err)
+	}
+
+	var specMap map[string]interface{}
+	if err := env.Spec.Decode(&specMap); err != nil {
+		return nil, fmt.Errorf("failed to decode spec: %w", err)
+	}
+
+	getString := func(key string) string {
+		if v, ok := specMap[key]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+		return ""
+	}
+
+	snapshot := &ControlRoomSnapshot{
+		AccountID:   getString("control_room_account_id"),
+		ClusterName: getString("control_room_cluster_name"),
+		Domain:      getString("control_room_domain"),
+		Region:      getString("control_room_region"),
+	}
+
+	return snapshot, nil
+}
+
+var controlRoomValuePattern = regexp.MustCompile(`(?m)^(\s*control_room_\w+:\s*)(.+)$`)
+
+func StripControlRoomFields(ptdYamlPath string) error {
+	data, err := os.ReadFile(ptdYamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to read ptd.yaml: %w", err)
+	}
+
+	stripped := controlRoomValuePattern.ReplaceAllStringFunc(string(data), func(match string) string {
+		parts := controlRoomValuePattern.FindStringSubmatch(match)
+		// parts[1] is the key+colon prefix, parts[2] is the value
+		value := strings.TrimSpace(parts[2])
+
+		// Preserve inline comments
+		if idx := strings.Index(value, " #"); idx >= 0 {
+			return parts[1] + `""` + value[idx:]
+		}
+		if idx := strings.Index(value, "\t#"); idx >= 0 {
+			return parts[1] + `""` + value[idx:]
+		}
+
+		return parts[1] + `""`
+	})
+
+	return os.WriteFile(ptdYamlPath, []byte(stripped), 0644)
+}

--- a/lib/eject/config_test.go
+++ b/lib/eject/config_test.go
@@ -1,0 +1,158 @@
+package eject
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const awsPtdYaml = `apiVersion: ptd.posit.co/v1
+kind: AWSWorkloadConfig
+spec:
+  account_id: "123456789012"
+  region: us-east-1
+  control_room_account_id: "999888777666"
+  control_room_cluster_name: ctrl-prod
+  control_room_domain: ctrl.posit.team
+  control_room_region: us-west-2
+  vpc_cidr: "10.0.0.0/16"
+  clusters:
+    "20240101":
+      spec:
+        k8s_version: "1.29"
+`
+
+const azurePtdYaml = `apiVersion: ptd.posit.co/v1
+kind: AzureWorkloadConfig
+spec:
+  subscription_id: "sub-1234"
+  region: eastus
+  control_room_account_id: "azure-ctrl-sub"
+  control_room_cluster_name: ctrl-aks
+  control_room_domain: ctrl.azure.posit.team
+  control_room_region: westus2
+  tenant_id: "tenant-5678"
+`
+
+func writePtdYaml(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ptd.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestSnapshotControlRoomFields_AWS(t *testing.T) {
+	path := writePtdYaml(t, awsPtdYaml)
+
+	snapshot, err := SnapshotControlRoomFields(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, "999888777666", snapshot.AccountID)
+	assert.Equal(t, "ctrl-prod", snapshot.ClusterName)
+	assert.Equal(t, "ctrl.posit.team", snapshot.Domain)
+	assert.Equal(t, "us-west-2", snapshot.Region)
+}
+
+func TestSnapshotControlRoomFields_Azure(t *testing.T) {
+	path := writePtdYaml(t, azurePtdYaml)
+
+	snapshot, err := SnapshotControlRoomFields(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, "azure-ctrl-sub", snapshot.AccountID)
+	assert.Equal(t, "ctrl-aks", snapshot.ClusterName)
+	assert.Equal(t, "ctrl.azure.posit.team", snapshot.Domain)
+	assert.Equal(t, "westus2", snapshot.Region)
+}
+
+func TestSnapshotControlRoomFields_MissingFile(t *testing.T) {
+	_, err := SnapshotControlRoomFields("/nonexistent/ptd.yaml")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read ptd.yaml")
+}
+
+func TestStripControlRoomFields_SetsValuesToEmpty(t *testing.T) {
+	path := writePtdYaml(t, awsPtdYaml)
+
+	err := StripControlRoomFields(path)
+
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, `control_room_account_id: ""`)
+	assert.Contains(t, content, `control_room_cluster_name: ""`)
+	assert.Contains(t, content, `control_room_domain: ""`)
+	assert.Contains(t, content, `control_room_region: ""`)
+}
+
+func TestStripControlRoomFields_PreservesOtherFields(t *testing.T) {
+	path := writePtdYaml(t, awsPtdYaml)
+
+	err := StripControlRoomFields(path)
+
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, `account_id: "123456789012"`)
+	assert.Contains(t, content, "region: us-east-1")
+	assert.Contains(t, content, `vpc_cidr: "10.0.0.0/16"`)
+	assert.Contains(t, content, "kind: AWSWorkloadConfig")
+	assert.Contains(t, content, "apiVersion: ptd.posit.co/v1")
+}
+
+func TestStripControlRoomFields_PreservesComments(t *testing.T) {
+	yaml := `apiVersion: ptd.posit.co/v1
+kind: AWSWorkloadConfig
+spec:
+  # This is an important comment
+  account_id: "123456789012"
+  control_room_domain: ctrl.posit.team  # EJECT: removed during control room severance
+  region: us-east-1
+`
+	path := writePtdYaml(t, yaml)
+
+	err := StripControlRoomFields(path)
+
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, "# This is an important comment")
+	assert.Contains(t, content, `control_room_domain: "" # EJECT: removed during control room severance`)
+}
+
+func TestStripControlRoomFields_RoundTrip(t *testing.T) {
+	path := writePtdYaml(t, awsPtdYaml)
+
+	snapshot, err := SnapshotControlRoomFields(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "999888777666", snapshot.AccountID)
+	assert.Equal(t, "ctrl-prod", snapshot.ClusterName)
+	assert.Equal(t, "ctrl.posit.team", snapshot.Domain)
+	assert.Equal(t, "us-west-2", snapshot.Region)
+
+	err = StripControlRoomFields(path)
+	require.NoError(t, err)
+
+	strippedSnapshot, err := SnapshotControlRoomFields(path)
+	require.NoError(t, err)
+
+	assert.Empty(t, strippedSnapshot.AccountID)
+	assert.Empty(t, strippedSnapshot.ClusterName)
+	assert.Empty(t, strippedSnapshot.Domain)
+	assert.Empty(t, strippedSnapshot.Region)
+}

--- a/lib/eject/config_test.go
+++ b/lib/eject/config_test.go
@@ -51,10 +51,11 @@ func TestSnapshotControlRoomFields_AWS(t *testing.T) {
 	snapshot, err := SnapshotControlRoomFields(path)
 
 	require.NoError(t, err)
-	assert.Equal(t, "999888777666", snapshot.AccountID)
-	assert.Equal(t, "ctrl-prod", snapshot.ClusterName)
-	assert.Equal(t, "ctrl.posit.team", snapshot.Domain)
-	assert.Equal(t, "us-west-2", snapshot.Region)
+	assert.Equal(t, "999888777666", snapshot.Get("control_room_account_id"))
+	assert.Equal(t, "ctrl-prod", snapshot.Get("control_room_cluster_name"))
+	assert.Equal(t, "ctrl.posit.team", snapshot.Get("control_room_domain"))
+	assert.Equal(t, "us-west-2", snapshot.Get("control_room_region"))
+	assert.Len(t, snapshot.Fields, 4)
 }
 
 func TestSnapshotControlRoomFields_Azure(t *testing.T) {
@@ -63,10 +64,42 @@ func TestSnapshotControlRoomFields_Azure(t *testing.T) {
 	snapshot, err := SnapshotControlRoomFields(path)
 
 	require.NoError(t, err)
-	assert.Equal(t, "azure-ctrl-sub", snapshot.AccountID)
-	assert.Equal(t, "ctrl-aks", snapshot.ClusterName)
-	assert.Equal(t, "ctrl.azure.posit.team", snapshot.Domain)
-	assert.Equal(t, "westus2", snapshot.Region)
+	assert.Equal(t, "azure-ctrl-sub", snapshot.Get("control_room_account_id"))
+	assert.Equal(t, "ctrl-aks", snapshot.Get("control_room_cluster_name"))
+	assert.Equal(t, "ctrl.azure.posit.team", snapshot.Get("control_room_domain"))
+	assert.Equal(t, "westus2", snapshot.Get("control_room_region"))
+}
+
+func TestSnapshotControlRoomFields_Dynamic(t *testing.T) {
+	yaml := `apiVersion: ptd.posit.co/v1
+kind: AWSWorkloadConfig
+spec:
+  account_id: "123"
+  control_room_account_id: "999"
+  control_room_domain: ctrl.posit.team
+  control_room_future_field: some-value
+`
+	path := writePtdYaml(t, yaml)
+
+	snapshot, err := SnapshotControlRoomFields(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, "some-value", snapshot.Get("control_room_future_field"))
+	assert.Len(t, snapshot.Fields, 3)
+}
+
+func TestSnapshotControlRoomFields_NumericAccountID(t *testing.T) {
+	yaml := `apiVersion: ptd.posit.co/v1
+kind: AWSWorkloadConfig
+spec:
+  control_room_account_id: 999888777666
+`
+	path := writePtdYaml(t, yaml)
+
+	snapshot, err := SnapshotControlRoomFields(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, "999888777666", snapshot.Get("control_room_account_id"))
 }
 
 func TestSnapshotControlRoomFields_MissingFile(t *testing.T) {
@@ -140,10 +173,10 @@ func TestStripControlRoomFields_RoundTrip(t *testing.T) {
 	snapshot, err := SnapshotControlRoomFields(path)
 	require.NoError(t, err)
 
-	assert.Equal(t, "999888777666", snapshot.AccountID)
-	assert.Equal(t, "ctrl-prod", snapshot.ClusterName)
-	assert.Equal(t, "ctrl.posit.team", snapshot.Domain)
-	assert.Equal(t, "us-west-2", snapshot.Region)
+	assert.Equal(t, "999888777666", snapshot.Get("control_room_account_id"))
+	assert.Equal(t, "ctrl-prod", snapshot.Get("control_room_cluster_name"))
+	assert.Equal(t, "ctrl.posit.team", snapshot.Get("control_room_domain"))
+	assert.Equal(t, "us-west-2", snapshot.Get("control_room_region"))
 
 	err = StripControlRoomFields(path)
 	require.NoError(t, err)
@@ -151,8 +184,35 @@ func TestStripControlRoomFields_RoundTrip(t *testing.T) {
 	strippedSnapshot, err := SnapshotControlRoomFields(path)
 	require.NoError(t, err)
 
-	assert.Empty(t, strippedSnapshot.AccountID)
-	assert.Empty(t, strippedSnapshot.ClusterName)
-	assert.Empty(t, strippedSnapshot.Domain)
-	assert.Empty(t, strippedSnapshot.Region)
+	for _, v := range strippedSnapshot.Fields {
+		assert.Empty(t, v)
+	}
+}
+
+func TestStripControlRoomFields_MissingFile(t *testing.T) {
+	err := StripControlRoomFields("/nonexistent/ptd.yaml")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read ptd.yaml")
+}
+
+func TestStripControlRoomFields_Idempotent(t *testing.T) {
+	yaml := `apiVersion: ptd.posit.co/v1
+kind: AWSWorkloadConfig
+spec:
+  control_room_domain: ""
+  control_room_account_id: ""
+`
+	path := writePtdYaml(t, yaml)
+
+	err := StripControlRoomFields(path)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, `control_room_domain: ""`)
+	assert.Contains(t, content, `control_room_account_id: ""`)
+	assert.NotContains(t, content, `""""`)
 }


### PR DESCRIPTION
## Summary
- `SnapshotControlRoomFields` extracts `control_room_*` values from ptd.yaml into a struct for re-adoption
- `StripControlRoomFields` replaces those values with empty strings via regex, preserving YAML comments and formatting
- Config-type-agnostic — works for both AWS and Azure ptd.yaml files

Closes #241