### PR TITLE
fix: stable exec-plugin kubeconfigs and proxy ports for AWS and Azure steps

### DIFF
--- a/lib/kube/config.go
+++ b/lib/kube/config.go
@@ -169,6 +169,64 @@ func WriteKubeConfig(config KubeConfig, filePath string) error {
 	return nil
 }
 
+// BuildAKSKubeconfigString converts the raw AKS kubeconfig from GetKubeCredentials
+// into a stable form suitable for Pulumi state. Azure returns a kubeconfig whose
+// exec plugin uses --login devicecode (interactive), which fails in Pulumi subprocesses
+// when no token is cached — device code flow requires a TTY. PTD uses --login azurecli
+// instead: the Pulumi subprocess environment sets NO_PROXY=.microsoftonline.com so
+// Azure CLI token refresh works, and the kubeconfig is identical on every run (no
+// cluster-specific IDs in the args), making it stable in Pulumi state without
+// IgnoreChanges. Pass empty proxyURL to omit the proxy (e.g. when Tailscale is enabled).
+func BuildAKSKubeconfigString(data []byte, proxyURL string) (string, error) {
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return "", fmt.Errorf("failed to parse AKS kubeconfig: %w", err)
+	}
+
+	if proxyURL != "" {
+		if clusters, ok := config["clusters"].([]interface{}); ok {
+			for _, cluster := range clusters {
+				if clusterMap, ok := cluster.(map[interface{}]interface{}); ok {
+					if clusterInfo, ok := clusterMap["cluster"].(map[interface{}]interface{}); ok {
+						clusterInfo["proxy-url"] = proxyURL
+					}
+				}
+			}
+		}
+	}
+
+	// Replace --login devicecode with --login azurecli in the exec args so the
+	// kubeconfig works non-interactively in the Pulumi subprocess. devicecode requires
+	// a TTY for the device code flow when no token is cached. azurecli uses the Azure
+	// CLI's cached credentials via `az account get-access-token --resource <server-id>`,
+	// which works non-interactively (microsoftonline.com is in NO_PROXY). All other
+	// args (--server-id, --tenant-id, etc.) are preserved unchanged.
+	if users, ok := config["users"].([]interface{}); ok {
+		for _, user := range users {
+			if userMap, ok := user.(map[interface{}]interface{}); ok {
+				if userInfo, ok := userMap["user"].(map[interface{}]interface{}); ok {
+					if exec, ok := userInfo["exec"].(map[interface{}]interface{}); ok {
+						if args, ok := exec["args"].([]interface{}); ok {
+							for i, arg := range args {
+								if arg == "--login" && i+1 < len(args) {
+									args[i+1] = "azurecli"
+									break
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	modified, err := yaml.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal AKS kubeconfig: %w", err)
+	}
+	return string(modified), nil
+}
+
 // AddProxyToKubeConfig reads existing kubeconfig, adds proxy-url to all clusters, writes back
 func AddProxyToKubeConfig(filePath string, proxyURL string) error {
 	content, err := os.ReadFile(filePath)

--- a/lib/kube/config.go
+++ b/lib/kube/config.go
@@ -140,6 +140,21 @@ func BuildEKSKubeConfigWithExec(endpoint, caCert, clusterName, region string) Ku
 	}
 }
 
+// BuildEKSKubeconfigString builds an exec-plugin kubeconfig for an EKS cluster,
+// optionally setting a SOCKS proxy URL, and returns it as a YAML string. Pass
+// an empty proxyURL to omit the proxy (e.g. when Tailscale is enabled).
+func BuildEKSKubeconfigString(endpoint, caCert, clusterName, region, proxyURL string) (string, error) {
+	config := BuildEKSKubeConfigWithExec(endpoint, caCert, clusterName, region)
+	if proxyURL != "" {
+		config.Clusters[0].Cluster.ProxyURL = proxyURL
+	}
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal kubeconfig for %s: %w", clusterName, err)
+	}
+	return string(data), nil
+}
+
 // WriteKubeConfig marshals to YAML and writes to file with 0600 permissions
 func WriteKubeConfig(config KubeConfig, filePath string) error {
 	data, err := yaml.Marshal(config)

--- a/lib/steps/clusters_aws.go
+++ b/lib/steps/clusters_aws.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/spf13/viper"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // --- AWS ---
@@ -101,19 +100,15 @@ func (s *ClustersStep) runAWSInlineGo(ctx context.Context, creds types.Credentia
 		if clusterErr != nil {
 			return fmt.Errorf("clusters: failed to get cluster info for %s: %w", clusterName, clusterErr)
 		}
-		token, clusterErr := aws.GetEKSToken(ctx, awsCreds, s.DstTarget.Region(), clusterName)
-		if clusterErr != nil {
-			return fmt.Errorf("clusters: failed to get EKS token for %s: %w", clusterName, clusterErr)
-		}
-		config := kube.BuildEKSKubeConfig(endpoint, caCert, token, clusterName)
+		proxyURL := ""
 		if !cfg.TailscaleEnabled {
-			config.Clusters[0].Cluster.ProxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
+			proxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
-		data, marshalErr := yaml.Marshal(config)
-		if marshalErr != nil {
-			return fmt.Errorf("clusters: failed to marshal kubeconfig for %s: %w", clusterName, marshalErr)
+		kubeconfig, clusterErr := kube.BuildEKSKubeconfigString(endpoint, caCert, clusterName, s.DstTarget.Region(), proxyURL)
+		if clusterErr != nil {
+			return fmt.Errorf("clusters: %w", clusterErr)
 		}
-		kubeconfigsByCluster[release] = string(data)
+		kubeconfigsByCluster[release] = kubeconfig
 
 		// Store the live OIDC issuer URL for this cluster (used by Karpenter controller role creation).
 		// Prefer the live URL from the cluster over the one in the config.
@@ -282,7 +277,7 @@ func awsClustersDeploy(ctx *pulumi.Context, _ types.Target, params awsClustersPa
 		k8sProviderName := name + "-" + release + "-k8s"
 		k8sProvider, err := kubernetes.NewProvider(ctx, k8sProviderName, &kubernetes.ProviderArgs{
 			Kubeconfig: pulumi.String(params.kubeconfigsByCluster[release]),
-		}, withAlias(), pulumi.IgnoreChanges([]string{"kubeconfig"}))
+		}, withAlias())
 		if err != nil {
 			return fmt.Errorf("clusters: failed to create K8s provider for %s: %w", release, err)
 		}

--- a/lib/steps/clusters_azure.go
+++ b/lib/steps/clusters_azure.go
@@ -80,13 +80,15 @@ func (s *ClustersStep) runAzureInlineGo(ctx context.Context, creds types.Credent
 		if err != nil {
 			return fmt.Errorf("clusters: failed to get AKS kubeconfig for %s: %w", clusterName, err)
 		}
+		proxyURL := ""
 		if !s.DstTarget.TailscaleEnabled() {
-			kubeconfigBytes, err = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name())))
-			if err != nil {
-				return fmt.Errorf("clusters: failed to add proxy to kubeconfig for %s: %w", clusterName, err)
-			}
+			proxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
-		kubeconfigsByCluster[release] = string(kubeconfigBytes)
+		kubeconfig, err := kube.BuildAKSKubeconfigString(kubeconfigBytes, proxyURL)
+		if err != nil {
+			return fmt.Errorf("clusters: %w", err)
+		}
+		kubeconfigsByCluster[release] = kubeconfig
 
 		identityInfo, err := azure.GetClusterIdentityInfo(
 			ctx, azCreds, azTarget.SubscriptionID(), azTarget.ResourceGroupName(), clusterName,
@@ -187,7 +189,7 @@ func azureClustersDeploy(ctx *pulumi.Context, _ types.Target, params azureCluste
 		k8sProviderName := name + "-" + release
 		k8sProvider, err := kubernetes.NewProvider(ctx, k8sProviderName, &kubernetes.ProviderArgs{
 			Kubeconfig: pulumi.String(params.kubeconfigsByCluster[release]),
-		}, withAlias(), pulumi.IgnoreChanges([]string{"kubeconfig"}))
+		}, withAlias())
 		if err != nil {
 			return fmt.Errorf("clusters: failed to create K8s provider for %s: %w", release, err)
 		}

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -21,7 +21,6 @@ import (
 	schedulingv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/scheduling/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	yamlv2 "gopkg.in/yaml.v2"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // --- AWS ---
@@ -64,7 +63,7 @@ func (s *HelmStep) runAWSInlineGo(ctx context.Context, creds types.Credentials, 
 		return err
 	}
 
-	// Build per-cluster kubeconfigs
+	// Build per-cluster kubeconfigs using exec credential plugin (no embedded token).
 	kubeconfigsByCluster := make(map[string]string, len(cfg.Clusters))
 	for release := range cfg.Clusters {
 		clusterName := s.DstTarget.Name() + "-" + release
@@ -72,19 +71,15 @@ func (s *HelmStep) runAWSInlineGo(ctx context.Context, creds types.Credentials, 
 		if clusterErr != nil {
 			return fmt.Errorf("helm: failed to get cluster info for %s: %w", clusterName, clusterErr)
 		}
-		token, clusterErr := aws.GetEKSToken(ctx, awsCreds, s.DstTarget.Region(), clusterName)
-		if clusterErr != nil {
-			return fmt.Errorf("helm: failed to get EKS token for %s: %w", clusterName, clusterErr)
-		}
-		config := kube.BuildEKSKubeConfig(endpoint, caCert, token, clusterName)
+		proxyURL := ""
 		if !cfg.TailscaleEnabled {
-			config.Clusters[0].Cluster.ProxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
+			proxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
-		data, marshalErr := yaml.Marshal(config)
-		if marshalErr != nil {
-			return fmt.Errorf("helm: failed to marshal kubeconfig for %s: %w", clusterName, marshalErr)
+		kubeconfig, clusterErr := kube.BuildEKSKubeconfigString(endpoint, caCert, clusterName, s.DstTarget.Region(), proxyURL)
+		if clusterErr != nil {
+			return fmt.Errorf("helm: %w", clusterErr)
 		}
-		kubeconfigsByCluster[release] = string(data)
+		kubeconfigsByCluster[release] = kubeconfig
 	}
 
 	// Fetch cert_arns from persistent stack outputs
@@ -256,8 +251,7 @@ func awsHelmDeploy(ctx *pulumi.Context, params awsHelmParams) error {
 			// Also alias for old Python naming: top-level resource with -k8s suffix.
 			pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(fmt.Sprintf(
 				"urn:pulumi:%s::%s::pulumi:providers:kubernetes::%s-k8s",
-				ctx.Stack(), outerProject, k8sProviderName))}}),
-			pulumi.IgnoreChanges([]string{"kubeconfig"}))
+				ctx.Stack(), outerProject, k8sProviderName))}}))
 		if err != nil {
 			return fmt.Errorf("helm aws: failed to create k8s provider for %s: %w", release, err)
 		}

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -87,13 +87,15 @@ func (s *HelmStep) runAzureInlineGo(ctx context.Context, creds types.Credentials
 		if clusterErr != nil {
 			return fmt.Errorf("helm azure: failed to get AKS kubeconfig for %s: %w", clusterName, clusterErr)
 		}
+		proxyURL := ""
 		if !s.DstTarget.TailscaleEnabled() {
-			kubeconfigBytes, clusterErr = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name())))
-			if clusterErr != nil {
-				return fmt.Errorf("helm azure: failed to add proxy to kubeconfig for %s: %w", clusterName, clusterErr)
-			}
+			proxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
-		kubeconfigsByCluster[release] = string(kubeconfigBytes)
+		kubeconfig, clusterErr := kube.BuildAKSKubeconfigString(kubeconfigBytes, proxyURL)
+		if clusterErr != nil {
+			return fmt.Errorf("helm azure: %w", clusterErr)
+		}
+		kubeconfigsByCluster[release] = kubeconfig
 
 		identityInfo, clusterErr := azure.GetClusterIdentityInfo(
 			ctx, azCreds, azureTarget.SubscriptionID(), azureTarget.ResourceGroupName(), clusterName,
@@ -218,8 +220,7 @@ func azureHelmDeploy(ctx *pulumi.Context, params azureHelmParams) error {
 		k8sProviderName := name + "-" + release
 		k8sProvider, err := kubernetes.NewProvider(ctx, k8sProviderName, &kubernetes.ProviderArgs{
 			Kubeconfig: pulumi.String(params.kubeconfigsByCluster[release]),
-		}, withAlias("pulumi:providers:kubernetes", k8sProviderName),
-			pulumi.IgnoreChanges([]string{"kubeconfig"}))
+		}, withAlias("pulumi:providers:kubernetes", k8sProviderName))
 		if err != nil {
 			return fmt.Errorf("helm azure: failed to create k8s provider for %s: %w", release, err)
 		}

--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -357,12 +357,11 @@ func (s *SitesStep) runAzureInlineGo(ctx context.Context, creds types.Credential
 		if err != nil {
 			return fmt.Errorf("sites: failed to get AKS kubeconfig for %s: %w", clusterName, err)
 		}
-
-		kubeconfigBytes, err = kube.AddProxyToKubeConfigBytes(kubeconfigBytes, fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name())))
+		kubeconfig, err := kube.BuildAKSKubeconfigString(kubeconfigBytes, fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name())))
 		if err != nil {
-			return fmt.Errorf("sites: failed to add proxy to kubeconfig for %s: %w", clusterName, err)
+			return fmt.Errorf("sites: %w", err)
 		}
-		kubeconfigsByRelease[release] = string(kubeconfigBytes)
+		kubeconfigsByRelease[release] = kubeconfig
 	}
 
 	ppmSize := cfg.PpmFileShareSizeGib

--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -117,10 +117,6 @@ func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials,
 		return fmt.Errorf("sites: failed to parse workload secret: %w", err)
 	}
 
-	// Build kubeconfig per release using the exec credential plugin so no token
-	// is embedded. The kubeconfig is stable across runs — no Pulumi state diff
-	// on token rotation. The AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN env vars
-	// set by prepareEnvVarsForPulumi are inherited by the aws subprocess.
 	kubeconfigsByRelease := make(map[string]string, len(cfg.Clusters))
 	for release := range cfg.Clusters {
 		clusterName := s.DstTarget.Name() + "-" + release
@@ -128,15 +124,15 @@ func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials,
 		if err != nil {
 			return fmt.Errorf("sites: failed to get cluster info for %s: %w", clusterName, err)
 		}
-		config := kube.BuildEKSKubeConfigWithExec(endpoint, caCert, clusterName, s.DstTarget.Region())
+		proxyURL := ""
 		if !cfg.TailscaleEnabled {
-			config.Clusters[0].Cluster.ProxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
+			proxyURL = fmt.Sprintf("socks5://localhost:%d", proxy.WorkloadPort(s.DstTarget.Name()))
 		}
-		data, err := yaml.Marshal(config)
+		kubeconfig, err := kube.BuildEKSKubeconfigString(endpoint, caCert, clusterName, s.DstTarget.Region(), proxyURL)
 		if err != nil {
-			return fmt.Errorf("sites: failed to marshal kubeconfig for %s: %w", clusterName, err)
+			return fmt.Errorf("sites: %w", err)
 		}
-		kubeconfigsByRelease[release] = string(data)
+		kubeconfigsByRelease[release] = kubeconfig
 	}
 
 	params := awsSiteParams{


### PR DESCRIPTION
## Description

Fixes several regressions in the Go-migrated helm and clusters steps, primarily around Kubernetes provider stability across Pulumi runs.

## Code Flow

**Stable kubeconfigs (main fix):**

The Go helm and clusters steps were generating kubeconfigs with embedded credentials (STS tokens for AWS, hardcoded `--login devicecode` for Azure) that change on every run. This caused Pulumi to see a kubeconfig diff on each apply, which triggers provider replacement and cascades to all child Kubernetes resources (namespaces, HelmCharts, secrets, etc.).

- **AWS (`helm_aws.go`, `clusters_aws.go`, `sites.go`):** Switched from `BuildEKSKubeConfig` (embeds a short-lived STS token) to `BuildEKSKubeconfigString` (exec credential plugin: `aws --region <r> eks get-token --cluster-name <n>`). The exec-plugin kubeconfig is identical on every run — no token embedded. Removed `IgnoreChanges` workarounds that were masking the instability. Added `BuildEKSKubeconfigString` to `lib/kube` as a shared helper used by all three steps.

- **Azure (`helm_azure.go`, `clusters_azure.go`, `sites.go`):** The raw AKS kubeconfig from `ListClusterUserCredentials` uses `--login devicecode`, which requires an interactive TTY for token refresh. Replaced with `BuildAKSKubeconfigString` which swaps `--login devicecode` → `--login azurecli` in-place, preserving all other exec args (`--server-id`, `--environment`, `--client-id`, `--tenant-id`). The `azurecli` login mode uses the Azure CLI's cached token via `az account get-access-token`, which works non-interactively when `microsoftonline.com` is in `NO_PROXY`.

**Deterministic proxy port (`99dfe02`):** Replaced hardcoded `socks5://localhost:1080` with `proxy.WorkloadPort(name)` (FNV-32a hash into 10000–19999 range), consistent with how the sites and proxy subsystem already work.

**Other fixes in earlier commits:** Karpenter subnet/SG selector fix, Traefik/Alloy config alignment with Python output, Alloy cluster label date suffix, overprovisioning session taint synthesis.

## Deployment note

Existing Pulumi stack states for the `clusters` and `helm` steps have stale provider state (old-format kubeconfig in the provider's `outputs` field). Applying this branch directly will show provider REPLACE + cascading child resource replacements. See the comment below for the per-workload remediation runbook.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about