### PR TITLE
fix: add CPU limits to Mimir store-gateway and Traefik

### DIFF
--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -1055,6 +1055,10 @@ func awsHelmMimir(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 			"replicas":             mreplicas,
 			"zoneAwareReplication": map[string]interface{}{"enabled": false},
 			"affinity":             affinityRule,
+			"resources": map[string]interface{}{
+				"requests": map[string]interface{}{"cpu": "100m", "memory": "512Mi"},
+				"limits":   map[string]interface{}{"cpu": "1", "memory": "4Gi"},
+			},
 		},
 		"gateway": map[string]interface{}{
 			"enabledNonEnterprise": true,

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -764,12 +764,18 @@ func azureHelmMimir(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 			"mimir": map[string]interface{}{
 				"structuredConfig": structuredConfig,
 			},
-			"minio":         map[string]interface{}{"enabled": false},
-			"alertmanager":  map[string]interface{}{"enabled": false},
-			"ruler":         map[string]interface{}{"enabled": false},
-			"ingester":      map[string]interface{}{"persistentVolume": map[string]interface{}{"size": "20Gi"}},
-			"compactor":     map[string]interface{}{"persistentVolume": map[string]interface{}{"size": "20Gi"}},
-			"store_gateway": map[string]interface{}{"persistentVolume": map[string]interface{}{"size": "20Gi"}},
+			"minio":        map[string]interface{}{"enabled": false},
+			"alertmanager": map[string]interface{}{"enabled": false},
+			"ruler":        map[string]interface{}{"enabled": false},
+			"ingester":     map[string]interface{}{"persistentVolume": map[string]interface{}{"size": "20Gi"}},
+			"compactor":    map[string]interface{}{"persistentVolume": map[string]interface{}{"size": "20Gi"}},
+			"store_gateway": map[string]interface{}{
+				"persistentVolume": map[string]interface{}{"size": "20Gi"},
+				"resources": map[string]interface{}{
+					"requests": map[string]interface{}{"cpu": "100m", "memory": "512Mi"},
+					"limits":   map[string]interface{}{"cpu": "1", "memory": "4Gi"},
+				},
+			},
 			"gateway": map[string]interface{}{
 				"enabledNonEnterprise": true,
 				"nginx": map[string]interface{}{

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -2331,7 +2331,14 @@ class AWSEKSCluster(pulumi.ComponentResource):
                     "ingester": {"persistentVolume": {"size": "20Gi"}},
                     "compactor": {"persistentVolume": {"size": "20Gi"}},
                     "distributor": {"replicas": 3},
-                    "store_gateway": {"persistentVolume": {"size": "20Gi"}, "replicas": 3},
+                    "store_gateway": {
+                        "persistentVolume": {"size": "20Gi"},
+                        "replicas": 3,
+                        "resources": {
+                            "requests": {"cpu": "100m", "memory": "512Mi"},
+                            "limits": {"cpu": "1", "memory": "4Gi"},
+                        },
+                    },
                     "nginx": {"enabled": False},
                     "gateway": {
                         "enabledNonEnterprise": True,

--- a/python-pulumi/src/ptd/pulumi_resources/traefik.py
+++ b/python-pulumi/src/ptd/pulumi_resources/traefik.py
@@ -220,6 +220,7 @@ class Traefik(pulumi.ComponentResource):
                             "memory": "256Mi",
                         },
                         "limits": {
+                            "cpu": "1000m",
                             "memory": "512Mi",
                         },
                     },


### PR DESCRIPTION
## Summary

- Add resource requests/limits to Mimir store-gateway pods across all deployment targets (control room, AWS workloads, Azure workloads): 100m/512Mi requests, 1 CPU/4Gi limits
- Add missing CPU limit (1000m) to the Traefik deployment

Store-gateways running Mimir 2.10.4 exhibit unbounded CPU growth over time (reaching 2-3 cores per pod despite requesting 100m), eventually starving colocated pods on the same nodes and causing cascading Traefik proxy failures. Adding a 1 CPU limit caps runaway usage while leaving ample headroom for normal operation (~5-7m after restart).

The Traefik CPU limit was applied during a previous incident but the change wasn't committed to IaC.

## Test plan

- [x] Store-gateway CPU limits applied manually to the control room cluster and verified via `kubectl top`
- [ ] Run `ptd ensure --only-steps helm --dry-run` on a workload target to verify Helm values render correctly
- [ ] Deploy to a test cluster and confirm store-gateway pods start with the new resource spec