### PR TITLE
feat: add RemoveWorkloadMimirPassword for eject severance

### DIFF
--- a/lib/eject/sever.go
+++ b/lib/eject/sever.go
@@ -1,0 +1,57 @@
+package eject
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/posit-dev/ptd/lib/types"
+)
+
+func RemoveWorkloadMimirPassword(ctx context.Context, controlRoomTarget types.Target, workloadName string) error {
+	creds, err := controlRoomTarget.Credentials(ctx)
+	if err != nil {
+		return fmt.Errorf("getting control room credentials: %w", err)
+	}
+
+	secretName := fmt.Sprintf("%s.mimir-auth.posit.team", controlRoomTarget.Name())
+
+	if !controlRoomTarget.SecretStore().SecretExists(ctx, creds, secretName) {
+		slog.Info("Mimir auth secret does not exist, nothing to remove", "secret", secretName)
+		return nil
+	}
+
+	val, err := controlRoomTarget.SecretStore().GetSecretValue(ctx, creds, secretName)
+	if err != nil {
+		return fmt.Errorf("getting mimir auth secret: %w", err)
+	}
+
+	var secret map[string]string
+	if err := json.Unmarshal([]byte(val), &secret); err != nil {
+		return fmt.Errorf("unmarshalling mimir auth secret: %w", err)
+	}
+
+	if _, exists := secret[workloadName]; !exists {
+		slog.Info("Workload not found in mimir auth secret, nothing to remove", "workload", workloadName, "secret", secretName)
+		return nil
+	}
+
+	delete(secret, workloadName)
+
+	if len(secret) == 0 {
+		slog.Info("Mimir auth secret is now empty after removal", "secret", secretName)
+	}
+
+	secretString, err := json.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("marshalling mimir auth secret: %w", err)
+	}
+
+	if err := controlRoomTarget.SecretStore().PutSecretValue(ctx, creds, secretName, string(secretString)); err != nil {
+		return fmt.Errorf("writing mimir auth secret: %w", err)
+	}
+
+	slog.Info("Removed workload mimir password from control room", "workload", workloadName, "secret", secretName)
+	return nil
+}

--- a/lib/eject/sever_test.go
+++ b/lib/eject/sever_test.go
@@ -1,0 +1,110 @@
+package eject
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/posit-dev/ptd/lib/types"
+	"github.com/posit-dev/ptd/lib/types/typestest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSecretStore struct {
+	secrets map[string]string
+}
+
+func (f *fakeSecretStore) SecretExists(_ context.Context, _ types.Credentials, secretName string) bool {
+	_, ok := f.secrets[secretName]
+	return ok
+}
+
+func (f *fakeSecretStore) GetSecretValue(_ context.Context, _ types.Credentials, secretName string) (string, error) {
+	return f.secrets[secretName], nil
+}
+
+func (f *fakeSecretStore) PutSecretValue(_ context.Context, _ types.Credentials, secretName string, secretString string) error {
+	f.secrets[secretName] = secretString
+	return nil
+}
+
+func (f *fakeSecretStore) CreateSecret(_ context.Context, _ types.Credentials, _ string, _ string) error {
+	return nil
+}
+
+func (f *fakeSecretStore) CreateSecretIfNotExists(_ context.Context, _ types.Credentials, _ string, _ any) error {
+	return nil
+}
+
+func (f *fakeSecretStore) EnsureWorkloadSecret(_ context.Context, _ types.Credentials, _ string, _ any) error {
+	return nil
+}
+
+func controlRoomTarget(name string, store types.SecretStore) *typestest.MockTarget {
+	mt := &typestest.MockTarget{}
+	mt.On("Name").Return(name)
+	mt.On("Credentials", mock.Anything).Return(typestest.DefaultCredentials(), nil)
+	mt.On("SecretStore").Return(store)
+	return mt
+}
+
+func TestRemoveWorkloadMimirPassword_MultipleEntries(t *testing.T) {
+	secretName := "ctrl.mimir-auth.posit.team"
+	initial := map[string]string{"workload-a": "pass-a", "workload-b": "pass-b"}
+	data, err := json.Marshal(initial)
+	require.NoError(t, err)
+
+	store := &fakeSecretStore{secrets: map[string]string{secretName: string(data)}}
+	target := controlRoomTarget("ctrl", store)
+
+	err = RemoveWorkloadMimirPassword(context.Background(), target, "workload-a")
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(store.secrets[secretName]), &result))
+	assert.Equal(t, map[string]string{"workload-b": "pass-b"}, result)
+}
+
+func TestRemoveWorkloadMimirPassword_OnlyEntry(t *testing.T) {
+	secretName := "ctrl.mimir-auth.posit.team"
+	initial := map[string]string{"workload-a": "pass-a"}
+	data, err := json.Marshal(initial)
+	require.NoError(t, err)
+
+	store := &fakeSecretStore{secrets: map[string]string{secretName: string(data)}}
+	target := controlRoomTarget("ctrl", store)
+
+	err = RemoveWorkloadMimirPassword(context.Background(), target, "workload-a")
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(store.secrets[secretName]), &result))
+	assert.Empty(t, result)
+}
+
+func TestRemoveWorkloadMimirPassword_SecretDoesNotExist(t *testing.T) {
+	store := &fakeSecretStore{secrets: map[string]string{}}
+	target := controlRoomTarget("ctrl", store)
+
+	err := RemoveWorkloadMimirPassword(context.Background(), target, "workload-a")
+	assert.NoError(t, err)
+}
+
+func TestRemoveWorkloadMimirPassword_WorkloadNotInMap(t *testing.T) {
+	secretName := "ctrl.mimir-auth.posit.team"
+	initial := map[string]string{"workload-b": "pass-b"}
+	data, err := json.Marshal(initial)
+	require.NoError(t, err)
+
+	store := &fakeSecretStore{secrets: map[string]string{secretName: string(data)}}
+	target := controlRoomTarget("ctrl", store)
+
+	err = RemoveWorkloadMimirPassword(context.Background(), target, "workload-a")
+	require.NoError(t, err)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(store.secrets[secretName]), &result))
+	assert.Equal(t, map[string]string{"workload-b": "pass-b"}, result)
+}


### PR DESCRIPTION
## Summary
- Removes a workload's entry from the shared `<controlRoom>.mimir-auth.posit.team` JSON map
- Removes the key rather than deleting the whole secret (other workloads share it)
- Fully idempotent: handles missing secret, missing key, and empty map

Closes #242