### PR TITLE
fix: enable NFD and disable MPS in NVIDIA device plugin chart

### DIFF
--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -1122,7 +1122,10 @@ func azureHelmNvidiaDevicePlugin(ctx *pulumi.Context, k8sOpt pulumi.ResourceOpti
 		"https://nvidia.github.io/k8s-device-plugin",
 		"nvidia-device-plugin",
 		helmNvidiaNamespace,
-		version, map[string]interface{}{}, k8sOpt,
+		version, map[string]interface{}{
+			"nfd": map[string]interface{}{"enabled": true},
+			"mps": map[string]interface{}{"enabled": false},
+		}, k8sOpt,
 		withAlias("kubernetes:helm.cattle.io/v1:HelmChart", resourceName),
 		pulumi.DependsOn([]pulumi.Resource{ns}))
 }


### PR DESCRIPTION
# Description

Enables NFD (required for GPU node discovery) and disables MPS (unused) in the NVIDIA device plugin helm chart values. Without NFD enabled, the device plugin DaemonSet had no nodes to schedule on.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about