### PR TITLE
chore: bump default team-operator chart version to v1.23.1

### DIFF
--- a/lib/steps/clusters.go
+++ b/lib/steps/clusters.go
@@ -16,7 +16,7 @@ const (
 	// clustersTeamOperatorServiceAccount is the Helm chart default service account name.
 	clustersTeamOperatorServiceAccount = "team-operator-controller-manager"
 	// clustersDefaultTeamOperatorChartVersion is used when no chart version is configured.
-	clustersDefaultTeamOperatorChartVersion = "v1.23.0"
+	clustersDefaultTeamOperatorChartVersion = "v1.23.1"
 	// clustersTraefikForwardAuthSA matches the Python Roles.TRAEFIK_FORWARD_AUTH value.
 	clustersTraefikForwardAuthSA = "traefik-forward-auth.posit.team"
 


### PR DESCRIPTION
## Summary

- Bumps the default team-operator Helm chart version from `v1.23.0` to `v1.23.1`

Picks up the fixes released in [posit-dev/team-operator v1.23.1](https://github.com/posit-dev/team-operator/releases/tag/v1.23.1):
- Bug fix: prevent status-patch reconcile storm in Site and child controllers (posit-dev/team-operator#128)
- Revert: remove dynamicLabels from session pod config (posit-dev/team-operator#126)

## Test plan

- [x] Deployed to staging workloads and verified operator upgrade completes cleanly