### PR TITLE
fix: correct Azure Alloy ConfigMap alias and helm chart YAML indentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ The Go CLI communicates the infrastructure path to Python Pulumi stacks via the 
 
 #### Build Commands
 
-- `just build-cmd`: Build command-line tool
+- `just cli`: Build command-line tool
 
 #### Test Commands
 
@@ -120,7 +120,7 @@ Always prefix worktree directories with `ptd-` to avoid collisions with other re
 1. **Build the binary** — each worktree needs its own ptd binary:
    ```bash
    cd ../.worktrees/ptd-<branch-name>
-   just build-cmd
+   just cli
    ```
 2. **direnv** — if direnv is available, copy `envrc.recommended` to `.envrc` in the worktree, then run `direnv allow`. The file uses `source_up` to inherit workspace vars and overrides `PTD` to point to the worktree.
 3. **For agents without direnv** — set env vars explicitly before running `ptd` commands:
@@ -140,7 +140,7 @@ git worktree remove ../.worktrees/ptd-<branch-name>
 
 - **NEVER** use `git checkout -b` for new work — always `git worktree add`
 - **NEVER** put worktrees inside the repo directory — always use `../.worktrees/ptd-<name>`
-- **ALWAYS** rebuild the binary after creating a worktree (`just build-cmd`)
+- **ALWAYS** rebuild the binary after creating a worktree (`just cli`)
 - Branch names: kebab-case, no slashes, no usernames (slashes break worktree directory paths)
 
 ## Monitoring and Alerts

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -287,10 +287,13 @@ func awsHelmDeploy(ctx *pulumi.Context, params awsHelmParams) error {
 }
 
 func helmChartCR(ctx *pulumi.Context, resourceName, metaName, namespace, repo, chart, targetNamespace, version string, valuesContent map[string]interface{}, k8sOpt pulumi.ResourceOption, aliases ...pulumi.ResourceOption) error {
-	valuesYAML, err := yaml.Marshal(valuesContent)
-	if err != nil {
-		return fmt.Errorf("failed to marshal values for %s: %w", resourceName, err)
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if encErr := enc.Encode(valuesContent); encErr != nil {
+		return fmt.Errorf("failed to marshal values for %s: %w", resourceName, encErr)
 	}
+	valuesYAML := buf.String()
 
 	opts := []pulumi.ResourceOption{k8sOpt}
 	opts = append(opts, aliases...)
@@ -299,13 +302,13 @@ func helmChartCR(ctx *pulumi.Context, resourceName, metaName, namespace, repo, c
 		"chart":           pulumi.String(chart),
 		"targetNamespace": pulumi.String(targetNamespace),
 		"version":         pulumi.String(version),
-		"valuesContent":   pulumi.String(string(valuesYAML)),
+		"valuesContent":   pulumi.String(valuesYAML),
 	}
 	if repo != "" {
 		spec["repo"] = pulumi.String(repo)
 	}
 
-	_, err = apiextensions.NewCustomResource(ctx, resourceName, &apiextensions.CustomResourceArgs{
+	_, err := apiextensions.NewCustomResource(ctx, resourceName, &apiextensions.CustomResourceArgs{
 		ApiVersion: pulumi.String("helm.cattle.io/v1"),
 		Kind:       pulumi.String("HelmChart"),
 		Metadata: metav1.ObjectMetaArgs{

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -286,14 +286,22 @@ func awsHelmDeploy(ctx *pulumi.Context, params awsHelmParams) error {
 	return nil
 }
 
-func helmChartCR(ctx *pulumi.Context, resourceName, metaName, namespace, repo, chart, targetNamespace, version string, valuesContent map[string]interface{}, k8sOpt pulumi.ResourceOption, aliases ...pulumi.ResourceOption) error {
+// marshalYAML encodes v as YAML with 2-space indentation (matching Python's yaml.dump default).
+func marshalYAML(v interface{}) (string, error) {
 	var buf strings.Builder
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
-	if encErr := enc.Encode(valuesContent); encErr != nil {
+	if err := enc.Encode(v); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func helmChartCR(ctx *pulumi.Context, resourceName, metaName, namespace, repo, chart, targetNamespace, version string, valuesContent map[string]interface{}, k8sOpt pulumi.ResourceOption, aliases ...pulumi.ResourceOption) error {
+	valuesYAML, encErr := marshalYAML(valuesContent)
+	if encErr != nil {
 		return fmt.Errorf("failed to marshal values for %s: %w", resourceName, encErr)
 	}
-	valuesYAML := buf.String()
 
 	opts := []pulumi.ResourceOption{k8sOpt}
 	opts = append(opts, aliases...)
@@ -1536,7 +1544,6 @@ func isThirdPartyTelemetryEnabled(v *bool) bool {
 	return *v
 }
 
-// mainDomain returns the domain of the first site (sorted by name), or empty string.
 // mainDomain returns the domain of the "main" site, mirroring Python's
 // WorkloadConfig.domain property (self.sites["main"].domain). Falls back to
 // the first site alphabetically for workloads without a "main" site.

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -293,6 +293,8 @@ func awsHelmDeploy(ctx *pulumi.Context, params awsHelmParams) error {
 
 // marshalYAML encodes v as YAML matching Python's yaml.dump default (yaml.v2 sequence behavior,
 // single-quoted boolean strings to avoid yaml.v2 quoting them as "true"/"false").
+// The boolean replacement only matches `: "keyword"` (colon-space-quoted value position), so it
+// cannot misfire on substrings inside longer string values or on YAML keys.
 func marshalYAML(v interface{}) (string, error) {
 	data, err := yamlv2.Marshal(v)
 	if err != nil {

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -1537,7 +1537,13 @@ func isThirdPartyTelemetryEnabled(v *bool) bool {
 }
 
 // mainDomain returns the domain of the first site (sorted by name), or empty string.
+// mainDomain returns the domain of the "main" site, mirroring Python's
+// WorkloadConfig.domain property (self.sites["main"].domain). Falls back to
+// the first site alphabetically for workloads without a "main" site.
 func mainDomain(sites map[string]types.SiteConfig) string {
+	if s, ok := sites["main"]; ok {
+		return s.Spec.Domain
+	}
 	names := helpers.SortedKeys(sites)
 	if len(names) == 0 {
 		return ""

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -19,6 +19,7 @@ import (
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	schedulingv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/scheduling/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	yamlv2 "gopkg.in/yaml.v2"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -286,15 +287,18 @@ func awsHelmDeploy(ctx *pulumi.Context, params awsHelmParams) error {
 	return nil
 }
 
-// marshalYAML encodes v as YAML with 2-space indentation (matching Python's yaml.dump default).
+// marshalYAML encodes v as YAML matching Python's yaml.dump default (yaml.v2 sequence behavior,
+// single-quoted boolean strings to avoid yaml.v2 quoting them as "true"/"false").
 func marshalYAML(v interface{}) (string, error) {
-	var buf strings.Builder
-	enc := yaml.NewEncoder(&buf)
-	enc.SetIndent(2)
-	if err := enc.Encode(v); err != nil {
+	data, err := yamlv2.Marshal(v)
+	if err != nil {
 		return "", err
 	}
-	return buf.String(), nil
+	result := string(data)
+	for _, kw := range []string{"true", "false", "yes", "no", "on", "off"} {
+		result = strings.ReplaceAll(result, fmt.Sprintf(`: "%s"`, kw), fmt.Sprintf(`: '%s'`, kw))
+	}
+	return result, nil
 }
 
 func helmChartCR(ctx *pulumi.Context, resourceName, metaName, namespace, repo, chart, targetNamespace, version string, valuesContent map[string]interface{}, k8sOpt pulumi.ResourceOption, aliases ...pulumi.ResourceOption) error {

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -203,6 +203,10 @@ func awsHelmDeploy(ctx *pulumi.Context, params awsHelmParams) error {
 		k8sProvider, err := kubernetes.NewProvider(ctx, k8sProviderName, &kubernetes.ProviderArgs{
 			Kubeconfig: pulumi.String(params.kubeconfigsByCluster[release]),
 		}, withAlias("pulumi:providers:kubernetes", k8sProviderName),
+			// Also alias for old Python naming: top-level resource with -k8s suffix.
+			pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(fmt.Sprintf(
+				"urn:pulumi:%s::%s::pulumi:providers:kubernetes::%s-k8s",
+				ctx.Stack(), outerProject, k8sProviderName))}}),
 			pulumi.IgnoreChanges([]string{"kubeconfig"}))
 		if err != nil {
 			return fmt.Errorf("helm aws: failed to create k8s provider for %s: %w", release, err)
@@ -1055,7 +1059,11 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 			"config.alloy": pulumi.String(alloyConfigStr),
 		},
 	}, k8sOpt,
-		withNestedAlias("ptd:AlloyConfig", "kubernetes:core/v1:ConfigMap", cmResourceName))
+		withNestedAlias("ptd:AlloyConfig", "kubernetes:core/v1:ConfigMap", cmResourceName),
+		// Also alias without ptd:AWSWorkloadHelm$ prefix for workloads where AlloyConfig was top-level.
+		pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(fmt.Sprintf(
+			"urn:pulumi:%s::%s::ptd:AlloyConfig$kubernetes:core/v1:ConfigMap::%s",
+			ctx.Stack(), ctx.Project(), cmResourceName))}}))
 	if err != nil {
 		return err
 	}
@@ -1071,12 +1079,16 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 			"password": pulumi.String(params.mimirPassword),
 		},
 	}, k8sOpt,
-		// In Python: opts=ResourceOptions(parent=namespace, ...) — so URN path includes Namespace
-		pulumi.Aliases([]pulumi.Alias{{
-			URN: pulumi.URN(fmt.Sprintf(
+		// In Python: opts=ResourceOptions(parent=namespace, ...) — so URN path includes Namespace.
+		// Two variants: with and without ptd:AWSWorkloadHelm$ prefix depending on Python state vintage.
+		pulumi.Aliases([]pulumi.Alias{
+			{URN: pulumi.URN(fmt.Sprintf(
 				"urn:pulumi:%s::%s::ptd:AWSWorkloadHelm$kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
-				ctx.Stack(), "ptd-aws-workload-helm", secretResourceName)),
-		}}),
+				ctx.Stack(), ctx.Project(), secretResourceName))},
+			{URN: pulumi.URN(fmt.Sprintf(
+				"urn:pulumi:%s::%s::kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
+				ctx.Stack(), ctx.Project(), secretResourceName))},
+		}),
 		pulumi.DependsOn([]pulumi.Resource{ns}))
 	if err != nil {
 		return err

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -504,7 +504,7 @@ func awsHelmTraefik(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	}
 
 	chartResourceName := compoundName + "-" + release + "-traefik-helm-release"
-	valuesYAML, err := yaml.Marshal(traefikValues)
+	valuesYAML, err := marshalYAML(traefikValues)
 	if err != nil {
 		return err
 	}
@@ -1062,8 +1062,8 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 		withNestedAlias("ptd:AlloyConfig", "kubernetes:core/v1:ConfigMap", cmResourceName),
 		// Also alias without ptd:AWSWorkloadHelm$ prefix for workloads where AlloyConfig was top-level.
 		pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(fmt.Sprintf(
-			"urn:pulumi:%s::%s::ptd:AlloyConfig$kubernetes:core/v1:ConfigMap::%s",
-			ctx.Stack(), ctx.Project(), cmResourceName))}}))
+			"urn:pulumi:%s::ptd-aws-workload-helm::ptd:AlloyConfig$kubernetes:core/v1:ConfigMap::%s",
+			ctx.Stack(), cmResourceName))}}))
 	if err != nil {
 		return err
 	}
@@ -1083,11 +1083,11 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 		// Two variants: with and without ptd:AWSWorkloadHelm$ prefix depending on Python state vintage.
 		pulumi.Aliases([]pulumi.Alias{
 			{URN: pulumi.URN(fmt.Sprintf(
-				"urn:pulumi:%s::%s::ptd:AWSWorkloadHelm$kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
-				ctx.Stack(), ctx.Project(), secretResourceName))},
+				"urn:pulumi:%s::ptd-aws-workload-helm::ptd:AWSWorkloadHelm$kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
+				ctx.Stack(), secretResourceName))},
 			{URN: pulumi.URN(fmt.Sprintf(
-				"urn:pulumi:%s::%s::kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
-				ctx.Stack(), ctx.Project(), secretResourceName))},
+				"urn:pulumi:%s::ptd-aws-workload-helm::kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
+				ctx.Stack(), secretResourceName))},
 		}),
 		pulumi.DependsOn([]pulumi.Resource{ns}))
 	if err != nil {
@@ -1266,7 +1266,7 @@ func awsHelmKarpenter(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoun
 	}
 
 	chartResourceName := compoundName + "-karpenter-helm-release"
-	valuesYAML, err := yaml.Marshal(values)
+	valuesYAML, err := marshalYAML(values)
 	if err != nil {
 		return err
 	}

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -200,10 +200,11 @@ func azureHelmDeploy(ctx *pulumi.Context, params azureHelmParams) error {
 		return pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(oldURN)}})
 	}
 
-	// withNestedAlias returns an alias for resources nested under a Python ComponentResource
-	// (e.g. AlloyConfig), where the parent chain is AzureWorkloadHelm$parentType$resourceType.
+	// withNestedAlias returns an alias for resources nested under a root-level Python ComponentResource.
+	// AlloyConfig was instantiated without a parent, so its children's URNs are just
+	// parentType$resourceType (NOT AzureWorkloadHelm$parentType$...).
 	withNestedAlias := func(parentType, resourceType, resourceName string) pulumi.ResourceOption {
-		oldURN := fmt.Sprintf("urn:pulumi:%s::%s::ptd:AzureWorkloadHelm$%s$%s::%s",
+		oldURN := fmt.Sprintf("urn:pulumi:%s::%s::%s$%s::%s",
 			ctx.Stack(), outerProject, parentType, resourceType, resourceName)
 		return pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(oldURN)}})
 	}

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -202,9 +202,9 @@ func azureHelmDeploy(ctx *pulumi.Context, params azureHelmParams) error {
 	// withNestedAlias returns an alias for resources nested under a root-level Python ComponentResource.
 	// AlloyConfig was instantiated without a parent, so its children's URNs are just
 	// parentType$resourceType (NOT AzureWorkloadHelm$parentType$...).
-	withNestedAlias := func(parentType, resourceType, resourceName string) pulumi.ResourceOption {
+	withNestedAlias := func(innerParentType, resourceType, resourceName string) pulumi.ResourceOption {
 		oldURN := fmt.Sprintf("urn:pulumi:%s::%s::%s$%s::%s",
-			ctx.Stack(), outerProject, parentType, resourceType, resourceName)
+			ctx.Stack(), outerProject, innerParentType, resourceType, resourceName)
 		return pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(oldURN)}})
 	}
 
@@ -459,17 +459,16 @@ func azureHelmExternalDNS(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, com
 	}
 
 	// azure.json config secret.
-	azureConfig := map[string]interface{}{
-		"tenantId":                     params.tenantID,
-		"subscriptionId":               params.subscriptionID,
-		"resourceGroup":                params.resourceGroupName,
-		"useWorkloadIdentityExtension": true,
-	}
-	azureConfigJSON, jsonErr := json.Marshal(azureConfig)
-	if jsonErr != nil {
-		return fmt.Errorf("helm azure: failed to marshal azure.json for external-dns: %w", jsonErr)
-	}
-	azureConfigB64 := base64.StdEncoding.EncodeToString(azureConfigJSON)
+	// Use fmt.Sprintf + per-field json.Marshal to match Python's json.dumps format
+	// (spaces after ":" and ",", insertion-ordered keys).
+	tenantIDJSON, _ := json.Marshal(params.tenantID)
+	subscriptionIDJSON, _ := json.Marshal(params.subscriptionID)
+	resourceGroupJSON, _ := json.Marshal(params.resourceGroupName)
+	azureConfigStr := fmt.Sprintf(
+		`{"tenantId": %s, "subscriptionId": %s, "resourceGroup": %s, "useWorkloadIdentityExtension": true}`,
+		tenantIDJSON, subscriptionIDJSON, resourceGroupJSON,
+	)
+	azureConfigB64 := base64.StdEncoding.EncodeToString([]byte(azureConfigStr))
 
 	secretResourceName := compoundName + "-" + release + "-external-dns-secret"
 	_, err = corev1.NewSecret(ctx, secretResourceName, &corev1.SecretArgs{
@@ -842,7 +841,7 @@ func azureHelmGrafana(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoun
 			"serve_from_sub_path": false,
 		},
 		"database": map[string]interface{}{
-			"url":      "${PTD_DATABASE_URL}",
+			"url":      `${{ "{" }}PTD_DATABASE_URL{{ "}" }}`,
 			"ssl_mode": "require",
 		},
 	}

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -461,9 +461,18 @@ func azureHelmExternalDNS(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, com
 	// azure.json config secret.
 	// Use fmt.Sprintf + per-field json.Marshal to match Python's json.dumps format
 	// (spaces after ":" and ",", insertion-ordered keys).
-	tenantIDJSON, _ := json.Marshal(params.tenantID)
-	subscriptionIDJSON, _ := json.Marshal(params.subscriptionID)
-	resourceGroupJSON, _ := json.Marshal(params.resourceGroupName)
+	tenantIDJSON, err := json.Marshal(params.tenantID)
+	if err != nil {
+		return fmt.Errorf("helm azure: failed to marshal tenantID: %w", err)
+	}
+	subscriptionIDJSON, err := json.Marshal(params.subscriptionID)
+	if err != nil {
+		return fmt.Errorf("helm azure: failed to marshal subscriptionID: %w", err)
+	}
+	resourceGroupJSON, err := json.Marshal(params.resourceGroupName)
+	if err != nil {
+		return fmt.Errorf("helm azure: failed to marshal resourceGroupName: %w", err)
+	}
 	azureConfigStr := fmt.Sprintf(
 		`{"tenantId": %s, "subscriptionId": %s, "resourceGroup": %s, "useWorkloadIdentityExtension": true}`,
 		tenantIDJSON, subscriptionIDJSON, resourceGroupJSON,

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -19,7 +19,6 @@ import (
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // Role UUIDs used by Azure helm resources (not already in clusters.go constants).
@@ -536,11 +535,7 @@ func azureHelmExternalDNS(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, com
 				},
 			},
 		}
-		data, marshalErr := yaml.Marshal(v)
-		if marshalErr != nil {
-			return "", marshalErr
-		}
-		return string(data), nil
+		return marshalYAML(v)
 	}).(pulumi.StringOutput)
 
 	_, err = apiextensions.NewCustomResource(ctx, chartResourceName, &apiextensions.CustomResourceArgs{
@@ -668,11 +663,7 @@ func azureHelmLoki(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNa
 			},
 			"test": map[string]interface{}{"enabled": false},
 		}
-		data, marshalErr := yaml.Marshal(v)
-		if marshalErr != nil {
-			return "", marshalErr
-		}
-		return string(data), nil
+		return marshalYAML(v)
 	}).(pulumi.StringOutput)
 
 	_, err = apiextensions.NewCustomResource(ctx, chartResourceName, &apiextensions.CustomResourceArgs{
@@ -780,11 +771,7 @@ func azureHelmMimir(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 			},
 			"nginx": map[string]interface{}{"enabled": false},
 		}
-		data, marshalErr := yaml.Marshal(v)
-		if marshalErr != nil {
-			return "", marshalErr
-		}
-		return string(data), nil
+		return marshalYAML(v)
 	}).(pulumi.StringOutput)
 
 	_, err = apiextensions.NewCustomResource(ctx, chartResourceName, &apiextensions.CustomResourceArgs{
@@ -1070,11 +1057,7 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 				"hosts":    []interface{}{fmt.Sprintf("faro.%s", domain)},
 			},
 		}
-		data, marshalErr := yaml.Marshal(v)
-		if marshalErr != nil {
-			return "", marshalErr
-		}
-		return string(data), nil
+		return marshalYAML(v)
 	}).(pulumi.StringOutput)
 
 	_, err = apiextensions.NewCustomResource(ctx, chartResourceName, &apiextensions.CustomResourceArgs{

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -850,6 +850,10 @@ func azureHelmGrafana(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoun
 			"serve_from_sub_path": false,
 		},
 		"database": map[string]interface{}{
+			// Go template escaping produces the literal string ${PTD_DATABASE_URL}, matching
+			// Python's output. Grafana ini supports ${VAR} for environment variable expansion.
+			// AWS uses the plain string directly; Azure differs because the Helm values pass
+			// through an additional template rendering step in the HelmChart CR controller.
 			"url":      `${{ "{" }}PTD_DATABASE_URL{{ "}" }}`,
 			"ssl_mode": "require",
 		},

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -200,6 +200,14 @@ func azureHelmDeploy(ctx *pulumi.Context, params azureHelmParams) error {
 		return pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(oldURN)}})
 	}
 
+	// withNestedAlias returns an alias for resources nested under a Python ComponentResource
+	// (e.g. AlloyConfig), where the parent chain is AzureWorkloadHelm$parentType$resourceType.
+	withNestedAlias := func(parentType, resourceType, resourceName string) pulumi.ResourceOption {
+		oldURN := fmt.Sprintf("urn:pulumi:%s::%s::ptd:AzureWorkloadHelm$%s$%s::%s",
+			ctx.Stack(), outerProject, parentType, resourceType, resourceName)
+		return pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(oldURN)}})
+	}
+
 	releases := helpers.SortedKeys(params.cfg.Clusters)
 
 	for _, release := range releases {
@@ -239,7 +247,7 @@ func azureHelmDeploy(ctx *pulumi.Context, params azureHelmParams) error {
 		}
 
 		// 5. Alloy
-		if err := azureHelmAlloy(ctx, k8sOpt, name, release, params, oidcIssuerURL, resolved.AlloyVersion, withAlias); err != nil {
+		if err := azureHelmAlloy(ctx, k8sOpt, name, release, params, oidcIssuerURL, resolved.AlloyVersion, withAlias, withNestedAlias); err != nil {
 			return err
 		}
 
@@ -909,7 +917,8 @@ func azureHelmGrafana(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoun
 
 func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundName, release string,
 	params azureHelmParams, oidcIssuerURL, version string,
-	withAlias func(string, string) pulumi.ResourceOption) error {
+	withAlias func(string, string) pulumi.ResourceOption,
+	withNestedAlias func(string, string, string) pulumi.ResourceOption) error {
 
 	identity, err := azureHelmAlloyMonitoringIdentity(ctx, compoundName, release, params, oidcIssuerURL, withAlias)
 	if err != nil {
@@ -952,7 +961,8 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	}
 	alloyConfigStr := buildAlloyConfig(alloyP)
 
-	// ConfigMap for Alloy (Python used resource name "alloy-config").
+	// ConfigMap for Alloy. Python named the AlloyConfig component "alloy-config" and the ConfigMap
+	// was a child of that component, so its URN uses the nested AlloyConfig parent type.
 	cmResourceName := compoundName + "-" + release + "-alloy-config-configmap"
 	_, err = corev1.NewConfigMap(ctx, cmResourceName, &corev1.ConfigMapArgs{
 		Metadata: metav1.ObjectMetaArgs{
@@ -962,7 +972,7 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 		Data: pulumi.StringMap{
 			"config.alloy": pulumi.String(alloyConfigStr),
 		},
-	}, k8sOpt, withAlias("kubernetes:core/v1:ConfigMap", cmResourceName),
+	}, k8sOpt, withNestedAlias("ptd:AlloyConfig", "kubernetes:core/v1:ConfigMap", "alloy-config-configmap"),
 		pulumi.DependsOn([]pulumi.Resource{ns}))
 	if err != nil {
 		return fmt.Errorf("helm azure: failed to create alloy configmap for %s: %w", release, err)


### PR DESCRIPTION
## Summary

This PR fixes a collection of alias and YAML serialization bugs that caused spurious diffs and resource churn when running the Go helm step against workloads migrated from Python Pulumi state.

### Pulumi alias fixes (Azure)

The Python `AlloyConfig` component was instantiated without a `parent=` argument, so its children's URNs take the form `ptd:AlloyConfig$kubernetes:core/v1:ConfigMap::alloy-config-configmap` — not `ptd:AzureWorkloadHelm$ptd:AlloyConfig$...` as the Go code originally assumed. Without this fix, every Azure helm run creates a new ConfigMap and deletes the old one.

### Pulumi alias fixes (AWS)

Python state varies in structure across workloads depending on when they were created:

- **k8s provider**: Python named it `{name}-{release}-k8s` as a top-level resource. The Go alias was looking for it under `ptd:AWSWorkloadHelm$`, causing a new orphan provider to be created on every run while HelmCharts remained bound to the old one.
- **Alloy ConfigMap**: In some workloads `AlloyConfig` was top-level (not nested under `AWSWorkloadHelm`), requiring a second alias variant without the `AWSWorkloadHelm$` prefix.
- **mimir-auth Secret**: Similarly, some workloads had the Secret parented directly under `Namespace` without the `AWSWorkloadHelm$` wrapper.

Each of these is fixed by registering dual aliases covering both Python state variants.

### YAML serialization

`marshalYAML` was using `gopkg.in/yaml.v3` which produces different sequence indentation than Python's `yaml.dump`. Switched to `gopkg.in/yaml.v2` which matches Python's output exactly, eliminating spurious helm chart value diffs on every run.

Additional formatting fixes:
- ExternalDNS `azure.json` secret: use `fmt.Sprintf` + per-field `json.Marshal` to match Python's `json.dumps` key order and spacing
- Grafana database URL: escape `${...}` syntax correctly for Grafana ini interpolation
- `mainDomain`: use the site named `"main"` explicitly rather than the first alphabetically, matching Python's `self.sites["main"].domain` behavior

## Test plan

- [x] Azure staging workload — 29 unchanged after apply, 0 diffs on re-run
- [x] AWS staging workloads — alias fixes confirmed via dry-run; one-time transition on first apply, clean on re-run
- [x] Alloy pods stable after ConfigMap replace (hot-reloads from mounted volume, no restart)