### PR TITLE
Add sample_age_limit to Alloy remote_write queue config

### DIFF
--- a/lib/steps/helm_helpers.go
+++ b/lib/steps/helm_helpers.go
@@ -116,6 +116,9 @@ func buildAlloyConfig(params alloyConfigParams) string {
         headers = {
             "X-Scope-OrgID" = "%s",
         }
+        queue_config {
+            sample_age_limit = "5m"
+        }
     }
 }
 `, tenantName, controlRoomURL, params.compoundName, params.accountIDOrTenantID)
@@ -254,6 +257,9 @@ prometheus.remote_write "workload" {
     }
     endpoint {
         url = "%s"
+        queue_config {
+            sample_age_limit = "5m"
+        }
     }
 }
 


### PR DESCRIPTION
# Description

When Mimir ingesters temporarily slow down (due to compaction, S3 latency, or resource pressure), Alloy buffers metric samples and retries them indefinitely. By the time the retries reach Mimir, newer samples from the same series have already been ingested, so Mimir rejects the stale ones as out-of-order (`err-mimir-sample-out-of-order`). The retry volume creates a cascading failure: Traefik gets overwhelmed by slow/stuck connections, its liveness probe times out, K8s kills it, which cancels more in-flight pushes, generating even more stale retries.

Setting `sample_age_limit = 5m` on both `prometheus.remote_write` endpoints (control room and workload) causes Alloy to silently drop samples older than 5 minutes from its WAL before attempting to send them. This breaks the retry storm cycle while still allowing normal scrape/send delays.

## Code Flow

`buildAlloyConfig()` in `helm_helpers.go` generates the Alloy River config. This adds a `queue_config` block with `sample_age_limit` to both the `control_room` and `workload` `prometheus.remote_write` endpoint blocks. Requires Alloy v1.5+ (all workloads are on v1.7.5).

Takes effect on next `ptd ensure <target> --only-steps helm` for each workload.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about