### PR TITLE
Harden Traefik and Alloy remote_write for control room resilience

### DIFF
--- a/lib/steps/helm_helpers.go
+++ b/lib/steps/helm_helpers.go
@@ -118,6 +118,8 @@ func buildAlloyConfig(params alloyConfigParams) string {
         }
         queue_config {
             sample_age_limit = "5m"
+            max_shards       = 3
+            max_backoff      = "5m"
         }
     }
 }
@@ -259,6 +261,8 @@ prometheus.remote_write "workload" {
         url = "%s"
         queue_config {
             sample_age_limit = "5m"
+            max_shards       = 3
+            max_backoff      = "5m"
         }
     }
 }

--- a/python-pulumi/src/ptd/pulumi_resources/traefik.py
+++ b/python-pulumi/src/ptd/pulumi_resources/traefik.py
@@ -214,8 +214,29 @@ class Traefik(pulumi.ComponentResource):
                     "additionalArguments": [
                         "--metrics.prometheus=true",
                     ],
+                    "resources": {
+                        "requests": {
+                            "cpu": "200m",
+                            "memory": "256Mi",
+                        },
+                        "limits": {
+                            "memory": "512Mi",
+                        },
+                    },
                     "deployment": {
                         "replicas": self.deployment_replicas,
+                    },
+                    "livenessProbe": {
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 5,
+                    },
+                    "readinessProbe": {
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 3,
                     },
                     "logs": {
                         "general": {"level": "DEBUG"},


### PR DESCRIPTION
## Summary
- Add resource requests/limits and probe tuning to Traefik Helm values to prevent
  node CPU starvation and crash loops under load
- Add max_shards=3 and max_backoff=5m to Alloy prometheus.remote_write queue_config
  to prevent thundering herd when multiple clusters push to a shared endpoint

## Context
Control room Traefik was crash-looping due to unbounded concurrent push connections
from workload Alloy instances. The default max_shards (200) per Alloy pod meant
recovery scenarios created massive connection floods that overwhelmed Traefik.

## Changes
- `traefik.py`: Add CPU/memory requests+limits (Burstable QoS), increase liveness
  probe timeout to 5s and failure threshold to 5, readiness failure threshold to 3
- `helm_helpers.go`: Add max_shards=3 and max_backoff=5m to both control_room and
  workload prometheus.remote_write queue_config blocks

## Test plan
- [ ] Verify Traefik pods get Burstable QoS after deploy
- [ ] Verify Alloy config includes max_shards after ptd ensure on a workload
- [ ] Confirm push latencies stay sub-second under normal load