### PR TITLE
fix: configure metrics-server for EKS host networking

### DIFF
--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -780,7 +780,11 @@ func awsHelmMetricsServer(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, com
 		"https://kubernetes-sigs.github.io/metrics-server/",
 		"metrics-server",
 		clustersKubeSystemNamespace,
-		version, map[string]interface{}{}, k8sOpt,
+		version, map[string]interface{}{
+			"hostNetwork":   map[string]interface{}{"enabled": true},
+			"containerPort": 4443,
+			"args":          []interface{}{"--kubelet-preferred-address-types=InternalIP"},
+		}, k8sOpt,
 		withAlias("kubernetes:helm.cattle.io/v1:HelmChart", resourceName))
 }
 

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -1779,11 +1779,6 @@ class AWSEKSCluster(pulumi.ComponentResource):
                 repository_opts=k8s.helm.v3.RepositoryOptsArgs(
                     repo="https://kubernetes-sigs.github.io/metrics-server/",
                 ),
-                values={
-                    "hostNetwork": {"enabled": True},
-                    "containerPort": 4443,
-                    "args": ["--kubelet-preferred-address-types=InternalIP"],
-                },
             ),
             opts=pulumi.ResourceOptions(provider=self.provider, parent=self),
         )

--- a/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
+++ b/python-pulumi/src/ptd/pulumi_resources/aws_eks_cluster.py
@@ -1779,6 +1779,11 @@ class AWSEKSCluster(pulumi.ComponentResource):
                 repository_opts=k8s.helm.v3.RepositoryOptsArgs(
                     repo="https://kubernetes-sigs.github.io/metrics-server/",
                 ),
+                values={
+                    "hostNetwork": {"enabled": True},
+                    "containerPort": 4443,
+                    "args": ["--kubelet-preferred-address-types=InternalIP"],
+                },
             ),
             opts=pulumi.ResourceOptions(provider=self.provider, parent=self),
         )


### PR DESCRIPTION
## Summary

- `kubectl top` fails on EKS workload clusters with "Metrics API not available" because metrics-server can't scrape kubelet metrics (connection timeout on port 10250)
- Workload clusters use Calico CNI (overlay network at 172.16.0.0/16) instead of the AWS VPC-CNI, so pod traffic originates from IPs outside the node security groups — kubelet:10250 is unreachable from pod networking
- Configures metrics-server Helm values on workload clusters to work around this:
  - `hostNetwork.enabled: true` — runs in the node network namespace, bypassing the Calico overlay
  - `containerPort: 4443` — avoids port conflict with kubelet already bound to 10250 on the host
  - `--kubelet-preferred-address-types=InternalIP` — resolves nodes by internal IP on EKS
- Control room clusters are unaffected — they use VPC-CNI where pods share node security groups, so metrics-server already works without hostNetwork

## Test plan

- [x] Deployed to an EKS workload cluster and verified `kubectl top pods` and `kubectl top nodes` return metrics
- [ ] Verify metrics-server pod is healthy after rollout to additional workload clusters