### PR TITLE
feat: nvidia device plugin for azure gpu nodes

### DIFF
--- a/lib/types/workload.go
+++ b/lib/types/workload.go
@@ -167,6 +167,7 @@ type AzureWorkloadConfig struct {
 	ThirdPartyTelemetryEnabled          *bool                                 `yaml:"third_party_telemetry_enabled,omitempty"`
 	Network                             NetworkConfig                         `yaml:"network"`
 	NetworkTrust                        string                                `yaml:"network_trust"`
+	NvidiaGpuEnabled                    bool                                  `yaml:"nvidia_gpu_enabled"`
 	PpmFileShareSizeGib                 int                                   `yaml:"ppm_file_share_size_gib"`
 	// RootDomain, when set, is used as the sole cert-manager domain instead of per-site domains.
 	// Mirrors Python: AzureWorkloadConfig.root_domain (via WorkloadConfig.domains fallback).
@@ -244,6 +245,7 @@ type AzureWorkloadClusterConfig struct {
 
 type AzureWorkloadClusterComponentConfig struct {
 	SecretStoreCsiDriverAzureProviderVersion string `yaml:"secret_store_csi_driver_azure_provider_version"`
+	NvidiaDevicePluginVersion                string `yaml:"nvidia_device_plugin_version"`
 }
 
 type SiteConfig struct {

--- a/python-pulumi/src/ptd/azure_workload.py
+++ b/python-pulumi/src/ptd/azure_workload.py
@@ -67,6 +67,7 @@ class AzureWorkloadConfig(ptd.WorkloadConfig):
     netapp_volume_workbench_capacity: int = 200  # GiB
     netapp_volume_workbench_shared_capacity: int = 200  # GiB
     ppm_file_share_size_gib: int = 100  # Minimum size for PPM Azure File Share in GiB
+    nvidia_gpu_enabled: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -119,6 +120,7 @@ class AzureWorkloadClusterConfig(ptd.WorkloadClusterConfig):
 @dataclasses.dataclass(frozen=True)
 class AzureWorkloadClusterComponentConfig(ptd.WorkloadClusterComponentConfig):
     secret_store_csi_driver_azure_provider_version: str | None = "1.5.6"  # noqa: S105
+    nvidia_device_plugin_version: str | None = "0.17.1"
 
 
 def load_workload_cluster_site_dict(

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
@@ -791,8 +791,31 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
                 "version": version,
                 "valuesContent": yaml.dump(
                     {
-                        # AKS labels GPU nodes with accelerator=nvidia natively; NFD is not needed.
-                        "nfd": {"enabled": False},
+                        "nfd": {
+                            "enabled": True,
+                            "worker": {
+                                "tolerations": [
+                                    {
+                                        "key": "workload-type",
+                                        "operator": "Equal",
+                                        "value": "session",
+                                        "effect": "NoSchedule",
+                                    },
+                                    {
+                                        "key": "nvidia.com/gpu",
+                                        "operator": "Equal",
+                                        "value": "present",
+                                        "effect": "NoSchedule",
+                                    },
+                                    {
+                                        "key": "node-role.kubernetes.io/master",
+                                        "operator": "Equal",
+                                        "value": "",
+                                        "effect": "NoSchedule",
+                                    },
+                                ],
+                            },
+                        },
                         "migStrategy": "none",
                         "failOnInitError": True,
                         "nvidiaDriverRoot": "/",
@@ -802,6 +825,12 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
                             "deviceIDStrategy": "uuid",
                         },
                         "tolerations": [
+                            {
+                                "key": "workload-type",
+                                "operator": "Equal",
+                                "value": "session",
+                                "effect": "NoSchedule",
+                            },
                             {
                                 "key": "nvidia.com/gpu",
                                 "operator": "Exists",

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
@@ -18,6 +18,7 @@ EXTERNAL_DNS_NAMESPACE = "external-dns"
 GRAFANA_NAMESPACE = "grafana"
 LOKI_NAMESPACE = "loki"
 MIMIR_NAMESPACE = "mimir"
+NVIDIA_DEVICE_PLUGIN_NAMESPACE = "nvidia-device-plugin"
 
 
 class AzureWorkloadHelm(pulumi.ComponentResource):
@@ -91,6 +92,9 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
             self._define_grafana(release, components.grafana_version)
             self._define_alloy(release, components.alloy_version)
             self._define_kube_state_metrics(release, components.kube_state_metrics_version)
+
+            if self.workload.cfg.nvidia_gpu_enabled:
+                self._define_nvidia_device_plugin(release, components.nvidia_device_plugin_version)
 
     def _define_loki(self, release: str, version: str):
         loki_identity = self._define_blob_storage_managed_identity(
@@ -761,4 +765,55 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
                 ),
             },
             opts=pulumi.ResourceOptions(provider=self.kube_providers[release]),
+        )
+
+    def _define_nvidia_device_plugin(self, release: str, version: str):
+        namespace = kubernetes.core.v1.Namespace(
+            f"{self.workload.compound_name}-{release}-nvidia-device-plugin-ns",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name=NVIDIA_DEVICE_PLUGIN_NAMESPACE,
+            ),
+            opts=pulumi.ResourceOptions(provider=self.kube_providers[release]),
+        )
+
+        kubernetes.apiextensions.CustomResource(
+            f"{self.workload.compound_name}-{release}-nvidia-device-plugin-helm-release",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name="nvidia-device-plugin",
+                namespace=ptd.HELM_CONTROLLER_NAMESPACE,
+            ),
+            api_version="helm.cattle.io/v1",
+            kind="HelmChart",
+            spec={
+                "repo": "https://nvidia.github.io/k8s-device-plugin",
+                "chart": "nvidia-device-plugin",
+                "targetNamespace": NVIDIA_DEVICE_PLUGIN_NAMESPACE,
+                "version": version,
+                "valuesContent": yaml.dump(
+                    {
+                        # AKS labels GPU nodes with accelerator=nvidia natively; NFD is not needed.
+                        "nfd": {"enabled": False},
+                        "migStrategy": "none",
+                        "failOnInitError": True,
+                        "nvidiaDriverRoot": "/",
+                        "plugin": {
+                            "passDeviceSpecs": False,
+                            "deviceListStrategy": "envvar",
+                            "deviceIDStrategy": "uuid",
+                        },
+                        "tolerations": [
+                            {
+                                "key": "nvidia.com/gpu",
+                                "operator": "Exists",
+                                "effect": "NoSchedule",
+                            },
+                            {
+                                "key": "CriticalAddonsOnly",
+                                "operator": "Exists",
+                            },
+                        ],
+                    }
+                ),
+            },
+            opts=pulumi.ResourceOptions(provider=self.kube_providers[release], depends_on=[namespace]),
         )

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
@@ -789,18 +789,7 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
                 "chart": "nvidia-device-plugin",
                 "targetNamespace": NVIDIA_DEVICE_PLUGIN_NAMESPACE,
                 "version": version,
-                "valuesContent": yaml.dump(
-                    {
-                        "migStrategy": "none",
-                        "failOnInitError": True,
-                        "nvidiaDriverRoot": "/",
-                        "plugin": {
-                            "passDeviceSpecs": False,
-                            "deviceListStrategy": "envvar",
-                            "deviceIDStrategy": "uuid",
-                        },
-                    }
-                ),
+                "valuesContent": "",
             },
             opts=pulumi.ResourceOptions(provider=self.kube_providers[release], depends_on=[namespace]),
         )

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_helm.py
@@ -791,31 +791,6 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
                 "version": version,
                 "valuesContent": yaml.dump(
                     {
-                        "nfd": {
-                            "enabled": True,
-                            "worker": {
-                                "tolerations": [
-                                    {
-                                        "key": "workload-type",
-                                        "operator": "Equal",
-                                        "value": "session",
-                                        "effect": "NoSchedule",
-                                    },
-                                    {
-                                        "key": "nvidia.com/gpu",
-                                        "operator": "Equal",
-                                        "value": "present",
-                                        "effect": "NoSchedule",
-                                    },
-                                    {
-                                        "key": "node-role.kubernetes.io/master",
-                                        "operator": "Equal",
-                                        "value": "",
-                                        "effect": "NoSchedule",
-                                    },
-                                ],
-                            },
-                        },
                         "migStrategy": "none",
                         "failOnInitError": True,
                         "nvidiaDriverRoot": "/",
@@ -824,23 +799,6 @@ class AzureWorkloadHelm(pulumi.ComponentResource):
                             "deviceListStrategy": "envvar",
                             "deviceIDStrategy": "uuid",
                         },
-                        "tolerations": [
-                            {
-                                "key": "workload-type",
-                                "operator": "Equal",
-                                "value": "session",
-                                "effect": "NoSchedule",
-                            },
-                            {
-                                "key": "nvidia.com/gpu",
-                                "operator": "Exists",
-                                "effect": "NoSchedule",
-                            },
-                            {
-                                "key": "CriticalAddonsOnly",
-                                "operator": "Exists",
-                            },
-                        ],
                     }
                 ),
             },


### PR DESCRIPTION
## Description

The AWS helm step already deploys the NVIDIA device plugin when `nvidia_gpu_enabled: true`; this PR adds the equivalent for AKS, which was missing. Without the device plugin, `nvidia.com/gpu` resources are never registered on GPU nodes, so pods requesting GPUs fail to schedule regardless of available hardware.

Note: We will need to follow up with additional scheduling configuration to keep non-gpu workloads off of these nodes.

## Code Flow

- `azure_workload.py`: adds `nvidia_gpu_enabled` flag and `nvidia_device_plugin_version` component version
- `workload.go`: mirrors both fields in the Go config structs
- `azure_workload_helm.py`: adds `_define_nvidia_device_plugin()`, called when `nvidia_gpu_enabled: true`; uses chart defaults

## Category of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about