### PR TITLE
Increase Alloy remote_write max_shards from 3 to 10

### DIFF
--- a/lib/steps/helm_helpers.go
+++ b/lib/steps/helm_helpers.go
@@ -118,7 +118,7 @@ func buildAlloyConfig(params alloyConfigParams) string {
         }
         queue_config {
             sample_age_limit = "5m"
-            max_shards       = 3
+            max_shards       = 10
             max_backoff      = "5m"
         }
     }
@@ -261,7 +261,7 @@ prometheus.remote_write "workload" {
         url = "%s"
         queue_config {
             sample_age_limit = "5m"
-            max_shards       = 3
+            max_shards       = 10
             max_backoff      = "5m"
         }
     }


### PR DESCRIPTION
## Summary
Increase max_shards from 3 to 10 on both control_room and workload
prometheus.remote_write queue_config blocks.

## Context
max_shards=3 (set in #270) was too aggressive — workloads with high series
cardinality can't drain their queue fast enough with only 3 concurrent senders
per Alloy pod, causing repeated "Remote storage resharding" log spam and
delayed metric delivery.

max_shards=10 provides enough throughput for high-cardinality workloads while
still limiting the fan-in blast radius during recovery (10 shards × 8 pods ×
9 clusters = 720 max concurrent connections, down from 3,600 at default 50).

## Test plan
- [ ] Verify no "Remote storage resharding" log spam on previously affected workload
- [ ] Confirm push latencies remain sub-second under normal load
- [ ] Verify control room Traefik stays stable under steady-state push traffic