### PR TITLE
feat(proxy): shared registry, deterministic ports, and new management commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ The proxy subsystem manages SOCKS proxy sessions to target bastion hosts. All pr
 # Interactive use — binds to port 1080
 ptd proxy <target>
 
-# Daemon mode — binds to the deterministic workload port (10000–10999) and
+# Daemon mode — binds to the deterministic workload port (10000–19999) and
 # stays running in the background; this is the same port used by ensure/workon
 ptd proxy <target> --daemon
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,56 @@ The Go CLI communicates the infrastructure path to Python Pulumi stacks via the 
 
 - `just aws-unset`: Unset all AWS environment variables
 
+## Using the PTD CLI
+
+### Proxy
+
+The proxy subsystem manages SOCKS proxy sessions to target bastion hosts. All proxy state is stored in a shared registry file (`~/.local/share/ptd/proxies.json`), enabling multiple concurrent proxies.
+
+**Starting a proxy:**
+
+```bash
+# Interactive use — binds to port 1080
+ptd proxy <target>
+
+# Daemon mode — binds to the deterministic workload port (10000–10999) and
+# stays running in the background; this is the same port used by ensure/workon
+ptd proxy <target> --daemon
+
+# Explicit port
+ptd proxy <target> --port 9090
+```
+
+**Print the deterministic port for a workload:**
+
+```bash
+ptd proxy port <target>
+```
+
+**Stopping proxies:**
+
+```bash
+# Stop one workload's proxy
+ptd proxy <target> --stop
+
+# Stop all running proxies
+ptd proxy --stop
+```
+
+**Registry management:**
+
+```bash
+# List all proxy sessions recorded in the registry
+ptd proxy --list
+
+# Remove stale entries (dead PIDs / closed ports)
+ptd proxy --prune
+```
+
+**Automatic proxy in ensure/workon:**
+
+`ptd ensure` and `ptd workon` start a proxy automatically on the deterministic workload port and reuse an existing one if it is already running. For scripted or agent use, prefer `ptd workon <target> -- <cmd>` rather than managing proxies manually.
+
 ## Git Worktrees
 
 **Always use git worktrees instead of plain branches.** This enables concurrent Claude sessions in the same repo.

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 	"slices"
+	"strconv"
 
 	"github.com/posit-dev/ptd/cmd/internal"
 	"github.com/posit-dev/ptd/cmd/internal/legacy"
 	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/steps"
 	"github.com/posit-dev/ptd/lib/types"
 	"github.com/spf13/cobra"
@@ -158,8 +159,8 @@ func runEnsure(ctx context.Context, target string) {
 
 	// if any of the steps require a proxy, start the proxy session, unless tailscale is enabled
 	if steps.ProxyRequiredSteps(stepsToRun) && !t.TailscaleEnabled() {
-		proxyFile := path.Join(internal.DataDir(), "proxy.json")
-		stopProxy, err := kube.StartProxy(ctx, t, proxyFile)
+		port := strconv.Itoa(proxy.WorkloadPort(t.Name()))
+		stopProxy, err := kube.StartProxy(ctx, t, port, internal.RegistryFilePath())
 		if err != nil {
 			slog.Error("Error starting proxy session", "error", err)
 			return

--- a/cmd/internal/helpers.go
+++ b/cmd/internal/helpers.go
@@ -24,3 +24,7 @@ func ConfigDir() string {
 	}
 	return configDir
 }
+
+func RegistryFilePath() string {
+	return DataDir() + "/proxies.json"
+}

--- a/cmd/internal/helpers.go
+++ b/cmd/internal/helpers.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func DataDir() string {
@@ -26,5 +27,5 @@ func ConfigDir() string {
 }
 
 func RegistryFilePath() string {
-	return DataDir() + "/proxies.json"
+	return filepath.Join(DataDir(), "proxies.json")
 }

--- a/cmd/k9s.go
+++ b/cmd/k9s.go
@@ -58,7 +58,7 @@ func runK9s(cmd *cobra.Command, target string) {
 	}
 
 	// Set up kubeconfig using native SDK
-	kubeconfigPath, err := kube.SetupKubeConfig(cmd.Context(), t, creds)
+	kubeconfigPath, err := kube.SetupKubeConfig(cmd.Context(), t, creds, port)
 	if err != nil {
 		slog.Error("Failed to setup kubeconfig", "error", err)
 		return

--- a/cmd/k9s.go
+++ b/cmd/k9s.go
@@ -5,11 +5,12 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path"
+	"strconv"
 
 	"github.com/posit-dev/ptd/cmd/internal"
 	"github.com/posit-dev/ptd/cmd/internal/legacy"
 	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/spf13/cobra"
 )
 
@@ -42,8 +43,8 @@ func runK9s(cmd *cobra.Command, target string) {
 	}
 
 	// Start proxy using shared kube package
-	proxyFile := path.Join(internal.DataDir(), "proxy.json")
-	stopProxy, err := kube.StartProxy(cmd.Context(), t, proxyFile)
+	port := strconv.Itoa(proxy.WorkloadPort(target))
+	stopProxy, err := kube.StartProxy(cmd.Context(), t, port, internal.RegistryFilePath())
 	if err != nil {
 		slog.Error("Error starting proxy session", "error", err)
 		return

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -17,8 +17,8 @@ import (
 func init() {
 	rootCmd.AddCommand(proxyCmd)
 	proxyCmd.AddCommand(proxyPortCmd)
-	proxyCmd.PersistentFlags().BoolVarP(&Daemon, "daemon", "d", false, "Run the proxy in the background")
-	proxyCmd.PersistentFlags().BoolVarP(&Stop, "stop", "s", false, "Stop any running proxy session")
+	proxyCmd.Flags().BoolVarP(&Daemon, "daemon", "d", false, "Run the proxy in the background")
+	proxyCmd.Flags().BoolVarP(&Stop, "stop", "s", false, "Stop any running proxy session")
 	proxyCmd.Flags().IntVar(&ProxyPort, "port", 0, "Local port to use for the proxy (default: 1080 for interactive, deterministic port for --daemon)")
 	proxyCmd.Flags().BoolVar(&List, "list", false, "List all running proxy sessions")
 	proxyCmd.Flags().BoolVar(&Prune, "prune", false, "Remove stale entries from the proxy registry")
@@ -114,6 +114,8 @@ var proxyCmd = &cobra.Command{
 
 		slog.Info("Proxy session started successfully", "port", localPort)
 		if Daemon {
+			// In daemon mode the proxy process is intentionally left running.
+			// Use `ptd proxy <target> --stop` to terminate it later.
 			slog.Info("Running in daemon mode, proxy session will run in the background")
 			slog.Info("You can stop the proxy session with `ptd proxy <workload> --stop`")
 			stopSignal()

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -93,6 +94,15 @@ var proxyCmd = &cobra.Command{
 			return
 		}
 
+		// In daemon mode use context.Background() so the subprocess is not tied
+		// to this process's lifetime. exec.CommandContext kills the child when
+		// its context is cancelled, which is correct for interactive mode but
+		// wrong for daemon mode where the proxy must outlive ptd.
+		proxyCtx := cmd.Context()
+		if Daemon {
+			proxyCtx = context.Background()
+		}
+
 		// Install the SIGINT handler BEFORE starting the proxy. Startup takes
 		// several seconds (Azure bastion handshake) and the subprocesses now
 		// run in their own process groups (Setpgid: true), so terminal SIGINT
@@ -100,10 +110,10 @@ var proxyCmd = &cobra.Command{
 		// Cancelling ctx triggers exec.CommandContext's Cancel callback,
 		// which is wired in azure/aws proxy.go to do a group-kill.
 		ctx, stopSignal := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer stopSignal()
 
-		stopProxy, err := kube.StartProxy(ctx, t, localPort, registryFile)
+		stopProxy, err := kube.StartProxy(proxyCtx, t, localPort, registryFile)
 		if err != nil {
-			stopSignal()
 			if ctx.Err() != nil {
 				slog.Info("Proxy session start cancelled by user")
 				return
@@ -114,15 +124,13 @@ var proxyCmd = &cobra.Command{
 
 		slog.Info("Proxy session started successfully", "port", localPort)
 		if Daemon {
-			// In daemon mode the proxy process is intentionally left running.
-			// Use `ptd proxy <target> --stop` to terminate it later.
+			// The proxy process is intentionally left running (started with
+			// context.Background()). Use `ptd proxy <target> --stop` to terminate it.
 			slog.Info("Running in daemon mode, proxy session will run in the background")
 			slog.Info("You can stop the proxy session with `ptd proxy <workload> --stop`")
-			stopSignal()
 			return
 		}
 
-		defer stopSignal()
 		slog.Info("Press Ctrl+C to stop the proxy session")
 		<-ctx.Done()
 		slog.Info("Received interrupt, stopping proxy session")

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
-	"path"
+	"strconv"
 
 	"github.com/posit-dev/ptd/cmd/internal"
 	"github.com/posit-dev/ptd/cmd/internal/legacy"
@@ -15,28 +16,78 @@ import (
 
 func init() {
 	rootCmd.AddCommand(proxyCmd)
+	proxyCmd.AddCommand(proxyPortCmd)
 	proxyCmd.PersistentFlags().BoolVarP(&Daemon, "daemon", "d", false, "Run the proxy in the background")
 	proxyCmd.PersistentFlags().BoolVarP(&Stop, "stop", "s", false, "Stop any running proxy session")
+	proxyCmd.Flags().IntVar(&ProxyPort, "port", 0, "Local port to use for the proxy (default: 1080 for interactive, deterministic port for --daemon)")
+	proxyCmd.Flags().BoolVar(&List, "list", false, "List all running proxy sessions")
+	proxyCmd.Flags().BoolVar(&Prune, "prune", false, "Remove stale entries from the proxy registry")
 }
 
 var Daemon bool
 var Stop bool
-var proxyFile = path.Join(internal.DataDir(), "proxy.json")
+var ProxyPort int
+var List bool
+var Prune bool
 
 var proxyCmd = &cobra.Command{
-	Use:               "proxy <target>",
+	Use:               "proxy [target]",
 	Short:             "Start a proxy session to the bastion host in a given target",
 	Long:              `Start a proxy session to the bastion host in a given target`,
-	Args:              cobra.ExactArgs(1),
+	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: legacy.ValidTargetArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		if Stop {
-			slog.Info("Stopping any running proxy session")
-			stopProxySession()
+		registryFile := internal.RegistryFilePath()
+
+		// --list
+		if List {
+			listProxies(registryFile)
 			return
 		}
 
-		t, err := legacy.TargetFromName(args[0])
+		// --prune
+		if Prune {
+			pruneProxies(registryFile)
+			return
+		}
+
+		// --stop (no target = stop all)
+		if Stop && len(args) == 0 {
+			slog.Info("Stopping all running proxy sessions")
+			if err := proxy.StopAll(registryFile); err != nil {
+				slog.Error("Error stopping all proxy sessions", "error", err)
+			}
+			return
+		}
+
+		// --stop with target = stop one
+		if Stop && len(args) == 1 {
+			slog.Info("Stopping running proxy session", "target", args[0])
+			stopProxySession(registryFile, args[0])
+			return
+		}
+
+		// start proxy — target required
+		if len(args) == 0 {
+			slog.Error("target argument is required when starting a proxy")
+			fmt.Fprintln(os.Stderr, "Error: target argument is required. Usage: ptd proxy <target>")
+			os.Exit(1)
+		}
+
+		targetName := args[0]
+
+		// Resolve port
+		var localPort string
+		switch {
+		case ProxyPort != 0:
+			localPort = strconv.Itoa(ProxyPort)
+		case Daemon:
+			localPort = strconv.Itoa(proxy.WorkloadPort(targetName))
+		default:
+			localPort = "1080"
+		}
+
+		t, err := legacy.TargetFromName(targetName)
 		if err != nil {
 			slog.Error("Could not load relevant ptd.yaml file", "error", err)
 			return
@@ -50,7 +101,7 @@ var proxyCmd = &cobra.Command{
 		// which is wired in azure/aws proxy.go to do a group-kill.
 		ctx, stopSignal := signal.NotifyContext(cmd.Context(), os.Interrupt)
 
-		stopProxy, err := kube.StartProxy(ctx, t, proxyFile)
+		stopProxy, err := kube.StartProxy(ctx, t, localPort, registryFile)
 		if err != nil {
 			stopSignal()
 			if ctx.Err() != nil {
@@ -61,10 +112,11 @@ var proxyCmd = &cobra.Command{
 			return
 		}
 
-		slog.Info("Proxy session started successfully")
+		slog.Info("Proxy session started successfully", "port", localPort)
 		if Daemon {
 			slog.Info("Running in daemon mode, proxy session will run in the background")
 			slog.Info("You can stop the proxy session with `ptd proxy <workload> --stop`")
+			stopSignal()
 			return
 		}
 
@@ -76,15 +128,82 @@ var proxyCmd = &cobra.Command{
 	},
 }
 
-func stopProxySession() {
-	runningProxy, err := proxy.GetRunningProxy(proxyFile)
+var proxyPortCmd = &cobra.Command{
+	Use:               "port <target>",
+	Short:             "Print the deterministic proxy port for a workload",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: legacy.ValidTargetArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(proxy.WorkloadPort(args[0]))
+	},
+}
+
+func stopProxySession(registryFile, targetName string) {
+	runningProxy, err := proxy.GetRunningProxy(registryFile, targetName)
 	if err != nil {
 		slog.Error("Error getting running proxy session", "error", err)
 		return
 	}
-	err = runningProxy.Stop()
-	if err != nil {
-		slog.Error("Error stopping running proxy session", "error", err)
+	if runningProxy.TargetName == "" {
+		slog.Warn("No running proxy session found for target", "target", targetName)
 		return
+	}
+	if err := runningProxy.Stop(); err != nil {
+		slog.Error("Error stopping running proxy session", "error", err)
+	}
+}
+
+func listProxies(registryFile string) {
+	proxies, err := proxy.ListRunningProxies(registryFile)
+	if err != nil {
+		slog.Error("Error listing proxy sessions", "error", err)
+		return
+	}
+
+	if len(proxies) == 0 {
+		fmt.Println("No proxy sessions found.")
+		return
+	}
+
+	fmt.Printf("%-30s  %-8s  %-12s  %-8s  %s\n", "TARGET", "PORT", "PID", "STATUS", "STARTED")
+	for _, rp := range proxies {
+		pid2Info := ""
+		if rp.Pid2 != 0 {
+			pid2Info = fmt.Sprintf("/%d", rp.Pid2)
+		}
+		status := "running"
+		if !rp.IsRunning() {
+			status = "stopped"
+		}
+		fmt.Printf("%-30s  %-8s  %-12s  %-8s  %s\n",
+			rp.TargetName,
+			rp.LocalPort,
+			fmt.Sprintf("%d%s", rp.Pid, pid2Info),
+			status,
+			rp.StartTime.Format("2006-01-02 15:04:05"),
+		)
+	}
+}
+
+func pruneProxies(registryFile string) {
+	pruned, err := proxy.PruneRegistry(registryFile)
+	if err != nil {
+		slog.Error("Error pruning proxy registry", "error", err)
+		return
+	}
+
+	if len(pruned) == 0 {
+		fmt.Println("No stale proxy entries found.")
+		return
+	}
+
+	fmt.Printf("Pruned %d stale proxy entr%s:\n", len(pruned), func() string {
+		if len(pruned) == 1 {
+			return "y"
+		}
+		return "ies"
+	}())
+	for _, name := range pruned {
+		fmt.Printf("  - %s\n", name)
 	}
 }

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -25,14 +25,14 @@ func TestProxyCommandRegistration(t *testing.T) {
 	}
 
 	// Check existing flags
-	daemonFlag := proxyCmd.PersistentFlags().Lookup("daemon")
+	daemonFlag := proxyCmd.Flags().Lookup("daemon")
 	if daemonFlag == nil {
 		t.Error("Expected daemon flag to be set")
 	} else if daemonFlag.Shorthand != "d" {
 		t.Errorf("Expected daemon flag shorthand to be 'd', got '%s'", daemonFlag.Shorthand)
 	}
 
-	stopFlag := proxyCmd.PersistentFlags().Lookup("stop")
+	stopFlag := proxyCmd.Flags().Lookup("stop")
 	if stopFlag == nil {
 		t.Error("Expected stop flag to be set")
 	} else if stopFlag.Shorthand != "s" {

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -7,41 +7,69 @@ import (
 
 	"github.com/posit-dev/ptd/lib/kube"
 	"github.com/posit-dev/ptd/lib/types"
+	"github.com/spf13/cobra"
 )
 
 func TestProxyCommandRegistration(t *testing.T) {
 	// Check that the proxy command is registered
-	found := false
+	var proxyCmd *cobra.Command
 	for _, cmd := range rootCmd.Commands() {
 		if cmd.Name() == "proxy" {
-			found = true
-
-			// Check flags
-			daemonFlag := cmd.PersistentFlags().Lookup("daemon")
-			if daemonFlag == nil {
-				t.Error("Expected daemon flag to be set")
-			} else if daemonFlag.Shorthand != "d" {
-				t.Errorf("Expected daemon flag shorthand to be 'd', got '%s'", daemonFlag.Shorthand)
-			}
-
-			stopFlag := cmd.PersistentFlags().Lookup("stop")
-			if stopFlag == nil {
-				t.Error("Expected stop flag to be set")
-			} else if stopFlag.Shorthand != "s" {
-				t.Errorf("Expected stop flag shorthand to be 's', got '%s'", stopFlag.Shorthand)
-			}
-
-			// Check that the command requires exactly one argument
-			if cmd.Args == nil {
-				t.Error("Expected Args function to be set")
-			}
-
+			proxyCmd = cmd
 			break
 		}
 	}
 
-	if !found {
-		t.Error("Proxy command not registered with root command")
+	if proxyCmd == nil {
+		t.Fatal("Proxy command not registered with root command")
+	}
+
+	// Check existing flags
+	daemonFlag := proxyCmd.PersistentFlags().Lookup("daemon")
+	if daemonFlag == nil {
+		t.Error("Expected daemon flag to be set")
+	} else if daemonFlag.Shorthand != "d" {
+		t.Errorf("Expected daemon flag shorthand to be 'd', got '%s'", daemonFlag.Shorthand)
+	}
+
+	stopFlag := proxyCmd.PersistentFlags().Lookup("stop")
+	if stopFlag == nil {
+		t.Error("Expected stop flag to be set")
+	} else if stopFlag.Shorthand != "s" {
+		t.Errorf("Expected stop flag shorthand to be 's', got '%s'", stopFlag.Shorthand)
+	}
+
+	// Check new flags
+	listFlag := proxyCmd.Flags().Lookup("list")
+	if listFlag == nil {
+		t.Error("Expected --list flag to be registered")
+	}
+
+	pruneFlag := proxyCmd.Flags().Lookup("prune")
+	if pruneFlag == nil {
+		t.Error("Expected --prune flag to be registered")
+	}
+
+	portFlag := proxyCmd.Flags().Lookup("port")
+	if portFlag == nil {
+		t.Error("Expected --port flag to be registered")
+	}
+
+	// Check that the command accepts 0 or 1 arguments (MaximumNArgs(1))
+	if proxyCmd.Args == nil {
+		t.Error("Expected Args function to be set")
+	}
+
+	// Check that the 'port' subcommand is registered
+	var portSubCmd *cobra.Command
+	for _, sub := range proxyCmd.Commands() {
+		if sub.Name() == "port" {
+			portSubCmd = sub
+			break
+		}
+	}
+	if portSubCmd == nil {
+		t.Error("Expected 'port' subcommand to be registered under proxy")
 	}
 }
 

--- a/cmd/workon.go
+++ b/cmd/workon.go
@@ -105,7 +105,7 @@ func runWorkOn(cmd *cobra.Command, target string, step string, execCmd []string)
 	}
 
 	// Set up kubeconfig (non-fatal)
-	kubeconfigPath, err := kube.SetupKubeConfig(cmd.Context(), t, creds)
+	kubeconfigPath, err := kube.SetupKubeConfig(cmd.Context(), t, creds, port)
 	if err != nil {
 		slog.Warn("Failed to setup kubeconfig, kubectl commands may not work", "error", err)
 	}

--- a/cmd/workon.go
+++ b/cmd/workon.go
@@ -5,14 +5,15 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/posit-dev/ptd/cmd/internal"
 	"github.com/posit-dev/ptd/cmd/internal/legacy"
 	"github.com/posit-dev/ptd/lib/customization"
 	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/pulumi"
 	"github.com/posit-dev/ptd/lib/steps"
 	"github.com/spf13/cobra"
@@ -95,8 +96,8 @@ func runWorkOn(cmd *cobra.Command, target string, step string, execCmd []string)
 	ptdRoot := helpers.GetTargetsConfigPath()
 
 	// Start proxy if needed (non-fatal)
-	proxyFile := path.Join(internal.DataDir(), "proxy.json")
-	stopProxy, err := kube.StartProxy(cmd.Context(), t, proxyFile)
+	port := strconv.Itoa(proxy.WorkloadPort(t.Name()))
+	stopProxy, err := kube.StartProxy(cmd.Context(), t, port, internal.RegistryFilePath())
 	if err != nil {
 		slog.Warn("Failed to start proxy", "error", err)
 	} else {

--- a/docs/cli/PTD_CLI_REFERENCE.md
+++ b/docs/cli/PTD_CLI_REFERENCE.md
@@ -434,7 +434,7 @@ $ ptd workon ganso01-staging -- kubectl get nonexistent; echo $?
 
 ### `ptd proxy`
 
-Start a SOCKS5 proxy session to the bastion host in a given target. The proxy runs on `localhost:1080` and enables secure access to private resources.
+Start a SOCKS5 proxy session to the bastion host in a given target. By default binds to `localhost:1080` for interactive/browser use; `--daemon` uses a deterministic per-workload port (10000–19999).
 
 **Usage:**
 ```bash
@@ -471,8 +471,8 @@ ptd proxy testing01-staging --stop
 **Implementation:** `/cmd/proxy.go:26`
 
 **Notes:**
-- Proxy runs on `localhost:1080`
-- Proxy session state is stored in `~/.local/share/ptd/proxy.json`
+- Interactive proxy binds to `localhost:1080`; `--daemon` binds to a deterministic per-workload port (10000–19999)
+- Proxy session state is stored in `~/.local/share/ptd/proxies.json`
 - Works with both AWS and Azure targets
 - Automatically handles credential management
 - Not needed if Tailscale is enabled for the target
@@ -730,9 +730,9 @@ Implementations:
 ### Proxy Sessions
 
 Proxy sessions enable secure access to private resources:
-- SOCKS5 proxy on `localhost:1080`
+- SOCKS5 proxy; interactive mode binds to `localhost:1080`, daemon/ensure/workon use deterministic per-workload ports (10000–19999)
 - Managed lifecycle (Start/Stop/Wait)
-- State persistence in `~/.local/share/ptd/proxy.json`
+- State persistence in `~/.local/share/ptd/proxies.json`
 - Automatic integration with ensure, k9s commands
 
 AWS: Uses SSM Session Manager (`aws ssm start-session --target <bastion-instance>`)
@@ -838,8 +838,8 @@ ptd ensure testing01-staging --auto-apply
 # Start proxy in background
 ptd proxy testing01-staging --daemon
 
-# Configure application to use SOCKS5 proxy on localhost:1080
-export HTTPS_PROXY=socks5://localhost:1080
+# Configure application to use the SOCKS5 proxy
+export HTTPS_PROXY=socks5://localhost:$(ptd proxy port testing01-staging)
 
 # When done, stop proxy
 ptd proxy testing01-staging --stop

--- a/docs/cli/ensure-flow.md
+++ b/docs/cli/ensure-flow.md
@@ -26,7 +26,7 @@ If any step requires a proxy connection (to access private resources like databa
 - **AWS**: Starts an SSM Session Manager tunnel through a bastion host
 - **Azure**: Starts an Azure Bastion tunnel
 - **Skipped if**: Tailscale is enabled on the target
-- The proxy runs on `localhost:1080` and is available to all subsequent steps
+- The proxy binds to a deterministic per-workload port (10000–19999) and is available to all subsequent steps
 
 ### 3. Step Execution
 

--- a/lib/aws/proxy.go
+++ b/lib/aws/proxy.go
@@ -27,10 +27,6 @@ type ProxySession struct {
 }
 
 func NewProxySession(t Target, awsCliPath string, localPort string, file string) *ProxySession {
-	if localPort == "" {
-		localPort = "1080"
-	}
-
 	runningProxy := proxy.NewRunningProxy(
 		t.Name(),
 		localPort,

--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -28,10 +28,6 @@ type ProxySession struct {
 }
 
 func NewProxySession(t Target, azCliPath string, localPort string, file string) *ProxySession {
-	if localPort == "" {
-		localPort = "1080"
-	}
-
 	runningProxy := proxy.NewRunningProxy(
 		t.Name(),
 		localPort,

--- a/lib/kube/proxy.go
+++ b/lib/kube/proxy.go
@@ -16,8 +16,9 @@ import (
 // StartProxy starts a SOCKS proxy session if needed for the target.
 // For non-tailscale targets, it starts the appropriate proxy.
 // For tailscale targets, it verifies connectivity and warns if not connected.
+// localPort is the SOCKS port to listen on; registryFile is the shared proxy registry.
 // Returns a stop function that should be deferred, and any error.
-func StartProxy(ctx context.Context, t types.Target, proxyFile string) (stopFunc func(), err error) {
+func StartProxy(ctx context.Context, t types.Target, localPort string, registryFile string) (stopFunc func(), err error) {
 	if t.TailscaleEnabled() {
 		// Check tailscale connectivity
 		client := local.Client{}
@@ -42,7 +43,7 @@ func StartProxy(ctx context.Context, t types.Target, proxyFile string) (stopFunc
 		}
 
 		// Create and start AWS proxy session
-		ps := awslib.NewProxySession(awsTarget, GetCliPath(types.AWS), "1080", proxyFile)
+		ps := awslib.NewProxySession(awsTarget, GetCliPath(types.AWS), localPort, registryFile)
 		if err := ps.Start(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start AWS proxy session: %w", err)
 		}
@@ -62,7 +63,7 @@ func StartProxy(ctx context.Context, t types.Target, proxyFile string) (stopFunc
 		}
 
 		// Create and start Azure proxy session
-		ps := azure.NewProxySession(azureTarget, GetCliPath(types.Azure), "1080", proxyFile)
+		ps := azure.NewProxySession(azureTarget, GetCliPath(types.Azure), localPort, registryFile)
 		if err := ps.Start(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start Azure proxy session: %w", err)
 		}

--- a/lib/kube/setup.go
+++ b/lib/kube/setup.go
@@ -19,21 +19,23 @@ import (
 //   - For AWS: native SDK-based kubeconfig generation (no CLI dependency)
 //   - For Azure: native SDK-based kubeconfig generation
 //   - Adding proxy configuration for non-tailscale clusters
-func SetupKubeConfig(ctx context.Context, t types.Target, creds types.Credentials) (string, error) {
+//
+// localPort is the SOCKS5 proxy port to inject into the kubeconfig.
+func SetupKubeConfig(ctx context.Context, t types.Target, creds types.Credentials, localPort string) (string, error) {
 	// Create a temp kubeconfig path
 	kubeconfigPath := filepath.Join(os.TempDir(), fmt.Sprintf("kubeconfig-%s", t.HashName()))
 
 	switch t.CloudProvider() {
 	case types.AWS:
-		return setupAWSKubeConfig(ctx, t, creds, kubeconfigPath)
+		return setupAWSKubeConfig(ctx, t, creds, kubeconfigPath, localPort)
 	case types.Azure:
-		return setupAzureKubeConfig(ctx, t, creds, kubeconfigPath)
+		return setupAzureKubeConfig(ctx, t, creds, kubeconfigPath, localPort)
 	default:
 		return "", fmt.Errorf("kubeconfig setup not implemented for cloud provider: %s", t.CloudProvider())
 	}
 }
 
-func setupAWSKubeConfig(ctx context.Context, t types.Target, creds types.Credentials, kubeconfigPath string) (string, error) {
+func setupAWSKubeConfig(ctx context.Context, t types.Target, creds types.Credentials, kubeconfigPath string, localPort string) (string, error) {
 	// Convert to AWS credentials
 	awsCreds, err := aws.OnlyAwsCredentials(creds)
 	if err != nil {
@@ -102,7 +104,7 @@ func setupAWSKubeConfig(ctx context.Context, t types.Target, creds types.Credent
 
 	// Add proxy if not using tailscale
 	if !t.TailscaleEnabled() {
-		if err := AddProxyToKubeConfig(kubeconfigPath, "socks5://localhost:1080"); err != nil {
+		if err := AddProxyToKubeConfig(kubeconfigPath, fmt.Sprintf("socks5://localhost:%s", localPort)); err != nil {
 			return "", fmt.Errorf("failed to add proxy to kubeconfig: %w", err)
 		}
 	}
@@ -110,7 +112,7 @@ func setupAWSKubeConfig(ctx context.Context, t types.Target, creds types.Credent
 	return kubeconfigPath, nil
 }
 
-func setupAzureKubeConfig(ctx context.Context, t types.Target, creds types.Credentials, kubeconfigPath string) (string, error) {
+func setupAzureKubeConfig(ctx context.Context, t types.Target, creds types.Credentials, kubeconfigPath string, localPort string) (string, error) {
 	// Type-assert to azure.Target
 	azureTarget, ok := t.(azure.Target)
 	if !ok {
@@ -160,7 +162,7 @@ func setupAzureKubeConfig(ctx context.Context, t types.Target, creds types.Crede
 	}
 
 	// Always add proxy for Azure (no tailscale support)
-	if err := AddProxyToKubeConfig(kubeconfigPath, "socks5://localhost:1080"); err != nil {
+	if err := AddProxyToKubeConfig(kubeconfigPath, fmt.Sprintf("socks5://localhost:%s", localPort)); err != nil {
 		return "", fmt.Errorf("failed to add proxy to Azure kubeconfig: %w", err)
 	}
 

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -3,12 +3,21 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"os"
 	"time"
 
 	"github.com/posit-dev/ptd/lib/helpers"
 )
+
+// WorkloadPort returns a deterministic port in the range [10000, 10999] for
+// the given workload name, derived via FNV-32a.
+func WorkloadPort(name string) int {
+	h := fnv.New32a()
+	h.Write([]byte(name))
+	return 10000 + int(h.Sum32()%1000)
+}
 
 type RunningProxy struct {
 	TargetName string    `json:"target_name"`
@@ -17,7 +26,7 @@ type RunningProxy struct {
 	Pid2       int       `json:"pid2,omitempty"` // Optional second PID for azure proxy sessions
 	StartTime  time.Time `json:"start_time"`
 
-	File string `json:"-"` // File path to store the running proxy session
+	File string `json:"-"` // Registry file path so Store/DeleteFile know where to write
 }
 
 // NewRunningProxy creates a new RunningProxy instance and initializes its fields.
@@ -32,12 +41,26 @@ func NewRunningProxy(targetName, localPort string, pid int, pid2 int, file strin
 	}
 }
 
-func GetRunningProxy(file string) (runningProxy *RunningProxy, err error) {
-	runningProxy = &RunningProxy{File: file}
-	err = helpers.ReadStruct(file, runningProxy)
-	return
+// GetRunningProxy loads the registry at file and returns the entry for targetName.
+// Returns an empty RunningProxy (not an error) when no entry exists.
+func GetRunningProxy(file, targetName string) (*RunningProxy, error) {
+	proxies, err := ListRunningProxies(file)
+	if err != nil {
+		return &RunningProxy{File: file}, err
+	}
+
+	for _, rp := range proxies {
+		if rp.TargetName == targetName {
+			rp.File = file
+			return rp, nil
+		}
+	}
+
+	// Not found — return an empty proxy rather than an error.
+	return &RunningProxy{File: file}, nil
 }
 
+// Store upserts this RunningProxy into the registry file.
 func (r *RunningProxy) Store() error {
 	if r.File == "" {
 		slog.Debug("Running proxy session file path is empty, not saving", "target_name", r.TargetName, "local_port", r.LocalPort, "pid", r.Pid)
@@ -45,20 +68,36 @@ func (r *RunningProxy) Store() error {
 	}
 
 	slog.Debug("Saving running proxy session", "target_name", r.TargetName, "local_port", r.LocalPort, "pid", r.Pid)
-	err := helpers.WriteStruct(r.File, r)
-	if err != nil {
-		slog.Error("Error writing running proxy session file", "file", r.File, "error", err)
-		return fmt.Errorf("error writing running proxy session file: %w", err)
-	}
-	return nil
+
+	return withRegistryLock(r.File, func(f *os.File) error {
+		m, err := loadRegistryFromHandle(f)
+		if err != nil {
+			return err
+		}
+		m[r.TargetName] = r
+		if err := saveRegistryToHandle(f, m); err != nil {
+			slog.Error("Error writing running proxy session to registry", "file", r.File, "error", err)
+			return fmt.Errorf("error writing running proxy session to registry: %w", err)
+		}
+		return nil
+	})
 }
 
+// DeleteFile removes this proxy's entry from the registry.
 func (r *RunningProxy) DeleteFile() error {
-	slog.Debug("Deleting running proxy session file", "file", r.File)
-	if _, err := os.Stat(r.File); os.IsNotExist(err) {
-		return nil // File does not exist, nothing to delete
+	slog.Debug("Removing running proxy entry from registry", "file", r.File, "target_name", r.TargetName)
+	if r.File == "" {
+		return nil
 	}
-	return os.Remove(r.File)
+
+	return withRegistryLock(r.File, func(f *os.File) error {
+		m, err := loadRegistryFromHandle(f)
+		if err != nil {
+			return err
+		}
+		delete(m, r.TargetName)
+		return saveRegistryToHandle(f, m)
+	})
 }
 
 func (r *RunningProxy) KillProcess() error {
@@ -134,35 +173,22 @@ func (r *RunningProxy) Stop() error {
 }
 
 func Preflight(file string, targetName string, localPort string) (existingRunningProxy *RunningProxy, active bool, err error) {
-	// try to read an existing running proxy session file
-	// if error, assume the file does not exist and carry on.
-	existingRunningProxy, err = GetRunningProxy(file)
+	// try to read an existing running proxy session from the registry.
+	// if error, assume the entry does not exist and carry on.
+	existingRunningProxy, err = GetRunningProxy(file, targetName)
 	if err != nil {
 		slog.Debug("Unable to read existing running proxy session", "file", file, "error", err)
 		err = nil // reset error to nil, we will handle the case where no running proxy is found later
 	}
 
-	// file loaded or not, check if the resulting running proxy is actually running.
+	// entry loaded or not, check if the resulting running proxy is actually running.
 	if existingRunningProxy.IsRunning() {
-		slog.Info("A proxy is already listening on the local port, attempting to identify", "local_port", localPort)
-
-		// the proxy is running, if target matches, reuse it.
-		if existingRunningProxy.TargetName == targetName {
-			slog.Info("Found existing proxy session to use",
-				"target_name", existingRunningProxy.TargetName,
-				"local_port", existingRunningProxy.LocalPort,
-				"pid", existingRunningProxy.Pid)
-
-			active = true
-			return
-		}
-
-		// proxy is running, but not for the target we want to use.
-		slog.Error("A proxy is running, but targeting another target",
-			"local_port", localPort,
-			"target_name", targetName,
-			"running_target_name", existingRunningProxy.TargetName)
-		return existingRunningProxy, false, fmt.Errorf("port %s is unavailable for use", localPort)
+		slog.Info("Found existing proxy session to use",
+			"target_name", existingRunningProxy.TargetName,
+			"local_port", existingRunningProxy.LocalPort,
+			"pid", existingRunningProxy.Pid)
+		active = true
+		return
 	}
 
 	// no running proxy is found, one last check to see if the port is open

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -11,12 +11,12 @@ import (
 	"github.com/posit-dev/ptd/lib/helpers"
 )
 
-// WorkloadPort returns a deterministic port in the range [10000, 10999] for
+// WorkloadPort returns a deterministic port in the range [10000, 19999] for
 // the given workload name, derived via FNV-32a.
 func WorkloadPort(name string) int {
 	h := fnv.New32a()
 	h.Write([]byte(name))
-	return 10000 + int(h.Sum32()%1000)
+	return 10000 + int(h.Sum32()%10000)
 }
 
 type RunningProxy struct {
@@ -44,20 +44,27 @@ func NewRunningProxy(targetName, localPort string, pid int, pid2 int, file strin
 // GetRunningProxy loads the registry at file and returns the entry for targetName.
 // Returns an empty RunningProxy (not an error) when no entry exists.
 func GetRunningProxy(file, targetName string) (*RunningProxy, error) {
-	proxies, err := ListRunningProxies(file)
+	var found *RunningProxy
+
+	err := withRegistryReadLock(file, func(f *os.File) error {
+		m, err := loadRegistryFromHandle(f)
+		if err != nil {
+			return err
+		}
+		if rp, ok := m[targetName]; ok {
+			rp.File = file
+			found = rp
+		}
+		return nil
+	})
 	if err != nil {
 		return &RunningProxy{File: file}, err
 	}
 
-	for _, rp := range proxies {
-		if rp.TargetName == targetName {
-			rp.File = file
-			return rp, nil
-		}
+	if found == nil {
+		return &RunningProxy{File: file}, nil
 	}
-
-	// Not found — return an empty proxy rather than an error.
-	return &RunningProxy{File: file}, nil
+	return found, nil
 }
 
 // Store upserts this RunningProxy into the registry file.
@@ -189,6 +196,19 @@ func Preflight(file string, targetName string, localPort string) (existingRunnin
 			"pid", existingRunningProxy.Pid)
 		active = true
 		return
+	}
+
+	// Check for a hash collision: another workload is using this port.
+	allProxies, _ := ListRunningProxies(file)
+	for _, rp := range allProxies {
+		if rp.LocalPort == localPort && rp.TargetName != targetName && rp.IsRunning() {
+			slog.Error("Port collision: another workload is using this port",
+				"local_port", localPort,
+				"target_name", targetName,
+				"colliding_target", rp.TargetName)
+			return existingRunningProxy, false, fmt.Errorf(
+				"port %s is already in use by workload %q (hash collision)", localPort, rp.TargetName)
+		}
 	}
 
 	// no running proxy is found, one last check to see if the port is open

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -49,7 +49,7 @@ func TestRunningProxyStoreAndLoad(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test loading the proxy from file
-	loadedProxy, err := GetRunningProxy(filePath)
+	loadedProxy, err := GetRunningProxy(filePath, "test-target")
 	require.NoError(t, err)
 
 	// Verify the loaded proxy matches the original
@@ -69,31 +69,55 @@ func TestRunningProxyStoreWithEmptyFile(t *testing.T) {
 }
 
 func TestRunningProxyDeleteFile(t *testing.T) {
-	// Create a temporary file for testing
+	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp("", "proxy-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
 	filePath := filepath.Join(tmpDir, "test-proxy.json")
 
-	// Create a test file
-	err = os.WriteFile(filePath, []byte("test"), 0644)
+	// Store a proxy entry into the registry
+	p := NewRunningProxy("test-target", "8080", 12345, 0, filePath)
+	err = p.Store()
 	require.NoError(t, err)
 
-	// Create a proxy with this file
-	proxy := NewRunningProxy("test-target", "8080", 12345, 0, filePath)
+	// Entry should be present
+	loaded, err := GetRunningProxy(filePath, "test-target")
+	require.NoError(t, err)
+	assert.Equal(t, "test-target", loaded.TargetName)
 
-	// Delete the file
-	err = proxy.DeleteFile()
+	// DeleteFile removes the entry from the registry
+	err = p.DeleteFile()
 	assert.NoError(t, err)
 
-	// Verify the file no longer exists
-	_, err = os.Stat(filePath)
-	assert.True(t, os.IsNotExist(err))
+	// Entry should be gone
+	after, err := GetRunningProxy(filePath, "test-target")
+	require.NoError(t, err)
+	assert.Empty(t, after.TargetName, "entry should have been removed from registry")
 
-	// Deleting a non-existent file should not return an error
-	err = proxy.DeleteFile()
+	// Calling DeleteFile again (entry already gone) should not error
+	err = p.DeleteFile()
 	assert.NoError(t, err)
+}
+
+func TestWorkloadPort(t *testing.T) {
+	// Stable: same name always returns the same port
+	port1 := WorkloadPort("my-workload")
+	port2 := WorkloadPort("my-workload")
+	assert.Equal(t, port1, port2, "WorkloadPort should be deterministic")
+
+	// In range [10000, 10999]
+	assert.GreaterOrEqual(t, port1, 10000, "Port should be >= 10000")
+	assert.LessOrEqual(t, port1, 10999, "Port should be <= 10999")
+
+	// Different names produce different ports (at least for these two)
+	portA := WorkloadPort("workload-alpha")
+	portB := WorkloadPort("workload-beta")
+	assert.NotEqual(t, portA, portB, "Different workload names should produce different ports")
+
+	// Range check for another workload
+	assert.GreaterOrEqual(t, portA, 10000)
+	assert.LessOrEqual(t, portA, 10999)
 }
 
 // Note: The following functions are difficult to test without mocking or using real processes

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -106,9 +106,9 @@ func TestWorkloadPort(t *testing.T) {
 	port2 := WorkloadPort("my-workload")
 	assert.Equal(t, port1, port2, "WorkloadPort should be deterministic")
 
-	// In range [10000, 10999]
+	// In range [10000, 19999]
 	assert.GreaterOrEqual(t, port1, 10000, "Port should be >= 10000")
-	assert.LessOrEqual(t, port1, 10999, "Port should be <= 10999")
+	assert.LessOrEqual(t, port1, 19999, "Port should be <= 19999")
 
 	// Different names produce different ports (at least for these two)
 	portA := WorkloadPort("workload-alpha")
@@ -117,7 +117,7 @@ func TestWorkloadPort(t *testing.T) {
 
 	// Range check for another workload
 	assert.GreaterOrEqual(t, portA, 10000)
-	assert.LessOrEqual(t, portA, 10999)
+	assert.LessOrEqual(t, portA, 19999)
 }
 
 // Note: The following functions are difficult to test without mocking or using real processes

--- a/lib/proxy/registry.go
+++ b/lib/proxy/registry.go
@@ -1,0 +1,159 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"syscall"
+)
+
+// withRegistryLock opens the registry file with an exclusive (write) lock
+// and calls fn with the open file handle. The lock is released when fn returns.
+func withRegistryLock(file string, fn func(f *os.File) error) error {
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("opening registry file: %w", err)
+	}
+	defer f.Close()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("locking registry file: %w", err)
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	return fn(f)
+}
+
+// withRegistryReadLock opens the registry file with a shared (read) lock
+// and calls fn with the open file handle. If the file does not exist, fn is
+// called with a nil handle so callers can treat that as an empty registry.
+func withRegistryReadLock(file string, fn func(f *os.File) error) error {
+	f, err := os.OpenFile(file, os.O_RDONLY, 0644)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Registry doesn't exist yet — treat as empty, no lock needed.
+			return fn(nil)
+		}
+		return fmt.Errorf("opening registry file: %w", err)
+	}
+	defer f.Close()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_SH); err != nil {
+		return fmt.Errorf("locking registry file: %w", err)
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	return fn(f)
+}
+
+// loadRegistryFromHandle reads and unmarshals the registry from an open file handle.
+// Returns an empty map if the file is empty or the handle is nil.
+func loadRegistryFromHandle(f *os.File) (map[string]*RunningProxy, error) {
+	m := make(map[string]*RunningProxy)
+	if f == nil {
+		return m, nil
+	}
+
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seeking registry file: %w", err)
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading registry file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return m, nil
+	}
+
+	if err := json.Unmarshal(data, &m); err != nil {
+		// If the file is corrupt, return an empty map rather than failing hard.
+		slog.Warn("Registry file could not be parsed, starting fresh", "error", err)
+		return make(map[string]*RunningProxy), nil
+	}
+
+	return m, nil
+}
+
+// saveRegistryToHandle marshals the registry map and writes it to the open file handle,
+// truncating first to handle shrinkage.
+func saveRegistryToHandle(f *os.File, m map[string]*RunningProxy) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking registry file: %w", err)
+	}
+
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("truncating registry file: %w", err)
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(m); err != nil {
+		return fmt.Errorf("encoding registry: %w", err)
+	}
+
+	return nil
+}
+
+// ListRunningProxies returns all entries currently in the registry.
+func ListRunningProxies(file string) ([]*RunningProxy, error) {
+	var result []*RunningProxy
+
+	err := withRegistryReadLock(file, func(f *os.File) error {
+		m, err := loadRegistryFromHandle(f)
+		if err != nil {
+			return err
+		}
+		for name, rp := range m {
+			rp.File = file
+			rp.TargetName = name // ensure TargetName is set (key mirrors the field)
+			result = append(result, rp)
+		}
+		return nil
+	})
+
+	return result, err
+}
+
+// PruneRegistry removes entries whose processes are no longer running.
+// Returns the list of pruned target names.
+func PruneRegistry(file string) (pruned []string, err error) {
+	err = withRegistryLock(file, func(f *os.File) error {
+		m, err := loadRegistryFromHandle(f)
+		if err != nil {
+			return err
+		}
+
+		for name, rp := range m {
+			rp.File = file
+			if !rp.IsRunning() {
+				delete(m, name)
+				pruned = append(pruned, name)
+				slog.Debug("Pruned stale proxy entry", "target_name", name, "pid", rp.Pid)
+			}
+		}
+
+		return saveRegistryToHandle(f, m)
+	})
+	return pruned, err
+}
+
+// StopAll stops every proxy currently recorded in the registry.
+func StopAll(file string) error {
+	// Load under a read lock so we get a consistent snapshot.
+	proxies, err := ListRunningProxies(file)
+	if err != nil {
+		return fmt.Errorf("listing proxies: %w", err)
+	}
+
+	for _, rp := range proxies {
+		if err := rp.Stop(); err != nil {
+			slog.Error("Error stopping proxy", "target_name", rp.TargetName, "error", err)
+		}
+	}
+
+	return nil
+}

--- a/lib/proxy/registry.go
+++ b/lib/proxy/registry.go
@@ -1,6 +1,9 @@
 package proxy
 
+// Registry file locking uses syscall.Flock which is only available on Linux and macOS.
+
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -79,22 +82,25 @@ func loadRegistryFromHandle(f *os.File) (map[string]*RunningProxy, error) {
 }
 
 // saveRegistryToHandle marshals the registry map and writes it to the open file handle,
-// truncating first to handle shrinkage.
+// truncating first to handle shrinkage. Encoding is done into a buffer first so that
+// a truncate is never followed by a partial write on encoding failure.
 func saveRegistryToHandle(f *os.File, m map[string]*RunningProxy) error {
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seeking registry file: %w", err)
-	}
-
-	if err := f.Truncate(0); err != nil {
-		return fmt.Errorf("truncating registry file: %w", err)
-	}
-
-	enc := json.NewEncoder(f)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(m); err != nil {
 		return fmt.Errorf("encoding registry: %w", err)
 	}
 
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("truncating registry file: %w", err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking registry file: %w", err)
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing registry file: %w", err)
+	}
 	return nil
 }
 

--- a/lib/proxy/registry.go
+++ b/lib/proxy/registry.go
@@ -136,6 +136,11 @@ func PruneRegistry(file string) (pruned []string, err error) {
 		for name, rp := range m {
 			rp.File = file
 			if !rp.IsRunning() {
+				// Kill any surviving processes before removing the entry (e.g. Azure
+				// dual-PID sessions where one process died but the other is still running).
+				if err := rp.KillProcess(); err != nil {
+					slog.Debug("Failed to kill process during prune (may already be gone)", "target_name", name, "error", err)
+				}
 				delete(m, name)
 				pruned = append(pruned, name)
 				slog.Debug("Pruned stale proxy entry", "target_name", name, "pid", rp.Pid)

--- a/lib/proxy/registry_test.go
+++ b/lib/proxy/registry_test.go
@@ -1,0 +1,149 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistryStoreAndList verifies that Store() upserts into the registry
+// and ListRunningProxies() returns all entries.
+func TestRegistryStoreAndList(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "registry-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	registryFile := filepath.Join(tmpDir, "proxies.json")
+
+	p1 := NewRunningProxy("workload-a", "10100", 1001, 0, registryFile)
+	p2 := NewRunningProxy("workload-b", "10200", 1002, 0, registryFile)
+
+	require.NoError(t, p1.Store())
+	require.NoError(t, p2.Store())
+
+	proxies, err := ListRunningProxies(registryFile)
+	require.NoError(t, err)
+	assert.Len(t, proxies, 2)
+
+	// Build a map for easier lookup
+	byName := make(map[string]*RunningProxy)
+	for _, rp := range proxies {
+		byName[rp.TargetName] = rp
+	}
+
+	require.Contains(t, byName, "workload-a")
+	assert.Equal(t, "10100", byName["workload-a"].LocalPort)
+	assert.Equal(t, 1001, byName["workload-a"].Pid)
+
+	require.Contains(t, byName, "workload-b")
+	assert.Equal(t, "10200", byName["workload-b"].LocalPort)
+	assert.Equal(t, 1002, byName["workload-b"].Pid)
+}
+
+// TestRegistryDeleteEntry verifies that DeleteFile() removes only the
+// target's entry, leaving others intact.
+func TestRegistryDeleteEntry(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "registry-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	registryFile := filepath.Join(tmpDir, "proxies.json")
+
+	p1 := NewRunningProxy("keep-me", "10300", 2001, 0, registryFile)
+	p2 := NewRunningProxy("remove-me", "10400", 2002, 0, registryFile)
+
+	require.NoError(t, p1.Store())
+	require.NoError(t, p2.Store())
+
+	// Remove p2
+	require.NoError(t, p2.DeleteFile())
+
+	proxies, err := ListRunningProxies(registryFile)
+	require.NoError(t, err)
+	assert.Len(t, proxies, 1)
+	assert.Equal(t, "keep-me", proxies[0].TargetName)
+}
+
+// TestPruneRegistryRemovesDeadPIDs verifies that PruneRegistry removes
+// entries with PIDs that are no longer running.
+func TestPruneRegistryRemovesDeadPIDs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "registry-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	registryFile := filepath.Join(tmpDir, "proxies.json")
+
+	// PID -1 is never a valid running process
+	dead := NewRunningProxy("dead-workload", "10500", -1, 0, registryFile)
+	// Use the current test process's PID — we definitely own it and it is running.
+	alivePID := os.Getpid()
+	alive := NewRunningProxy("alive-workload", "10600", alivePID, 0, registryFile)
+
+	require.NoError(t, dead.Store())
+	require.NoError(t, alive.Store())
+
+	pruned, err := PruneRegistry(registryFile)
+	require.NoError(t, err)
+	assert.Contains(t, pruned, "dead-workload")
+	assert.NotContains(t, pruned, "alive-workload")
+
+	remaining, err := ListRunningProxies(registryFile)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "alive-workload", remaining[0].TargetName)
+}
+
+// TestListRunningProxiesEmptyRegistry verifies that an empty or nonexistent
+// registry returns an empty slice without error.
+func TestListRunningProxiesEmptyRegistry(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "registry-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	registryFile := filepath.Join(tmpDir, "proxies.json")
+
+	// File does not exist yet
+	proxies, err := ListRunningProxies(registryFile)
+	require.NoError(t, err)
+	assert.Empty(t, proxies)
+}
+
+// TestGetRunningProxyNotFound verifies that GetRunningProxy returns an empty
+// RunningProxy (not an error) when the target is not in the registry.
+func TestGetRunningProxyNotFound(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "registry-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	registryFile := filepath.Join(tmpDir, "proxies.json")
+
+	rp, err := GetRunningProxy(registryFile, "nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, rp.TargetName)
+	assert.Equal(t, registryFile, rp.File)
+}
+
+// TestRegistryUpsertOverwrites verifies that storing the same target twice
+// updates the entry rather than duplicating it.
+func TestRegistryUpsertOverwrites(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "registry-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	registryFile := filepath.Join(tmpDir, "proxies.json")
+
+	p1 := NewRunningProxy("my-workload", "10700", 3001, 0, registryFile)
+	require.NoError(t, p1.Store())
+
+	// Overwrite with a new PID
+	p2 := NewRunningProxy("my-workload", "10700", 3999, 0, registryFile)
+	require.NoError(t, p2.Store())
+
+	proxies, err := ListRunningProxies(registryFile)
+	require.NoError(t, err)
+	assert.Len(t, proxies, 1)
+	assert.Equal(t, 3999, proxies[0].Pid)
+}

--- a/lib/steps/clusters.go
+++ b/lib/steps/clusters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/types"
 )
 
@@ -70,7 +71,7 @@ func (s *ClustersStep) Run(ctx context.Context) error {
 
 	// clusters step always needs proxy for K8s connectivity
 	if !s.DstTarget.TailscaleEnabled() {
-		envVars["ALL_PROXY"] = "socks5://localhost:1080"
+		envVars["ALL_PROXY"] = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 	}
 
 	switch s.DstTarget.CloudProvider() {

--- a/lib/steps/clusters_aws.go
+++ b/lib/steps/clusters_aws.go
@@ -12,6 +12,7 @@ import (
 	"github.com/posit-dev/ptd/lib/aws"
 	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/posit-dev/ptd/lib/proxy"
 	ptdpulumi "github.com/posit-dev/ptd/lib/pulumi"
 	"github.com/posit-dev/ptd/lib/types"
 	awscloudwatch "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
@@ -106,7 +107,7 @@ func (s *ClustersStep) runAWSInlineGo(ctx context.Context, creds types.Credentia
 		}
 		config := kube.BuildEKSKubeConfig(endpoint, caCert, token, clusterName)
 		if !cfg.TailscaleEnabled {
-			config.Clusters[0].Cluster.ProxyURL = "socks5://localhost:1080"
+			config.Clusters[0].Cluster.ProxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
 		data, marshalErr := yaml.Marshal(config)
 		if marshalErr != nil {

--- a/lib/steps/clusters_azure.go
+++ b/lib/steps/clusters_azure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posit-dev/ptd/lib/azure"
 	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/types"
 	azauthorization "github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
 	azmanagedidentity "github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v3"
@@ -80,7 +81,7 @@ func (s *ClustersStep) runAzureInlineGo(ctx context.Context, creds types.Credent
 			return fmt.Errorf("clusters: failed to get AKS kubeconfig for %s: %w", clusterName, err)
 		}
 		if !s.DstTarget.TailscaleEnabled() {
-			kubeconfigBytes, err = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, "socks5://localhost:1080")
+			kubeconfigBytes, err = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name())))
 			if err != nil {
 				return fmt.Errorf("clusters: failed to add proxy to kubeconfig for %s: %w", clusterName, err)
 			}

--- a/lib/steps/helm.go
+++ b/lib/steps/helm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/types"
 )
 
@@ -51,10 +52,8 @@ func (s *HelmStep) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	// helm step always needs proxy for K8s connectivity
 	if !s.DstTarget.TailscaleEnabled() {
-		envVars["ALL_PROXY"] = "socks5://localhost:1080"
+		envVars["ALL_PROXY"] = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 	}
 
 	switch s.DstTarget.CloudProvider() {

--- a/lib/steps/postgres_config.go
+++ b/lib/steps/postgres_config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/posit-dev/ptd/lib/azure"
 	"github.com/posit-dev/ptd/lib/helpers"
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/types"
 )
 
@@ -53,7 +54,7 @@ func (s *PostgresConfigStep) Run(ctx context.Context) error {
 
 	// if the target isn't tailscale enabled, add ALL_PROXY to the env vars
 	if !s.DstTarget.TailscaleEnabled() {
-		envVars["ALL_PROXY"] = "socks5://localhost:1080" // TODO: make this configurable
+		envVars["ALL_PROXY"] = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 	}
 
 	switch s.DstTarget.CloudProvider() {

--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -15,6 +15,7 @@ import (
 	"github.com/posit-dev/ptd/lib/azure"
 	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/kube"
+	"github.com/posit-dev/ptd/lib/proxy"
 	"github.com/posit-dev/ptd/lib/types"
 	pulumiaws "github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/rds"
@@ -129,7 +130,7 @@ func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials,
 		}
 		config := kube.BuildEKSKubeConfigWithExec(endpoint, caCert, clusterName, s.DstTarget.Region())
 		if !cfg.TailscaleEnabled {
-			config.Clusters[0].Cluster.ProxyURL = "socks5://localhost:1080"
+			config.Clusters[0].Cluster.ProxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
 		data, err := yaml.Marshal(config)
 		if err != nil {
@@ -361,7 +362,7 @@ func (s *SitesStep) runAzureInlineGo(ctx context.Context, creds types.Credential
 			return fmt.Errorf("sites: failed to get AKS kubeconfig for %s: %w", clusterName, err)
 		}
 
-		kubeconfigBytes, err = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, "socks5://localhost:1080")
+		kubeconfigBytes, err = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name())))
 		if err != nil {
 			return fmt.Errorf("sites: failed to add proxy to kubeconfig for %s: %w", clusterName, err)
 		}

--- a/python-pulumi/src/ptd/aws_workload.py
+++ b/python-pulumi/src/ptd/aws_workload.py
@@ -799,7 +799,8 @@ class AWSWorkload(ptd.workload.AbstractWorkload):
         )
 
         if not self.cfg.tailscale_enabled:
-            kubeconfig["clusters"][0]["cluster"]["proxy-url"] = "socks5://localhost:1080"
+            proxy_url = os.environ.get("ALL_PROXY", "socks5://localhost:1080")
+            kubeconfig["clusters"][0]["cluster"]["proxy-url"] = proxy_url
         return kubeconfig
 
     def aws_assume_role(self, aws_region: str | None = None) -> ptd.AWSSession:

--- a/python-pulumi/src/ptd/azure_workload.py
+++ b/python-pulumi/src/ptd/azure_workload.py
@@ -252,7 +252,8 @@ class AzureWorkload(ptd.workload.AbstractWorkload):
         kubeconfig = yaml.safe_load(kubeconfig_str)
 
         # assume azure workloads do not support tailscale, enforce socks5 proxy for kube interactions
-        kubeconfig["clusters"][0]["cluster"]["proxy-url"] = "socks5://localhost:1080"
+        proxy_url = os.environ.get("ALL_PROXY", "socks5://localhost:1080")
+        kubeconfig["clusters"][0]["cluster"]["proxy-url"] = proxy_url
 
         # Save kubeconfig to a temporary file to pass to kubelogin command
         with tempfile.NamedTemporaryFile(delete=False) as temp_kubeconfig:

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -3,6 +3,7 @@ import collections
 import dataclasses
 import enum
 import json
+import os
 import re
 import typing
 import warnings
@@ -2709,6 +2710,7 @@ def get_kubeconfig_for_cluster(name, tailscale_enabled, endpoint=None, ca_data=N
     }
 
     if not tailscale_enabled:
-        k["clusters"][0]["cluster"]["proxy-url"] = "socks5://localhost:1080"
+        proxy_url = os.environ.get("ALL_PROXY", "socks5://localhost:1080")
+        k["clusters"][0]["cluster"]["proxy-url"] = proxy_url
 
     return json.dumps(k)


### PR DESCRIPTION
## What

Replaces the single `proxy.json` with a shared `proxies.json` registry so multiple proxy sessions can run concurrently — unblocking parallel `workon`/`ensure` invocations and multi-session Claude usage.

## Changes

**Registry (`lib/proxy/registry.go` — new)**
- `proxies.json` keyed by target name, serialised under `syscall.Flock` (exclusive write, shared read) to avoid concurrent-write corruption
- `ListRunningProxies`, `PruneRegistry`, `StopAll` public API
- `RunningProxy.Store()` / `DeleteFile()` updated to upsert/remove from the registry transparently — no changes needed in `aws/` or `azure/` proxy code

**Deterministic ports (`lib/proxy/proxy.go`)**
- `WorkloadPort(name string) int` — FNV-32a hash of the workload name, range 10000–10999
- `ensure`, `workon`, and `k9s` use `WorkloadPort(t.Name())` automatically
- `ptd proxy <target>` defaults to **1080** for interactive/browser use; `--daemon` uses the deterministic port so it is reused by `ensure`/`workon`

**New CLI surface (`cmd/proxy.go`)**
- `ptd proxy --list` — tabular output with live running/stopped status
- `ptd proxy --prune` — remove stale registry entries (dead PIDs)
- `ptd proxy --stop` (no target) — stop all running proxies
- `ptd proxy port <target>` — print the deterministic port for a workload

## Testing

- New `lib/proxy/registry_test.go`: store/list round-trip, delete, prune dead PIDs, empty registry, upsert overwrite
- Updated `lib/proxy/proxy_test.go`: `WorkloadPort` stability and range, `DeleteFile` registry semantics
- Updated `cmd/proxy_test.go`: new flags and `port` subcommand registration
- All pre-commit hooks pass (format, lint, test-cmd, test-lib)