### PR TITLE
fix(clusters-azure): use corev1.NewConfigMapPatch for CoreDNS forwarding ConfigMap

### DIFF
--- a/lib/steps/clusters_azure.go
+++ b/lib/steps/clusters_azure.go
@@ -861,7 +861,6 @@ func azureClustersDeploy(ctx *pulumi.Context, _ types.Target, params azureCluste
 
 		// ── CoreDNS forwarding (optional) ──────────────────────────────────────
 		// Python: uses kubernetes.core.v1.ConfigMapPatch with replace_on_changes=[].
-		// In Go Pulumi SDK, we use a custom K8s resource with server-side apply semantics.
 		// DNS forwarding entries are direct children of AzureWorkloadClusters.
 		if len(params.dnsForwardDomains) > 0 {
 			dnsData := pulumi.StringMap{}
@@ -870,18 +869,14 @@ func azureClustersDeploy(ctx *pulumi.Context, _ types.Target, params azureCluste
 				val := fmt.Sprintf("%s:53 {\n  errors\n  cache 30\n  forward . %s\n}\n", domain.Host, domain.IP)
 				dnsData[key] = pulumi.String(val)
 			}
-			_, err = apiextensions.NewCustomResource(ctx,
+			_, err = corev1.NewConfigMapPatch(ctx,
 				fmt.Sprintf("%s-%s-coredns-forward", name, release),
-				&apiextensions.CustomResourceArgs{
-					ApiVersion: pulumi.String("v1"),
-					Kind:       pulumi.String("ConfigMap"),
-					Metadata: &metav1.ObjectMetaArgs{
-						Name:      pulumi.String("coredns-custom"),
-						Namespace: pulumi.String(clustersKubeSystemNamespace),
+				&corev1.ConfigMapPatchArgs{
+					Metadata: &metav1.ObjectMetaPatchArgs{
+						Name:      pulumi.StringPtr("coredns-custom"),
+						Namespace: pulumi.StringPtr(clustersKubeSystemNamespace),
 					},
-					OtherFields: kubernetes.UntypedArgs{
-						"data": dnsData,
-					},
+					Data: dnsData,
 				}, k8sProviderOpt, withAlias())
 			if err != nil {
 				return fmt.Errorf("clusters: failed to create coredns forwarding configmap for %s: %w", release, err)


### PR DESCRIPTION
# Description

The CoreDNS forwarding ConfigMap in the Azure clusters step was created using `apiextensions.NewCustomResource` with `ApiVersion: "v1"`. The Pulumi Kubernetes provider fails to parse the bare `"v1"` group/version string when reading the live resource back from the cluster, causing state reconciliation errors.

## Code Flow

`azureDeployWorkloadClusters` builds CoreDNS forwarding entries and registers a Kubernetes ConfigMap resource. Previously this used `apiextensions.NewCustomResource` with a bare `"v1"` ApiVersion field, which the Pulumi provider cannot correctly round-trip when reading back from the cluster.

The fix replaces this with `corev1.NewConfigMapPatch`, which uses the fully-typed `kubernetes:core/v1:ConfigMapPatch` resource. This matches the existing Pulumi state type for the resource, so no alias changes are required.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about