### PR TITLE
fix(proxy): kill subprocess group on stop to avoid Azure tunnel orphan

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -42,8 +42,21 @@ var proxyCmd = &cobra.Command{
 			return
 		}
 
-		stopProxy, err := kube.StartProxy(cmd.Context(), t, proxyFile)
+		// Install the SIGINT handler BEFORE starting the proxy. Startup takes
+		// several seconds (Azure bastion handshake) and the subprocesses now
+		// run in their own process groups (Setpgid: true), so terminal SIGINT
+		// no longer reaches them — only ptd's handler can clean them up.
+		// Cancelling ctx triggers exec.CommandContext's Cancel callback,
+		// which is wired in azure/aws proxy.go to do a group-kill.
+		ctx, stopSignal := signal.NotifyContext(cmd.Context(), os.Interrupt)
+
+		stopProxy, err := kube.StartProxy(ctx, t, proxyFile)
 		if err != nil {
+			stopSignal()
+			if ctx.Err() != nil {
+				slog.Info("Proxy session start cancelled by user")
+				return
+			}
 			slog.Error("Error starting proxy session", "error", err)
 			return
 		}
@@ -52,14 +65,15 @@ var proxyCmd = &cobra.Command{
 		if Daemon {
 			slog.Info("Running in daemon mode, proxy session will run in the background")
 			slog.Info("You can stop the proxy session with `ptd proxy <workload> --stop`")
+			// Do NOT call stopSignal() here — cancelling ctx would fire
+			// exec.Cmd's auto-cancel and kill the daemon's subprocesses.
+			// Letting ptd exit without cancelling leaves them running.
 			return
 		}
 
-		// Wait for interrupt signal
+		defer stopSignal()
 		slog.Info("Press Ctrl+C to stop the proxy session")
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt)
-		<-sigCh
+		<-ctx.Done()
 		slog.Info("Received interrupt, stopping proxy session")
 		stopProxy()
 	},

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -65,9 +65,6 @@ var proxyCmd = &cobra.Command{
 		if Daemon {
 			slog.Info("Running in daemon mode, proxy session will run in the background")
 			slog.Info("You can stop the proxy session with `ptd proxy <workload> --stop`")
-			// Do NOT call stopSignal() here — cancelling ctx would fire
-			// exec.Cmd's auto-cancel and kill the daemon's subprocesses.
-			// Letting ptd exit without cancelling leaves them running.
 			return
 		}
 

--- a/lib/aws/proxy.go
+++ b/lib/aws/proxy.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"os/signal"
 	"strings"
 	"syscall"
 	"time"
@@ -198,24 +197,4 @@ func buildTempSshAccessCommand(publicKeyPath string) (cmd []string) {
 	cmd = append(cmd, fmt.Sprintf("echo '%s' >> /home/ec2-user/.ssh/authorized_keys", pubKeyStr))
 	cmd = append(cmd, fmt.Sprintf("(sleep 60 && sed -i '\\;%s;d' /home/ec2-user/.ssh/authorized_keys &) >/dev/null 2>&1", pubKeyStr))
 	return
-}
-
-func (p *ProxySession) Wait() {
-	defer func() {
-		if err := p.Stop(); err != nil {
-			slog.Error("Error stopping proxy session", "error", err)
-		}
-	}()
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		for sig := range c {
-			slog.Info("Received signal, stopping proxy session", "signal", sig)
-			if err := p.Stop(); err != nil {
-				slog.Error("Error stopping proxy session", "error", err)
-			}
-			os.Exit(0)
-		}
-	}()
-	select {}
 }

--- a/lib/aws/proxy.go
+++ b/lib/aws/proxy.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/posit-dev/ptd/lib/helpers"
@@ -123,6 +124,14 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-N", "-D", p.localPort,
 		fmt.Sprintf("ec2-user@%s", bastionId))
+	// Put ssh in its own process group so helpers.KillProcess reaps the
+	// ProxyCommand shell and the aws-ssm-plugin subprocess it spawns.
+	p.command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Override exec.CommandContext's default cancel (single-pid kill); the
+	// ProxyCommand shell would otherwise orphan.
+	p.command.Cancel = func() error {
+		return helpers.KillProcess(p.command.Process.Pid)
+	}
 
 	// set the environment variables for the command
 	// add each aws env var to command

--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"os/signal"
 	"syscall"
 	"time"
 
@@ -245,20 +244,4 @@ func (p *ProxySession) Stop() error {
 	}
 
 	return p.runningProxy.Stop()
-}
-
-func (p *ProxySession) Wait() {
-	defer p.Stop()
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		for sig := range c {
-			slog.Info("Received signal, stopping proxy session", "signal", sig)
-			if err := p.Stop(); err != nil {
-				slog.Error("Error stopping proxy session", "error", err)
-			}
-			os.Exit(0)
-		}
-	}()
-	select {}
 }

--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/posit-dev/ptd/lib/helpers"
@@ -132,6 +133,16 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		"--resource-port", "22",
 		"--port", "22001",
 	)
+	// Put the tunnel in its own process group so helpers.KillProcess can kill
+	// the whole group — the homebrew `az` wrapper forks python without exec,
+	// and killing only the bash pid orphans the python child (which keeps
+	// port 22001 bound).
+	p.tunnelCommand.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Override exec.CommandContext's default cancel (single-pid kill), which
+	// would orphan the python child. Group-kill instead.
+	p.tunnelCommand.Cancel = func() error {
+		return helpers.KillProcess(p.tunnelCommand.Process.Pid)
+	}
 
 	// build the command to start the SOCKS proxy via SSH, using the jumpbox tunnel from above
 	p.socksCommand = exec.CommandContext(
@@ -143,6 +154,10 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-i", p.sshKeyPath)
+	p.socksCommand.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	p.socksCommand.Cancel = func() error {
+		return helpers.KillProcess(p.socksCommand.Process.Pid)
+	}
 
 	// set the environment variables for the command
 	// HOME is required by the az CLI (Python) to locate ~/.azure config and cache directories.
@@ -174,6 +189,9 @@ func (p *ProxySession) Start(ctx context.Context) error {
 	time.Sleep(3 * time.Second)
 	if !helpers.PortOpen("localhost", "22001") {
 		slog.Error("Tunnel is not listening on port 22001")
+		if killErr := helpers.KillProcess(p.tunnelCommand.Process.Pid); killErr != nil {
+			slog.Warn("Error killing orphaned tunnel command", "pid", p.tunnelCommand.Process.Pid, "error", killErr)
+		}
 		return fmt.Errorf("tunnel session did not start successfully on port 22001")
 	}
 
@@ -187,6 +205,9 @@ func (p *ProxySession) Start(ctx context.Context) error {
 	err = p.socksCommand.Start()
 	if err != nil {
 		slog.Error("Error starting proxy session socks command", "error", err)
+		if killErr := helpers.KillProcess(p.tunnelCommand.Process.Pid); killErr != nil {
+			slog.Warn("Error killing orphaned tunnel command", "pid", p.tunnelCommand.Process.Pid, "error", killErr)
+		}
 		return err
 	}
 
@@ -201,6 +222,12 @@ func (p *ProxySession) Start(ctx context.Context) error {
 
 	if !p.runningProxy.WaitForPortOpen(8) {
 		slog.Error("Proxy is not listening on port", "local_port", p.localPort)
+		if killErr := helpers.KillProcess(p.tunnelCommand.Process.Pid); killErr != nil {
+			slog.Warn("Error killing orphaned tunnel command", "pid", p.tunnelCommand.Process.Pid, "error", killErr)
+		}
+		if killErr := helpers.KillProcess(p.socksCommand.Process.Pid); killErr != nil {
+			slog.Warn("Error killing orphaned socks command", "pid", p.socksCommand.Process.Pid, "error", killErr)
+		}
 		return fmt.Errorf("proxy session did not start successfully on port %s", p.localPort)
 	}
 

--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -134,7 +134,7 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		"--port", "22001",
 	)
 	// Put the tunnel in its own process group so helpers.KillProcess can kill
-	// the whole group — the homebrew `az` wrapper forks python without exec,
+	// the whole group — the `az` wrapper forks python without exec,
 	// and killing only the bash pid orphans the python child (which keeps
 	// port 22001 bound).
 	p.tunnelCommand.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/lib/helpers/ps.go
+++ b/lib/helpers/ps.go
@@ -10,7 +10,7 @@ import (
 
 // KillProcess sends SIGKILL to the process group led by pid, so any child
 // processes forked by the target (e.g. the python subprocess spawned by the
-// homebrew `az` bash wrapper) are reaped along with it. It expects pid to be
+// `az` bash wrapper) are reaped along with it. It expects pid to be
 // the process group leader; callers should spawn with
 // SysProcAttr{Setpgid: true}. If no process group with that leader exists
 // (ESRCH), it falls back to a single-process kill.

--- a/lib/helpers/ps.go
+++ b/lib/helpers/ps.go
@@ -1,19 +1,40 @@
 package helpers
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"syscall"
 )
 
+// KillProcess sends SIGKILL to the process group led by pid, so any child
+// processes forked by the target (e.g. the python subprocess spawned by the
+// homebrew `az` bash wrapper) are reaped along with it. It expects pid to be
+// the process group leader; callers should spawn with
+// SysProcAttr{Setpgid: true}. If no process group with that leader exists
+// (ESRCH), it falls back to a single-process kill.
 func KillProcess(pid int) error {
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		slog.Debug("Error finding process for running proxy session", "pid", pid, "error", err)
-		return err
+	if pid <= 0 {
+		return fmt.Errorf("invalid pid: %d", pid)
 	}
 
-	return process.Kill()
+	err := syscall.Kill(-pid, syscall.SIGKILL)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, syscall.ESRCH) {
+		slog.Debug("No process group found, falling back to single-process kill", "pid", pid)
+		if fallbackErr := syscall.Kill(pid, syscall.SIGKILL); fallbackErr != nil {
+			slog.Debug("Error killing single process", "pid", pid, "error", fallbackErr)
+			return fallbackErr
+		}
+		return nil
+	}
+
+	slog.Debug("Error killing process group", "pid", pid, "error", err)
+	return err
 }
 
 func ProcessRunning(pid int) bool {

--- a/lib/helpers/ps_test.go
+++ b/lib/helpers/ps_test.go
@@ -1,9 +1,18 @@
 package helpers
 
 import (
+	"bufio"
+	"errors"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestProcessRunning tests the ProcessRunning function
@@ -29,4 +38,53 @@ func TestKillProcess(t *testing.T) {
 		err := KillProcess(-1)
 		assert.Error(t, err)
 	})
+}
+
+// TestKillProcessKillsGroup verifies KillProcess reaps the entire process
+// group, not just the leader. This is the core of the orphan fix: the `az`
+// wrapper forks python as a child, and killing only the shell pid would
+// leave python alive holding port 22001.
+func TestKillProcessKillsGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups not available on Windows")
+	}
+
+	// Shell forks a sleep into the background, prints its pid, then waits.
+	// With Setpgid: true the shell is its own pgid leader and the sleep
+	// inherits that pgid.
+	cmd := exec.Command("sh", "-c", "sleep 60 & echo $! && wait")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	require.NoError(t, err)
+	childPid, err := strconv.Atoi(strings.TrimSpace(line))
+	require.NoError(t, err)
+	require.Greater(t, childPid, 0)
+
+	shellPid := cmd.Process.Pid
+	require.NoError(t, syscall.Kill(shellPid, 0), "shell should be alive before kill")
+	require.NoError(t, syscall.Kill(childPid, 0), "child should be alive before kill")
+
+	require.NoError(t, KillProcess(shellPid))
+
+	// Reap the shell so it doesn't linger as a zombie.
+	_ = cmd.Wait()
+
+	// Once the shell is reaped, the orphaned sleep is reparented to init/launchd
+	// and reaped quickly. Poll for ESRCH on the child pid.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("child pid %d was not killed by group-kill", childPid)
 }

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -61,16 +62,28 @@ func (r *RunningProxy) DeleteFile() error {
 }
 
 func (r *RunningProxy) KillProcess() error {
-	err := helpers.KillProcess(r.Pid)
-	if err != nil {
-		slog.Error("Error killing process for running proxy session", "pid", r.Pid, "error", err)
-		return fmt.Errorf("error killing process for running proxy session: %w", err)
+	err1 := helpers.KillProcess(r.Pid)
+	if err1 != nil {
+		slog.Warn("Error killing process for running proxy session", "pid", r.Pid, "error", err1)
 	}
 
-	if r.Pid2 != 0 {
-		return helpers.KillProcess(r.Pid2)
+	if r.Pid2 == 0 {
+		if err1 != nil {
+			return fmt.Errorf("error killing process for running proxy session: %w", err1)
+		}
+		return nil
 	}
 
+	err2 := helpers.KillProcess(r.Pid2)
+	if err2 != nil {
+		slog.Warn("Error killing second process for running proxy session", "pid", r.Pid2, "error", err2)
+	}
+
+	// Only propagate an error if BOTH kills failed — a single failure usually
+	// means that process already exited, which is fine.
+	if err1 != nil && err2 != nil {
+		return fmt.Errorf("error killing processes for running proxy session: %w", errors.Join(err1, err2))
+	}
 	return nil
 }
 
@@ -105,8 +118,9 @@ func (r *RunningProxy) Stop() error {
 	slog.Info("Stopping running proxy session", "target_name", r.TargetName, "local_port", r.LocalPort, "pid", r.Pid)
 
 	if err := r.KillProcess(); err != nil {
+		// KillProcess already wraps with "error killing process for running proxy session".
 		slog.Error("Error killing process for running proxy session", "pid", r.Pid, "error", err)
-		return fmt.Errorf("error killing process for running proxy session: %w", err)
+		return err
 	}
 
 	if err := r.DeleteFile(); err != nil {


### PR DESCRIPTION
# Description

The PTD proxy command for Azure workloads was leaking the Azure CLI Python subprocess after Ctrl+C or `--stop`, leaving port 22001 bound and breaking the next proxy attempt.

The `az` wrapper script (azure-cli 2.83.0) does **not** `exec` — it forks Python as a child:

```bash
#!/usr/bin/env bash
AZ_INSTALLER=HOMEBREW /opt/homebrew/Cellar/azure-cli/2.83.0/libexec/bin/python -Im azure.cli "$@"
```

So the process tree is `ptd → bash (recorded as Pid) → python -Im azure.cli (owns port 22001)`. Killing only the recorded `Pid` reaped the bash wrapper and orphaned Python.

## Code Flow

**1. Group-kill instead of single-pid kill** — `helpers.KillProcess` now sends `SIGKILL` to the process group (`syscall.Kill(-pid, SIGKILL)`), with an `ESRCH` fallback to single-process kill for stale `proxy.json` files written by older ptd versions whose subprocess wasn't a pgid leader.

**2. Subprocesses are pgid leaders** — Azure (tunnel + ssh) and AWS (ssh w/ ProxyCommand) commands now spawn with `SysProcAttr{Setpgid: true}`, so each subprocess tree lives in its own process group that `KillProcess` can fully reap.

**3. SIGINT during startup no longer orphans** — Because `Setpgid: true` isolates children from the terminal's foreground process group, terminal SIGINT no longer reaches them; only ptd's handler can clean them up. `cmd/proxy.go` now installs the SIGINT handler via `signal.NotifyContext` *before* `kube.StartProxy`, so ctrl+C during the multi-second Azure handshake cancels the context. The Azure/AWS commands set `exec.Cmd.Cancel` to do a group-kill (overriding Go's default single-pid kill on context cancellation). Daemon mode skips the cancel so backgrounded subprocesses survive ptd exit.

**4. Startup error paths cleaned up** — Three pre-existing leak paths in `azure.ProxySession.Start()` (port-open check, socks Start, WaitForPortOpen) now kill already-started subprocesses before returning.

**5. KillProcess no longer short-circuits** — `RunningProxy.KillProcess` previously bailed on the first error and never attempted `Pid2`. Now both kills are always attempted; an error only propagates when both fail (a single failure usually means the process already exited).

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [ ] On macOS with homebrew `az`, run `ptd proxy <azure-target>`, ctrl+C after the proxy starts, then `ps aux | grep azure.cli` — should show no orphans.
- [ ] Repeat with ctrl+C **during** the Azure bastion handshake (within the first ~5 seconds) — should also leave no orphans.
- [ ] Run `ptd proxy <azure-target> --daemon`, then `ptd proxy <target> --stop` — daemon should be cleanly terminated.
- [ ] Verify AWS proxy still works end-to-end; ctrl+C should cleanly stop ssh and the SSM plugin.
- [ ] Verify a stale `proxy.json` from an older ptd version (where Pid is not a pgid leader) is still handled — the ESRCH fallback to single-pid kill should kick in.