### PR TITLE
fix: allow AKS node pools with initial_count of 0

### DIFF
--- a/lib/azure/validation.go
+++ b/lib/azure/validation.go
@@ -64,11 +64,6 @@ func ValidateUserNodePoolConfig(pool types.AzureUserNodePoolConfig) error {
 		initialCount = *pool.InitialCount
 	}
 
-	// Azure requires at least 1 node when creating a pool
-	if initialCount < 1 {
-		return fmt.Errorf("pool %s: initial_count must be at least 1 (defaults to min_count if not specified), got %d", pool.Name, initialCount)
-	}
-
 	// Validate initial count is within range
 	if initialCount < pool.MinCount || initialCount > pool.MaxCount {
 		return fmt.Errorf("pool %s: initial_count (%d) must be between min_count (%d) and max_count (%d)", pool.Name, initialCount, pool.MinCount, pool.MaxCount)

--- a/lib/azure/validation_test.go
+++ b/lib/azure/validation_test.go
@@ -181,7 +181,7 @@ func TestValidateUserNodePoolConfig(t *testing.T) {
 			errorMsg:    "min_count (10) must be <= max_count (5)",
 		},
 		{
-			name: "invalid initial count too low",
+			name: "valid initial count of 0 with min_count 0",
 			poolConfig: types.AzureUserNodePoolConfig{
 				Name:              "general",
 				VMSize:            "Standard_D8s_v6",
@@ -190,8 +190,7 @@ func TestValidateUserNodePoolConfig(t *testing.T) {
 				InitialCount:      func() *int { i := 0; return &i }(),
 				EnableAutoScaling: true,
 			},
-			expectError: true,
-			errorMsg:    "initial_count must be at least 1",
+			expectError: false,
 		},
 		{
 			name: "invalid initial count below min",


### PR DESCRIPTION
# Description

Remove the validation that required `initial_count` to be at least 1 for AKS user node pools. AKS supports scale-to-zero when autoscaling is enabled, so pools with `min_count: 0` and no explicit `initial_count` should be valid.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about