### PR TITLE
Switch to reusable Claude auto-review workflow

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -2,56 +2,9 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [opened]
-
-env:
-  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
-  auto-review:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
-          role-session-name: gha-claude-code-action
-          aws-region: us-east-2
-
-      - name: Automatic PR Review
-        uses: anthropics/claude-code-action@beta
-        if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
-        with:
-          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
-          use_bedrock: true
-          model: "us.anthropic.claude-opus-4-6-v1"
-          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-          timeout_minutes: "60"
-          direct_prompt: |
-            Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
-
-            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
-            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
-            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
-
-            Review priorities from guidelines:
-            - **Simplicity**: Code should be explicit, not clever. Functions do one thing. Names reveal intent.
-            - **Maintainability**: Follow existing patterns. New code should look like it belongs.
-            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
-
-            Use the area-specific checklists from the guidelines for Go CLI, Python/Pulumi, and infrastructure changes.
-
-            Provide constructive feedback with specific suggestions for improvement.
-            Don't be overly complimentary; focus on actionable insights and keep your comments concise.
-            Use inline comments to highlight specific areas of concern.
-
-            IMPORTANT: Do NOT post any additional comments after submitting the review. The GitHub review itself is sufficient and any additional summary comments will be redundant.
+  review:
+    uses: posit-dev/ptd-workspace/.github/workflows/claude-auto-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
# Description

Replaces the full Claude auto-review workflow with a thin caller that delegates to the reusable workflow in [posit-dev/ptd-workspace](https://github.com/posit-dev/ptd-workspace/blob/main/.github/workflows/claude-auto-review.yml).

All review logic (auth, tools, prompt, triggers, concurrency) now lives in ptd-workspace and is shared across repos.


## Category of change

- [x] Build: a code change that affects the build system or external dependencies

## Checklist

- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about