### PR TITLE
feat: add snapshot and backup protection to Azure NetApp volumes

### DIFF
--- a/lib/helpers/helpers.go
+++ b/lib/helpers/helpers.go
@@ -66,6 +66,7 @@ func LoadPtdYaml(filename string) (interface{}, error) {
 		if err := base.Spec.Decode(&config); err != nil {
 			return nil, err
 		}
+		config.SetDefaults()
 		return config, nil
 	case "AWSControlRoomConfig":
 		var config types.AWSControlRoomConfig

--- a/lib/helpers/helpers.go
+++ b/lib/helpers/helpers.go
@@ -66,7 +66,6 @@ func LoadPtdYaml(filename string) (interface{}, error) {
 		if err := base.Spec.Decode(&config); err != nil {
 			return nil, err
 		}
-		config.SetDefaults()
 		return config, nil
 	case "AWSControlRoomConfig":
 		var config types.AWSControlRoomConfig

--- a/lib/types/workload.go
+++ b/lib/types/workload.go
@@ -292,18 +292,6 @@ type AzureWorkloadConfig struct {
 	RootDomain *string `yaml:"root_domain"`
 }
 
-func (c *AzureWorkloadConfig) SetDefaults() {
-	if c.NetappBackupRetentionDays == 0 {
-		c.NetappBackupRetentionDays = 30
-	}
-	if c.NetappDailyBackupStartTime == "" {
-		c.NetappDailyBackupStartTime = "02:00"
-	}
-	if c.NetappSnapshotsToKeep == 0 {
-		c.NetappSnapshotsToKeep = 7
-	}
-}
-
 type NetworkConfig struct {
 	VnetCidr                  string                   `yaml:"vnet_cidr"`
 	PublicSubnetCidr          string                   `yaml:"public_subnet_cidr"`

--- a/lib/types/workload.go
+++ b/lib/types/workload.go
@@ -273,6 +273,9 @@ type AzureWorkloadConfig struct {
 	AdminGroupID                        string                                `yaml:"admin_group_id"`
 	AutomatedVolumeProvisioning         bool                                  `yaml:"automated_volume_provisioning"`
 	BastionInstanceType                 string                                `yaml:"bastion_instance_type"`
+	NetappBackupRetentionDays           int                                   `yaml:"netapp_backup_retention_days"`
+	NetappDailyBackupStartTime          string                                `yaml:"netapp_daily_backup_start_time"`
+	NetappSnapshotsToKeep               int                                   `yaml:"netapp_snapshots_to_keep"`
 	NetappVolumeConnectCapacity         int                                   `yaml:"netapp_volume_connect_capacity"`
 	NetappVolumeWorkbenchCapacity       int                                   `yaml:"netapp_volume_workbench_capacity"`
 	NetappVolumeWorkbenchSharedCapacity int                                   `yaml:"netapp_volume_workbench_shared_capacity"`
@@ -287,6 +290,18 @@ type AzureWorkloadConfig struct {
 	// RootDomain, when set, is used as the sole cert-manager domain instead of per-site domains.
 	// Mirrors Python: AzureWorkloadConfig.root_domain (via WorkloadConfig.domains fallback).
 	RootDomain *string `yaml:"root_domain"`
+}
+
+func (c *AzureWorkloadConfig) SetDefaults() {
+	if c.NetappBackupRetentionDays == 0 {
+		c.NetappBackupRetentionDays = 30
+	}
+	if c.NetappDailyBackupStartTime == "" {
+		c.NetappDailyBackupStartTime = "02:00"
+	}
+	if c.NetappSnapshotsToKeep == 0 {
+		c.NetappSnapshotsToKeep = 7
+	}
 }
 
 type NetworkConfig struct {

--- a/python-pulumi/src/ptd/azure_workload.py
+++ b/python-pulumi/src/ptd/azure_workload.py
@@ -63,6 +63,9 @@ class AzureWorkloadConfig(ptd.WorkloadConfig):
     admin_group_id: str | None = None
     automated_volume_provisioning: bool = False
     bastion_instance_type: str = "Standard_B1s"
+    netapp_backup_retention_days: int = 30
+    netapp_daily_backup_start_time: str = "02:00"
+    netapp_snapshots_to_keep: int = 7
     netapp_volume_connect_capacity: int = 200  # GiB
     netapp_volume_workbench_capacity: int = 200  # GiB
     netapp_volume_workbench_shared_capacity: int = 200  # GiB
@@ -379,8 +382,20 @@ class AzureWorkload(ptd.workload.AbstractWorkload):
         return f"naa-ptd-{self.compound_name}"
 
     @property
+    def netapp_backup_policy_name(self) -> str:
+        return f"bkp-ptd-{self.compound_name}"
+
+    @property
+    def netapp_backup_vault_name(self) -> str:
+        return f"bkv-ptd-{self.compound_name}"
+
+    @property
     def netapp_pool_name(self) -> str:
         return f"nap-ptd-{self.compound_name}"
+
+    @property
+    def netapp_snapshot_policy_name(self) -> str:
+        return f"snp-ptd-{self.compound_name}"
 
     # Replicates ResourceGroupName logic from azure/target.go
     @property

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_persistent.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_persistent.py
@@ -30,7 +30,8 @@ class AzureWorkloadPersistent(pulumi.ComponentResource):
     - Mimir authentication password
 
     Uses all-in-constructor pattern with `_define_*()` methods. Unlike AWS EKS builder pattern,
-    there are no method ordering dependencies - all `_define_*()` methods can be called in any order.
+    most `_define_*()` methods can be called in any order. Exception:
+    `_define_netapp_volumes()` must follow `_define_file_storage()` (needs snapshot/backup resources).
 
     Outputs are consumed by later steps:
     - postgres_config: Database connection details
@@ -558,8 +559,10 @@ class AzureWorkloadPersistent(pulumi.ComponentResource):
             h_str, m_str = time_str.split(":")
             hour, minute = int(h_str), int(m_str)
         except (ValueError, AttributeError):
+            hour, minute = -1, -1
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):  # noqa: PLR2004
             msg = f"netapp_daily_backup_start_time must be HH:MM, got {time_str!r}"
-            raise ValueError(msg) from None
+            raise ValueError(msg)
 
         self.snapshot_policy = netapp.SnapshotPolicy(
             self.workload.netapp_snapshot_policy_name,

--- a/python-pulumi/src/ptd/pulumi_resources/azure_workload_persistent.py
+++ b/python-pulumi/src/ptd/pulumi_resources/azure_workload_persistent.py
@@ -553,6 +553,58 @@ class AzureWorkloadPersistent(pulumi.ComponentResource):
             ),
         )
 
+        time_str = self.workload.cfg.netapp_daily_backup_start_time
+        try:
+            h_str, m_str = time_str.split(":")
+            hour, minute = int(h_str), int(m_str)
+        except (ValueError, AttributeError):
+            msg = f"netapp_daily_backup_start_time must be HH:MM, got {time_str!r}"
+            raise ValueError(msg) from None
+
+        self.snapshot_policy = netapp.SnapshotPolicy(
+            self.workload.netapp_snapshot_policy_name,
+            snapshot_policy_name=self.workload.netapp_snapshot_policy_name,
+            resource_group_name=self.workload.resource_group_name,
+            account_name=netapp_account.name,
+            location=self.workload.cfg.region,
+            enabled=True,
+            daily_schedule=netapp.DailyScheduleArgs(
+                hour=hour,
+                minute=minute,
+                snapshots_to_keep=self.workload.cfg.netapp_snapshots_to_keep,
+            ),
+            tags=self.required_tags,
+            opts=pulumi.ResourceOptions(
+                protect=self.workload.cfg.protect_persistent_resources,
+            ),
+        )
+
+        self.backup_vault = netapp.BackupVault(
+            self.workload.netapp_backup_vault_name,
+            backup_vault_name=self.workload.netapp_backup_vault_name,
+            resource_group_name=self.workload.resource_group_name,
+            account_name=netapp_account.name,
+            location=self.workload.cfg.region,
+            tags=self.required_tags,
+            opts=pulumi.ResourceOptions(
+                protect=self.workload.cfg.protect_persistent_resources,
+            ),
+        )
+
+        self.backup_policy = netapp.BackupPolicy(
+            self.workload.netapp_backup_policy_name,
+            backup_policy_name=self.workload.netapp_backup_policy_name,
+            resource_group_name=self.workload.resource_group_name,
+            account_name=netapp_account.name,
+            location=self.workload.cfg.region,
+            enabled=True,
+            daily_backups_to_keep=self.workload.cfg.netapp_backup_retention_days,
+            tags=self.required_tags,
+            opts=pulumi.ResourceOptions(
+                protect=self.workload.cfg.protect_persistent_resources,
+            ),
+        )
+
     _NETAPP_VOLUME_PRODUCTS: typing.ClassVar[dict[str, str]] = {
         "connect": "netapp_volume_connect_capacity",
         "workbench": "netapp_volume_workbench_capacity",
@@ -602,6 +654,15 @@ class AzureWorkloadPersistent(pulumi.ComponentResource):
                                 has_root_access=True,
                             ),
                         ],
+                    ),
+                    data_protection=netapp.VolumePropertiesDataProtectionArgs(
+                        backup=netapp.VolumeBackupPropertiesArgs(
+                            backup_policy_id=self.backup_policy.id,
+                            backup_vault_id=self.backup_vault.id,
+                        ),
+                        snapshot=netapp.VolumeSnapshotPropertiesArgs(
+                            snapshot_policy_id=self.snapshot_policy.id,
+                        ),
                     ),
                     tags=self.required_tags,
                     opts=pulumi.ResourceOptions(


### PR DESCRIPTION
## Summary
- Creates a snapshot policy (7 daily at 02:00 UTC), backup vault, and backup policy (30 daily) on every Azure NetApp account — matching the AWS FSx 30-day automatic backup posture
- Wires `data_protection` into auto-provisioned volumes so they get both snapshots and backups automatically
- Adds Go-side config fields with `SetDefaults()` so existing ptd.yaml files work without changes
- Snapshot/backup/vault resources are created unconditionally (even without `automated_volume_provisioning`) so they're available for manually-created volumes

## Issue
https://github.com/posit-dev/ptd/issues/250

## New config fields (all optional, with defaults)
| Field | Default | Notes |
|-------|---------|-------|
| `netapp_backup_retention_days` | `30` | Daily backups to retain |
| `netapp_daily_backup_start_time` | `"02:00"` | HH:MM UTC for daily snapshots |
| `netapp_snapshots_to_keep` | `7` | Daily snapshots to retain (local, fast restore) |

## Rollout notes
- Existing workloads: running `ptd ensure --only-steps persistent` will create the new resources. Volumes not managed by `automated_volume_provisioning` need snapshot/backup assignment in the portal.
- First backup per volume is a full copy — schedule during low-usage windows.

## Test plan
- [ ] `ptd ensure <azure-staging-target> --only-steps persistent --dry-run` — verify snapshot policy, backup vault, and backup policy appear in preview
- [ ] Apply to staging and confirm resources created in Azure portal
- [ ] Verify auto-provisioned volumes show data_protection with both snapshot and backup references
- [ ] Manually assign snapshot policy and enable backup on a non-auto-provisioned volume