### PR TITLE
fix: default Karpenter NodePool weight to 100 when unset

### DIFF
--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -1412,6 +1412,10 @@ func awsHelmKarpenter(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoun
 		if consolidateAfter == "" {
 			consolidateAfter = "5m"
 		}
+		weight := nodePool.Weight
+		if weight == 0 {
+			weight = 100
+		}
 
 		nodepoolSpec := map[string]interface{}{
 			"template": map[string]interface{}{
@@ -1428,7 +1432,7 @@ func awsHelmKarpenter(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoun
 				"consolidationPolicy": consolidationPolicy,
 				"consolidateAfter":    consolidateAfter,
 			},
-			"weight": nodePool.Weight,
+			"weight": weight,
 		}
 
 		if nodePool.ExpireAfter != nil {


### PR DESCRIPTION
## Description

Go's zero value for `int` causes `spec.weight: 0` on Karpenter NodePools that don't set the `weight` field in their YAML config. Kubernetes rejects this — the field must be ≥ 1. This applies the same default (100) as the Python dataclass (`weight: int = 100` in `aws_workload.py`), consistent with how `consolidationPolicy` and `consolidateAfter` already handle their zero-value defaults in the same function.

## Code Flow

In `awsHelmKarpenter`, each NodePool's config is read from Go structs and assembled into a Pulumi resource map. `nodePool.Weight` is an `int` with no YAML default, so omitting `weight:` in config yields `0`. The fix introduces a local `weight` variable with the same `== 0 → 100` guard pattern already used for `consolidationPolicy` and `consolidateAfter`.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about