### PR TITLE
attestation: add full resource inventory and Kubernetes object appendices

### DIFF
--- a/lib/attestation/attestation.go
+++ b/lib/attestation/attestation.go
@@ -152,7 +152,7 @@ var stackPurposes = map[string]map[string]string{
 		"sites":           "Posit product deployments (TeamSite CRDs), ingress resources, site-specific configuration",
 	},
 	"azure": {
-		"persistent":      "VNet, Azure PostgreSQL, Storage accounts, NetApp Files, Key Vault, managed identities, NSGs",
+		"persistent":      "Network, PostgreSQL database, storage accounts, NetApp/Azure Files for product data, Key Vault, managed identities, network security groups",
 		"postgres-config": "PostgreSQL database users, databases, and grants",
 		"aks":             "AKS cluster, node pools, managed identity, storage classes",
 		"acr-cache":       "Azure Container Registry cache rules for container image pull-through",
@@ -308,6 +308,17 @@ func Collect(ctx context.Context, target types.Target, workloadPath string) (*At
 	}
 	attestation.Sites = sites
 
+	// Chronicle is optional; flag it on the infra config when any site configures
+	// it, so chronicle-specific prose (e.g. the Azure storage container) is only
+	// emitted when the telemetry is actually deployed.
+	for _, site := range sites {
+		for _, product := range site.Products {
+			if product.Name == "chronicle" {
+				infraCfg.ChronicleEnabled = true
+			}
+		}
+	}
+
 	// Read customizations/manifest.yaml
 	customSteps, err := collectCustomSteps(workloadPath)
 	if err != nil {
@@ -409,7 +420,7 @@ func parseAWSInfraConfig(data []byte) (*InfraConfig, error) {
 			VpcAzCount                  int    `yaml:"vpc_az_count"`
 			FsxOpenzfsMultiAz           bool   `yaml:"fsx_openzfs_multi_az"`
 			KeycloakEnabled             bool   `yaml:"keycloak_enabled"`
-			ExternalDNSEnabled          bool   `yaml:"external_dns_enabled"`
+			ExternalDNSEnabled          *bool  `yaml:"external_dns_enabled"`
 			PublicLoadBalancer          bool   `yaml:"public_load_balancer"`
 			SecretsStoreAddonEnabled    *bool  `yaml:"secrets_store_addon_enabled"`
 			HostedZoneManagementEnabled *bool  `yaml:"hosted_zone_management_enabled"`
@@ -442,7 +453,7 @@ func parseAWSInfraConfig(data []byte) (*InfraConfig, error) {
 		VpcAzCount:               raw.Spec.VpcAzCount,
 		FsxMultiAz:               raw.Spec.FsxOpenzfsMultiAz,
 		KeycloakEnabled:          raw.Spec.KeycloakEnabled,
-		ExternalDNSEnabled:       raw.Spec.ExternalDNSEnabled,
+		ExternalDNSEnabled:       raw.Spec.ExternalDNSEnabled == nil || *raw.Spec.ExternalDNSEnabled,
 		PublicLoadBalancer:       raw.Spec.PublicLoadBalancer,
 		SecretsStoreAddonEnabled: raw.Spec.SecretsStoreAddonEnabled == nil || *raw.Spec.SecretsStoreAddonEnabled,
 		CustomerManagedBastionID: raw.Spec.CustomerManagedBastionId,
@@ -490,9 +501,9 @@ func parseAzureInfraConfig(data []byte) (*InfraConfig, error) {
 				ProvisionedVnetName string `yaml:"provisioned_vnet_name"`
 				VnetRsgName         string `yaml:"vnet_rsg_name"`
 			} `yaml:"network"`
-			KeycloakEnabled          bool `yaml:"keycloak_enabled"`
-			ExternalDNSEnabled       bool `yaml:"external_dns_enabled"`
-			SecretsStoreAddonEnabled bool `yaml:"secrets_store_addon_enabled"`
+			KeycloakEnabled          bool  `yaml:"keycloak_enabled"`
+			ExternalDNSEnabled       *bool `yaml:"external_dns_enabled"`
+			SecretsStoreAddonEnabled bool  `yaml:"secrets_store_addon_enabled"`
 			Clusters                 map[string]struct {
 				KubernetesVersion          string `yaml:"kubernetes_version"`
 				SystemNodePoolInstanceType string `yaml:"system_node_pool_instance_type"`
@@ -517,7 +528,7 @@ func parseAzureInfraConfig(data []byte) (*InfraConfig, error) {
 		ProvisionedVnetID:        raw.Spec.Network.ProvisionedVnetID,
 		ProvisionedVnetName:      raw.Spec.Network.ProvisionedVnetName,
 		KeycloakEnabled:          raw.Spec.KeycloakEnabled,
-		ExternalDNSEnabled:       raw.Spec.ExternalDNSEnabled,
+		ExternalDNSEnabled:       raw.Spec.ExternalDNSEnabled == nil || *raw.Spec.ExternalDNSEnabled,
 		SecretsStoreAddonEnabled: raw.Spec.SecretsStoreAddonEnabled,
 		SiteDomains:              make(map[string]string),
 	}

--- a/lib/attestation/attestation.go
+++ b/lib/attestation/attestation.go
@@ -6,36 +6,40 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	ptdaws "github.com/posit-dev/ptd/lib/aws"
 	ptdazure "github.com/posit-dev/ptd/lib/azure"
+	"github.com/posit-dev/ptd/lib/consts"
 	"github.com/posit-dev/ptd/lib/customization"
 	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/pulumistate"
+	"github.com/posit-dev/ptd/lib/secrets"
 	"github.com/posit-dev/ptd/lib/types"
 	"gopkg.in/yaml.v3"
 )
 
 // AttestationData contains all collected information about a workload deployment
 type AttestationData struct {
-	TargetName      string                 `json:"target_name"`
-	Title           string                 `json:"title,omitempty"`
-	CloudProvider   string                 `json:"cloud_provider"`
-	Region          string                 `json:"region"`
-	AccountID       string                 `json:"account_id"`
-	Profile         string                 `json:"profile"`
-	GeneratedAt     time.Time              `json:"generated_at"`
-	Sites           []SiteInfo             `json:"sites"`
-	Stacks          []StackSummary         `json:"stacks"`
-	CustomSteps     []CustomStepInfo       `json:"custom_steps"`
-	ClusterConfig   map[string]interface{} `json:"cluster_config"`
-	Infra           *InfraConfig           `json:"infra"`
-	ProductSummary  string                 `json:"product_summary"`
-	StateBackendURL string                 `json:"state_backend_url,omitempty"`
-	RawStateFiles   map[string][]byte      `json:"-"`
+	TargetName         string                 `json:"target_name"`
+	Title              string                 `json:"title,omitempty"`
+	CloudProvider      string                 `json:"cloud_provider"`
+	Region             string                 `json:"region"`
+	AccountID          string                 `json:"account_id"`
+	Profile            string                 `json:"profile"`
+	GeneratedAt        time.Time              `json:"generated_at"`
+	Sites              []SiteInfo             `json:"sites"`
+	Stacks             []StackSummary         `json:"stacks"`
+	BootstrapResources []ResourceDetail       `json:"bootstrap_resources"`
+	CustomSteps        []CustomStepInfo       `json:"custom_steps"`
+	ClusterConfig      map[string]interface{} `json:"cluster_config"`
+	Infra              *InfraConfig           `json:"infra"`
+	ProductSummary     string                 `json:"product_summary"`
+	StateBackendURL    string                 `json:"state_backend_url,omitempty"`
+	RawStateFiles      map[string][]byte      `json:"-"`
 }
 
 // DisplayTitle returns the title to render at the top of the attestation
@@ -75,14 +79,66 @@ type AuthDetail struct {
 
 // StackSummary contains summary information from a Pulumi stack state file
 type StackSummary struct {
-	ProjectName   string    `json:"project_name"`
-	StackName     string    `json:"stack_name"`
-	Purpose       string    `json:"purpose"`
-	Timestamp     time.Time `json:"timestamp"`
-	PulumiVersion string    `json:"pulumi_version"`
-	ResourceCount int       `json:"resource_count"`
-	ResourceTypes []string  `json:"resource_types"`
-	StateKey      string    `json:"state_key"`
+	ProjectName       string             `json:"project_name"`
+	StackName         string             `json:"stack_name"`
+	Purpose           string             `json:"purpose"`
+	Timestamp         time.Time          `json:"timestamp"`
+	PulumiVersion     string             `json:"pulumi_version"`
+	ResourceCount     int                `json:"resource_count"`
+	ResourceTypes     []string           `json:"resource_types"`
+	Resources         []ResourceDetail   `json:"resources"`
+	KubernetesObjects []KubernetesObject `json:"kubernetes_objects"`
+	StateKey          string             `json:"state_key"`
+}
+
+// KubernetesObject describes a Kubernetes object managed in a Pulumi stack,
+// captured from the resource's state outputs for the Kubernetes appendix.
+type KubernetesObject struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	UID       string `json:"uid"`
+}
+
+// DisplayNamespace returns the namespace, or "—" for cluster-scoped objects.
+func (k KubernetesObject) DisplayNamespace() string {
+	if k.Namespace == "" {
+		return "—"
+	}
+	return k.Namespace
+}
+
+// DisplayUID returns the cluster-assigned UID. Helm releases wrap multiple
+// objects and carry no single UID, so they render as "— (release)".
+func (k KubernetesObject) DisplayUID() string {
+	if k.UID != "" {
+		return k.UID
+	}
+	if k.Kind == "Helm Release" {
+		return "— (release)"
+	}
+	return "—"
+}
+
+// ResourceDetail describes a single managed resource within a Pulumi stack,
+// used to render the full resource appendix.
+type ResourceDetail struct {
+	Name string `json:"name"` // logical name (last segment of the URN)
+	Type string `json:"type"` // Pulumi resource type token
+	ID   string `json:"id"`   // cloud provider resource ID (empty for logical/component resources)
+	URN  string `json:"urn"`  // full Pulumi URN, used as the identifier when no cloud ID exists
+}
+
+// DisplayID returns the identifier to show in the resource inventory: the cloud
+// provider resource ID when one exists, otherwise the full Pulumi URN. Some
+// resources (e.g. component resources) carry no ID, and others report a literal
+// "none" (e.g. random.RandomPassword); in both cases the URN is the stable
+// identifier.
+func (r ResourceDetail) DisplayID() string {
+	if r.ID == "" || r.ID == "none" {
+		return r.URN
+	}
+	return r.ID
 }
 
 // stackPurposes returns human-readable descriptions for standard stack types, keyed by cloud
@@ -282,6 +338,10 @@ func Collect(ctx context.Context, target types.Target, workloadPath string) (*At
 		}
 	}
 	attestation.Stacks = stacks
+
+	// The bootstrap step runs imperatively and produces no Pulumi state, so its
+	// resources are synthesized from PTD's naming conventions.
+	attestation.BootstrapResources = collectBootstrapResources(target)
 
 	// Generate product summary paragraph
 	attestation.ProductSummary = GenerateProductSummary(infraCfg, sites)
@@ -753,16 +813,47 @@ func parseStateFile(data []byte, stateKey string) (StackSummary, error) {
 		timestamp = time.Time{}
 	}
 
-	// Count resources (excluding pulumi internal resources)
+	// Count resources (excluding pulumi internal resources) and capture the
+	// full per-resource detail for the appendix.
 	resourceCount := 0
 	resourceTypeSet := make(map[string]bool)
+	var resources []ResourceDetail
+	var k8sObjects []KubernetesObject
 	for _, resource := range state.Checkpoint.Latest.Resources {
 		if pulumistate.IsInternalResource(resource.Type) {
 			continue
 		}
 		resourceCount++
 		resourceTypeSet[resource.Type] = true
+		resources = append(resources, ResourceDetail{
+			Name: resourceNameFromURN(resource.URN),
+			Type: resource.Type,
+			ID:   resource.ID,
+			URN:  resource.URN,
+		})
+		if strings.HasPrefix(resource.Type, "kubernetes:") {
+			k8sObjects = append(k8sObjects, extractKubernetesObject(resource))
+		}
 	}
+
+	// Present resources in a stable order: by type, then by name.
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Type != resources[j].Type {
+			return resources[i].Type < resources[j].Type
+		}
+		return resources[i].Name < resources[j].Name
+	})
+
+	// Present Kubernetes objects by kind, then namespace, then name.
+	sort.Slice(k8sObjects, func(i, j int) bool {
+		if k8sObjects[i].Kind != k8sObjects[j].Kind {
+			return k8sObjects[i].Kind < k8sObjects[j].Kind
+		}
+		if k8sObjects[i].Namespace != k8sObjects[j].Namespace {
+			return k8sObjects[i].Namespace < k8sObjects[j].Namespace
+		}
+		return k8sObjects[i].Name < k8sObjects[j].Name
+	})
 
 	// Convert resource type set to sorted slice
 	var resourceTypes []string
@@ -781,12 +872,174 @@ func parseStateFile(data []byte, stateKey string) (StackSummary, error) {
 	}
 
 	return StackSummary{
-		ProjectName:   projectName,
-		StackName:     stackName,
-		Timestamp:     timestamp,
-		PulumiVersion: state.Checkpoint.Latest.Manifest.Version,
-		ResourceCount: resourceCount,
-		ResourceTypes: resourceTypes,
-		StateKey:      stateKey,
+		ProjectName:       projectName,
+		StackName:         stackName,
+		Timestamp:         timestamp,
+		PulumiVersion:     state.Checkpoint.Latest.Manifest.Version,
+		ResourceCount:     resourceCount,
+		ResourceTypes:     resourceTypes,
+		Resources:         resources,
+		KubernetesObjects: k8sObjects,
+		StateKey:          stateKey,
 	}, nil
+}
+
+// collectBootstrapResources synthesizes the resources created by the bootstrap
+// step. Bootstrap runs imperatively (it provisions the very state backend that
+// Pulumi later uses), so these resources never appear in a Pulumi state file.
+// Identifiers are derived from PTD's deterministic naming conventions rather
+// than queried from the cloud; the logic mirrors lib/steps/bootstrap.go.
+func collectBootstrapResources(target types.Target) []ResourceDetail {
+	var resources []ResourceDetail
+	switch target.CloudProvider() {
+	case types.Azure:
+		if t, ok := target.(ptdazure.Target); ok {
+			resources = bootstrapAzureResources(t)
+		}
+	case types.AWS:
+		if t, ok := target.(ptdaws.Target); ok {
+			resources = bootstrapAWSResources(t)
+		}
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Type != resources[j].Type {
+			return resources[i].Type < resources[j].Type
+		}
+		return resources[i].Name < resources[j].Name
+	})
+	return resources
+}
+
+// bootstrapAzureResources lists the Azure resources created by the bootstrap
+// step (see BootstrapStep.runAzure). Role-assignment IDs are random GUIDs that
+// cannot be derived, so the built-in role-definition GUID is shown instead.
+func bootstrapAzureResources(t ptdazure.Target) []ResourceDetail {
+	add := func(res *[]ResourceDetail, name, typ, id string) {
+		*res = append(*res, ResourceDetail{Name: name, Type: typ, ID: id})
+	}
+	var res []ResourceDetail
+
+	add(&res, t.ResourceGroupName(), "Azure Resource Group", t.ResourceGroupName())
+	add(&res, t.StateBucketName(), "Azure Storage Account (Pulumi state)", t.StateBucketName())
+	add(&res, t.BlobStorageName(), "Azure Blob Container (Pulumi state)", t.BlobStorageName())
+	add(&res, t.VaultName(), "Azure Key Vault", t.VaultName())
+	add(&res, consts.AzKeyName, "Azure Key Vault Key (state encryption)", consts.AzKeyName)
+
+	adminGroup := t.AdminGroupID()
+	add(&res, fmt.Sprintf("Key Vault Administrator → %s", adminGroup), "Azure Role Assignment", consts.KeyVaultAdminRoleId)
+	add(&res, fmt.Sprintf("Storage Blob Data Contributor → %s", adminGroup), "Azure Role Assignment", consts.StorageBlobDataContribRoleId)
+	add(&res, fmt.Sprintf("AKS RBAC Cluster Admin → %s", adminGroup), "Azure Role Assignment", consts.AksRbacClusterAdminRoleId)
+
+	for siteName := range t.Sites() {
+		for _, field := range bootstrapSiteSecretFields(siteName) {
+			name := fmt.Sprintf("%s-%s", siteName, field)
+			add(&res, name, "Azure Key Vault Secret", name)
+		}
+	}
+	return res
+}
+
+// bootstrapAWSResources lists the AWS resources created by the bootstrap step
+// (see BootstrapStep.runAws).
+func bootstrapAWSResources(t ptdaws.Target) []ResourceDetail {
+	add := func(res *[]ResourceDetail, name, typ string) {
+		*res = append(*res, ResourceDetail{Name: name, Type: typ, ID: name})
+	}
+	var res []ResourceDetail
+
+	add(&res, t.StateBucketName(), "AWS S3 Bucket (Pulumi state)")
+	add(&res, consts.KmsAlias, "AWS KMS Key (state encryption)")
+	if t.CreateAdminPolicyAsResource() {
+		add(&res, consts.PositTeamDedicatedAdminPolicyName, "AWS IAM Policy")
+	}
+	add(&res, fmt.Sprintf("%s.posit.team", t.Name()), "AWS Secrets Manager Secret")
+
+	for siteName := range t.Sites() {
+		add(&res, fmt.Sprintf("%s-%s.posit.team", t.Name(), siteName), "AWS Secrets Manager Secret")
+		add(&res, fmt.Sprintf("%s-%s.sessions.posit.team", t.Name(), siteName), "AWS Secrets Manager Secret")
+		add(&res, fmt.Sprintf("%s-%s-ssh-ppm-keys.posit.team", t.Name(), siteName), "AWS Secrets Manager Secret")
+	}
+	return res
+}
+
+// bootstrapSiteSecretFields returns the per-site secret field names that the
+// bootstrap step writes into the Key Vault, mirroring its logic: marshal the
+// NewSiteSecret template and emit one entry per populated field.
+func bootstrapSiteSecretFields(siteName string) []string {
+	siteSecret := secrets.NewSiteSecret(siteName)
+	data, err := json.Marshal(siteSecret)
+	if err != nil {
+		return nil
+	}
+	var fieldMap map[string]any
+	if err := json.Unmarshal(data, &fieldMap); err != nil {
+		return nil
+	}
+	var fields []string
+	for field, value := range fieldMap {
+		if fmt.Sprintf("%v", value) == "" {
+			continue
+		}
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+// extractKubernetesObject pulls the kind, namespace, name, and cluster-assigned
+// UID for a Kubernetes resource from its Pulumi state outputs. Helm releases
+// expose name/namespace at the top level and have no metadata.uid.
+func extractKubernetesObject(r pulumistate.PulumiResource) KubernetesObject {
+	obj := KubernetesObject{Kind: kubernetesKind(r.Type, r.Outputs)}
+
+	if md, ok := r.Outputs["metadata"].(map[string]interface{}); ok {
+		obj.Name = stateString(md, "name")
+		obj.Namespace = stateString(md, "namespace")
+		obj.UID = stateString(md, "uid")
+	}
+	// Helm releases (and similar) carry name/namespace at the top level.
+	if obj.Name == "" {
+		obj.Name = stateString(r.Outputs, "name")
+	}
+	if obj.Namespace == "" {
+		obj.Namespace = stateString(r.Outputs, "namespace")
+	}
+	if obj.Name == "" {
+		obj.Name = resourceNameFromURN(r.URN)
+	}
+	return obj
+}
+
+// kubernetesKind derives a human-readable Kubernetes kind from the resource's
+// state outputs, falling back to the last segment of the Pulumi type token.
+func kubernetesKind(resType string, outputs map[string]interface{}) string {
+	if strings.Contains(resType, "helm.sh") {
+		return "Helm Release"
+	}
+	if kind := stateString(outputs, "kind"); kind != "" {
+		return kind
+	}
+	if i := strings.LastIndex(resType, ":"); i >= 0 && i < len(resType)-1 {
+		return resType[i+1:]
+	}
+	return resType
+}
+
+// stateString safely reads a string field from a Pulumi state outputs map.
+func stateString(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// resourceNameFromURN extracts the logical resource name from a Pulumi URN.
+// URNs have the form urn:pulumi:{stack}::{project}::{type-chain}::{name};
+// the name is the final "::"-delimited segment.
+func resourceNameFromURN(urn string) string {
+	if urn == "" {
+		return ""
+	}
+	parts := strings.Split(urn, "::")
+	return parts[len(parts)-1]
 }

--- a/lib/attestation/attestation.go
+++ b/lib/attestation/attestation.go
@@ -895,11 +895,17 @@ func collectBootstrapResources(target types.Target) []ResourceDetail {
 	case types.Azure:
 		if t, ok := target.(ptdazure.Target); ok {
 			resources = bootstrapAzureResources(t)
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: target %q reports Azure but is not an *azure.Target; bootstrap inventory will be empty\n", target.Name())
 		}
 	case types.AWS:
 		if t, ok := target.(ptdaws.Target); ok {
 			resources = bootstrapAWSResources(t)
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: target %q reports AWS but is not an *aws.Target; bootstrap inventory will be empty\n", target.Name())
 		}
+	default:
+		fmt.Fprintf(os.Stderr, "Warning: unrecognized cloud provider %q for target %q; bootstrap inventory will be empty\n", target.CloudProvider(), target.Name())
 	}
 	sort.Slice(resources, func(i, j int) bool {
 		if resources[i].Type != resources[j].Type {

--- a/lib/attestation/attestation_test.go
+++ b/lib/attestation/attestation_test.go
@@ -475,6 +475,63 @@ func TestPurposeForStack(t *testing.T) {
 	}
 }
 
+func TestParseInfraConfigExternalDNSDefault(t *testing.T) {
+	t.Run("aws omitted defaults true", func(t *testing.T) {
+		yaml := `spec:
+  vpc_cidr: 10.0.0.0/16
+`
+		cfg, err := parseAWSInfraConfig([]byte(yaml))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cfg.ExternalDNSEnabled {
+			t.Errorf("ExternalDNSEnabled = false, want true (omitted should default true)")
+		}
+	})
+
+	t.Run("aws explicit false", func(t *testing.T) {
+		yaml := `spec:
+  external_dns_enabled: false
+`
+		cfg, err := parseAWSInfraConfig([]byte(yaml))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ExternalDNSEnabled {
+			t.Errorf("ExternalDNSEnabled = true, want false (explicit false)")
+		}
+	})
+
+	t.Run("azure omitted defaults true", func(t *testing.T) {
+		yaml := `kind: AzureWorkloadConfig
+spec:
+  subscription_id: sub-id
+`
+		cfg, err := parseAzureInfraConfig([]byte(yaml))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cfg.ExternalDNSEnabled {
+			t.Errorf("ExternalDNSEnabled = false, want true (omitted should default true)")
+		}
+	})
+
+	t.Run("azure explicit false", func(t *testing.T) {
+		yaml := `kind: AzureWorkloadConfig
+spec:
+  subscription_id: sub-id
+  external_dns_enabled: false
+`
+		cfg, err := parseAzureInfraConfig([]byte(yaml))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ExternalDNSEnabled {
+			t.Errorf("ExternalDNSEnabled = true, want false (explicit false)")
+		}
+	})
+}
+
 func TestCleanVersion(t *testing.T) {
 	tests := []struct {
 		image string

--- a/lib/attestation/attestation_test.go
+++ b/lib/attestation/attestation_test.go
@@ -1,8 +1,13 @@
 package attestation
 
 import (
+	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/posit-dev/ptd/lib/azure"
+	"github.com/posit-dev/ptd/lib/pulumistate"
+	"github.com/posit-dev/ptd/lib/types"
 )
 
 func TestParseStateFile(t *testing.T) {
@@ -141,6 +146,228 @@ func TestParseStateFile(t *testing.T) {
 				t.Errorf("StateKey = %q, want %q", summary.StateKey, tt.key)
 			}
 		})
+	}
+}
+
+func TestResourceNameFromURN(t *testing.T) {
+	tests := []struct {
+		urn  string
+		want string
+	}{
+		{"urn:pulumi:prod::proj::aws:s3/bucket:Bucket::my-bucket", "my-bucket"},
+		{"urn:pulumi:prod::proj::azure-native:containerservice:ManagedCluster::aks", "aks"},
+		// Component resources nest the type chain; the name is still the last segment.
+		{"urn:pulumi:prod::proj::my:component:Thing$aws:ec2/vpc:Vpc::my-vpc", "my-vpc"},
+		{"", ""},
+		{"no-delimiters", "no-delimiters"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.urn, func(t *testing.T) {
+			if got := resourceNameFromURN(tt.urn); got != tt.want {
+				t.Errorf("resourceNameFromURN(%q) = %q, want %q", tt.urn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseStateFileResources(t *testing.T) {
+	stateJSON := `{
+		"version": 3,
+		"checkpoint": {
+			"latest": {
+				"manifest": {"time": "2025-01-15T10:30:00Z", "version": "3.100.0"},
+				"resources": [
+					{"type": "pulumi:pulumi:Stack", "urn": "urn:pulumi:prod::proj::pulumi:pulumi:Stack::proj-prod"},
+					{"type": "pulumi:providers:aws", "urn": "urn:pulumi:prod::proj::pulumi:providers:aws::default"},
+					{"type": "aws:s3/bucket:Bucket", "urn": "urn:pulumi:prod::proj::aws:s3/bucket:Bucket::my-bucket", "id": "my-bucket-1234"},
+					{"type": "aws:ec2/vpc:Vpc", "urn": "urn:pulumi:prod::proj::aws:ec2/vpc:Vpc::my-vpc", "id": "vpc-0abc"}
+				]
+			}
+		}
+	}`
+
+	summary, err := parseStateFile([]byte(stateJSON), ".pulumi/stacks/ptd-aws-workload-persistent/prod.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Internal resources are excluded; only the two cloud resources remain.
+	if len(summary.Resources) != 2 {
+		t.Fatalf("got %d resources, want 2", len(summary.Resources))
+	}
+
+	// Resources are sorted by type, so the VPC precedes the bucket.
+	want := []ResourceDetail{
+		{Name: "my-vpc", Type: "aws:ec2/vpc:Vpc", ID: "vpc-0abc", URN: "urn:pulumi:prod::proj::aws:ec2/vpc:Vpc::my-vpc"},
+		{Name: "my-bucket", Type: "aws:s3/bucket:Bucket", ID: "my-bucket-1234", URN: "urn:pulumi:prod::proj::aws:s3/bucket:Bucket::my-bucket"},
+	}
+	for i, w := range want {
+		got := summary.Resources[i]
+		if got != w {
+			t.Errorf("Resources[%d] = %+v, want %+v", i, got, w)
+		}
+	}
+}
+
+func TestResourceDetailDisplayID(t *testing.T) {
+	urn := "urn:pulumi:prod::proj::ptd:AzureBastion::bastion"
+	tests := []struct {
+		name string
+		res  ResourceDetail
+		want string
+	}{
+		{"cloud id present", ResourceDetail{ID: "vpc-0abc", URN: urn}, "vpc-0abc"},
+		{"empty id falls back to urn", ResourceDetail{ID: "", URN: urn}, urn},
+		{"literal none falls back to urn", ResourceDetail{ID: "none", URN: urn}, urn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.res.DisplayID(); got != tt.want {
+				t.Errorf("DisplayID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBootstrapSiteSecretFields(t *testing.T) {
+	got := bootstrapSiteSecretFields("main")
+	want := []string{
+		"dev-db-password",
+		"keycloak-db-password",
+		"keycloak-db-user",
+		"pkg-db-password",
+		"pkg-secret-key",
+		"pub-db-password",
+		"pub-secret-key",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bootstrapSiteSecretFields(main) = %v, want %v", got, want)
+	}
+}
+
+func TestCollectBootstrapResourcesAzure(t *testing.T) {
+	sites := map[string]types.SiteConfig{
+		"main": {Spec: types.SiteConfigSpec{Domain: "example.com"}},
+	}
+	target := azure.NewTarget("example01-production", "sub-id", "tenant-id", "westeurope", sites, "admin-group-id", "", nil)
+
+	res := collectBootstrapResources(target)
+
+	// 5 foundational resources + 3 role assignments + 7 per-site secrets.
+	if len(res) != 15 {
+		t.Fatalf("got %d bootstrap resources, want 15", len(res))
+	}
+
+	// Spot-check that key foundational resources are present with derived IDs.
+	byName := make(map[string]ResourceDetail, len(res))
+	for _, r := range res {
+		byName[r.Name] = r
+	}
+	for _, name := range []string{
+		target.ResourceGroupName(),
+		target.StateBucketName(),
+		target.VaultName(),
+		"posit-team-dedicated", // consts.AzKeyName
+		"main-pub-db-password", // a per-site secret
+	} {
+		r, ok := byName[name]
+		if !ok {
+			t.Errorf("expected bootstrap resource %q to be present", name)
+			continue
+		}
+		if r.DisplayID() == "" {
+			t.Errorf("bootstrap resource %q has empty DisplayID", name)
+		}
+	}
+
+	// Results must be sorted by type then name.
+	if !sort.SliceIsSorted(res, func(i, j int) bool {
+		if res[i].Type != res[j].Type {
+			return res[i].Type < res[j].Type
+		}
+		return res[i].Name < res[j].Name
+	}) {
+		t.Error("bootstrap resources are not sorted by type then name")
+	}
+}
+
+func TestExtractKubernetesObject(t *testing.T) {
+	tests := []struct {
+		name string
+		res  pulumistate.PulumiResource
+		want KubernetesObject
+	}{
+		{
+			name: "namespaced object with uid",
+			res: pulumistate.PulumiResource{
+				Type: "kubernetes:core/v1:ConfigMap",
+				URN:  "urn:pulumi:p::proj::kubernetes:core/v1:ConfigMap::cm",
+				Outputs: map[string]interface{}{
+					"kind": "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "alloy-config",
+						"namespace": "alloy",
+						"uid":       "abc-123",
+					},
+				},
+			},
+			want: KubernetesObject{Kind: "ConfigMap", Namespace: "alloy", Name: "alloy-config", UID: "abc-123"},
+		},
+		{
+			name: "cluster-scoped object has no namespace",
+			res: pulumistate.PulumiResource{
+				Type: "kubernetes:core/v1:Namespace",
+				URN:  "urn:pulumi:p::proj::kubernetes:core/v1:Namespace::ns",
+				Outputs: map[string]interface{}{
+					"kind":     "Namespace",
+					"metadata": map[string]interface{}{"name": "posit-team", "uid": "ns-1"},
+				},
+			},
+			want: KubernetesObject{Kind: "Namespace", Namespace: "", Name: "posit-team", UID: "ns-1"},
+		},
+		{
+			name: "helm release: top-level name/namespace, no uid",
+			res: pulumistate.PulumiResource{
+				Type: "kubernetes:helm.sh/v3:Release",
+				URN:  "urn:pulumi:p::proj::kubernetes:helm.sh/v3:Release::traefik",
+				Outputs: map[string]interface{}{
+					"name":      "traefik",
+					"namespace": "traefik",
+				},
+			},
+			want: KubernetesObject{Kind: "Helm Release", Namespace: "traefik", Name: "traefik", UID: ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractKubernetesObject(tt.res)
+			if got != tt.want {
+				t.Errorf("extractKubernetesObject() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubernetesObjectDisplay(t *testing.T) {
+	ns := KubernetesObject{Kind: "Namespace", Name: "posit-team", UID: "ns-1"}
+	if ns.DisplayNamespace() != "—" {
+		t.Errorf("cluster-scoped DisplayNamespace() = %q, want —", ns.DisplayNamespace())
+	}
+	if ns.DisplayUID() != "ns-1" {
+		t.Errorf("DisplayUID() = %q, want ns-1", ns.DisplayUID())
+	}
+
+	release := KubernetesObject{Kind: "Helm Release", Namespace: "traefik", Name: "traefik"}
+	if release.DisplayUID() != "— (release)" {
+		t.Errorf("Helm release DisplayUID() = %q, want — (release)", release.DisplayUID())
+	}
+	if release.DisplayNamespace() != "traefik" {
+		t.Errorf("DisplayNamespace() = %q, want traefik", release.DisplayNamespace())
+	}
+
+	orphan := KubernetesObject{Kind: "ConfigMap", Name: "x"}
+	if orphan.DisplayUID() != "—" {
+		t.Errorf("missing-uid non-release DisplayUID() = %q, want —", orphan.DisplayUID())
 	}
 }
 

--- a/lib/attestation/attestation_test.go
+++ b/lib/attestation/attestation_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/posit-dev/ptd/lib/aws"
 	"github.com/posit-dev/ptd/lib/azure"
 	"github.com/posit-dev/ptd/lib/pulumistate"
 	"github.com/posit-dev/ptd/lib/types"
@@ -269,6 +270,54 @@ func TestCollectBootstrapResourcesAzure(t *testing.T) {
 		target.VaultName(),
 		"posit-team-dedicated", // consts.AzKeyName
 		"main-pub-db-password", // a per-site secret
+	} {
+		r, ok := byName[name]
+		if !ok {
+			t.Errorf("expected bootstrap resource %q to be present", name)
+			continue
+		}
+		if r.DisplayID() == "" {
+			t.Errorf("bootstrap resource %q has empty DisplayID", name)
+		}
+	}
+
+	// Results must be sorted by type then name.
+	if !sort.SliceIsSorted(res, func(i, j int) bool {
+		if res[i].Type != res[j].Type {
+			return res[i].Type < res[j].Type
+		}
+		return res[i].Name < res[j].Name
+	}) {
+		t.Error("bootstrap resources are not sorted by type then name")
+	}
+}
+
+func TestCollectBootstrapResourcesAWS(t *testing.T) {
+	sites := map[string]types.SiteConfig{
+		"main": {Spec: types.SiteConfigSpec{Domain: "example.com"}},
+	}
+	// createAdminPolicyAsResource is set explicitly so the expected resource
+	// count is deterministic (the admin policy is only emitted when true).
+	target := aws.NewTarget("example01-production", "123456789012", "example-profile", nil, "us-east-2", false, false, true, sites, nil)
+
+	res := collectBootstrapResources(target)
+
+	// state bucket + KMS alias + admin policy + workload secret + 3 per-site secrets.
+	if len(res) != 7 {
+		t.Fatalf("got %d bootstrap resources, want 7", len(res))
+	}
+
+	// Spot-check key resources are present with derived IDs.
+	byName := make(map[string]ResourceDetail, len(res))
+	for _, r := range res {
+		byName[r.Name] = r
+	}
+	for _, name := range []string{
+		target.StateBucketName(),
+		"example01-production.posit.team",
+		"example01-production-main.posit.team",
+		"example01-production-main.sessions.posit.team",
+		"example01-production-main-ssh-ppm-keys.posit.team",
 	} {
 		r, ok := byName[name]
 		if !ok {

--- a/lib/attestation/markdown.go
+++ b/lib/attestation/markdown.go
@@ -215,27 +215,27 @@ _Generated: {{ .GeneratedAt | formatDate }}_
 
 The following table enumerates every managed resource across all Pulumi stacks, as reported by the state files at the time of generation. Pulumi-internal resources (the stack object and provider instances) are excluded. The ` + "`" + `bootstrap` + "`" + ` step provisions the Pulumi state backend itself and therefore runs outside Pulumi; its resources are listed from PTD's naming conventions rather than from state.
 
-| Step / Stack | Name | Type | Cloud / Logical Resource ID |
+| Pulumi Stack | Name | Type | Cloud / Logical Resource ID |
 |---|---|---|---|
 {{ range .BootstrapResources -}}
 | bootstrap | ` + "`" + `{{ .Name }}` + "`" + ` | {{ .Type }} | ` + "`" + `{{ .DisplayID }}` + "`" + ` |
 {{ end -}}
 {{ range .Stacks -}}
-{{ $step := .StepNameFromProject -}}
+{{ $project := .ProjectName -}}
 {{ range .Resources -}}
-| {{ $step }} | ` + "`" + `{{ .Name }}` + "`" + ` | ` + "`" + `{{ .Type }}` + "`" + ` | ` + "`" + `{{ .DisplayID }}` + "`" + ` |
+| ` + "`" + `{{ $project }}` + "`" + ` | ` + "`" + `{{ .Name }}` + "`" + ` | ` + "`" + `{{ .Type }}` + "`" + ` | ` + "`" + `{{ .DisplayID }}` + "`" + ` |
 {{ end -}}
 {{ end }}
 ## Appendix B — Kubernetes Objects
 
 This table lists the Kubernetes objects PTD configures across the cluster, together with the cluster-assigned ` + "`" + `metadata.uid` + "`" + ` recorded in Pulumi state at the time of the last deployment. The UID is assigned by Kubernetes when an object is admitted, so it confirms the object was actually created in the cluster. Helm releases wrap multiple objects and therefore carry no single UID.
 
-| Step | Kind | Namespace | Name | UID |
+| Pulumi Stack | Kind | Namespace | Name | UID |
 |---|---|---|---|---|
 {{ range .Stacks -}}
-{{ $step := .StepNameFromProject -}}
+{{ $project := .ProjectName -}}
 {{ range .KubernetesObjects -}}
-| {{ $step }} | {{ .Kind }} | {{ .DisplayNamespace }} | ` + "`" + `{{ .Name }}` + "`" + ` | ` + "`" + `{{ .DisplayUID }}` + "`" + ` |
+| ` + "`" + `{{ $project }}` + "`" + ` | {{ .Kind }} | {{ .DisplayNamespace }} | ` + "`" + `{{ .Name }}` + "`" + ` | ` + "`" + `{{ .DisplayUID }}` + "`" + ` |
 {{ end -}}
 {{ end }}
 `))

--- a/lib/attestation/markdown.go
+++ b/lib/attestation/markdown.go
@@ -210,6 +210,34 @@ _Generated: {{ .GeneratedAt | formatDate }}_
 | | Name | Date |
 |---|---|---|
 | Prepared By | | {{ .GeneratedAt | formatDate }} |
+
+## Appendix A — Full Resource Inventory
+
+The following table enumerates every managed resource across all Pulumi stacks, as reported by the state files at the time of generation. Pulumi-internal resources (the stack object and provider instances) are excluded. The ` + "`" + `bootstrap` + "`" + ` step provisions the Pulumi state backend itself and therefore runs outside Pulumi; its resources are listed from PTD's naming conventions rather than from state.
+
+| Step / Stack | Name | Type | Cloud / Logical Resource ID |
+|---|---|---|---|
+{{ range .BootstrapResources -}}
+| bootstrap | ` + "`" + `{{ .Name }}` + "`" + ` | {{ .Type }} | ` + "`" + `{{ .DisplayID }}` + "`" + ` |
+{{ end -}}
+{{ range .Stacks -}}
+{{ $step := .StepNameFromProject -}}
+{{ range .Resources -}}
+| {{ $step }} | ` + "`" + `{{ .Name }}` + "`" + ` | ` + "`" + `{{ .Type }}` + "`" + ` | ` + "`" + `{{ .DisplayID }}` + "`" + ` |
+{{ end -}}
+{{ end }}
+## Appendix B — Kubernetes Objects
+
+This table lists the Kubernetes objects PTD configures across the cluster, together with the cluster-assigned ` + "`" + `metadata.uid` + "`" + ` recorded in Pulumi state at the time of the last deployment. The UID is assigned by Kubernetes when an object is admitted, so it confirms the object was actually created in the cluster. Helm releases wrap multiple objects and therefore carry no single UID.
+
+| Step | Kind | Namespace | Name | UID |
+|---|---|---|---|---|
+{{ range .Stacks -}}
+{{ $step := .StepNameFromProject -}}
+{{ range .KubernetesObjects -}}
+| {{ $step }} | {{ .Kind }} | {{ .DisplayNamespace }} | ` + "`" + `{{ .Name }}` + "`" + ` | ` + "`" + `{{ .DisplayUID }}` + "`" + ` |
+{{ end -}}
+{{ end }}
 `))
 
 // RenderMarkdown writes the attestation data as a Markdown document to the given writer.

--- a/lib/attestation/pdf.go
+++ b/lib/attestation/pdf.go
@@ -14,6 +14,7 @@ import (
 	"github.com/johnfercher/maroto/v2/pkg/config"
 	"github.com/johnfercher/maroto/v2/pkg/consts/align"
 	"github.com/johnfercher/maroto/v2/pkg/consts/border"
+	"github.com/johnfercher/maroto/v2/pkg/consts/breakline"
 	"github.com/johnfercher/maroto/v2/pkg/consts/fontstyle"
 	"github.com/johnfercher/maroto/v2/pkg/core"
 	"github.com/johnfercher/maroto/v2/pkg/props"
@@ -256,6 +257,65 @@ func RenderPDF(outputPath string, data *AttestationData) error {
 		PdfSignatureRow("Prepared By", data.GeneratedAt.Format("2006-01-02")),
 	))
 
+	// Appendix A — full resource inventory, on its own page.
+	appendixRows := []core.Row{
+		text.NewRow(10, "Appendix A — Full Resource Inventory", props.Text{
+			Size:  14,
+			Style: fontstyle.Bold,
+			Align: align.Left,
+			Color: AccentColor,
+		}),
+		line.NewRow(2, props.Line{
+			Color:     BorderColor,
+			Thickness: 0.5,
+		}),
+		row.New(2),
+		text.NewRow(14, "Every managed resource across all Pulumi stacks, as reported by the state files at the time of generation. Pulumi-internal resources are excluded. The bootstrap step provisions the Pulumi state backend itself and runs outside Pulumi; its resources are listed from PTD's naming conventions rather than from state.", props.Text{
+			Size:  9,
+			Align: align.Left,
+		}),
+		row.New(2),
+		PdfAppendixHeader([]string{"Step / Stack", "Name", "Type", "Cloud / Logical Resource ID"}, appendixColSizes),
+	}
+	for _, res := range data.BootstrapResources {
+		appendixRows = append(appendixRows, PdfAppendixRow([]string{"bootstrap", res.Name, res.Type, res.DisplayID()}, appendixColSizes))
+	}
+	for _, stack := range data.Stacks {
+		step := stack.StepNameFromProject()
+		for _, res := range stack.Resources {
+			appendixRows = append(appendixRows, PdfAppendixRow([]string{step, res.Name, res.Type, res.DisplayID()}, appendixColSizes))
+		}
+	}
+	m.AddPages(page.New().Add(appendixRows...))
+
+	// Appendix B — Kubernetes objects, on its own page.
+	appendixBRows := []core.Row{
+		text.NewRow(10, "Appendix B — Kubernetes Objects", props.Text{
+			Size:  14,
+			Style: fontstyle.Bold,
+			Align: align.Left,
+			Color: AccentColor,
+		}),
+		line.NewRow(2, props.Line{
+			Color:     BorderColor,
+			Thickness: 0.5,
+		}),
+		row.New(2),
+		text.NewRow(18, "Kubernetes objects PTD configures across the cluster, with the cluster-assigned metadata.uid recorded in Pulumi state at the last deployment. The UID is assigned by Kubernetes when an object is admitted, so it confirms the object was actually created. Helm releases wrap multiple objects and carry no single UID.", props.Text{
+			Size:  9,
+			Align: align.Left,
+		}),
+		row.New(2),
+		PdfAppendixHeader([]string{"Step", "Kind", "Namespace", "Name", "UID"}, appendixBColSizes),
+	}
+	for _, stack := range data.Stacks {
+		step := stack.StepNameFromProject()
+		for _, obj := range stack.KubernetesObjects {
+			appendixBRows = append(appendixBRows, PdfAppendixRow([]string{step, obj.Kind, obj.DisplayNamespace(), obj.Name, obj.DisplayUID()}, appendixBColSizes))
+		}
+	}
+	m.AddPages(page.New().Add(appendixBRows...))
+
 	// Generate
 	doc, err := m.Generate()
 	if err != nil {
@@ -397,6 +457,51 @@ func PdfTableRow(values []string, sizes []int) core.Row {
 		}))
 	}
 	return row.New(6).Add(cols...).WithStyle(&props.Cell{
+		BorderType:      border.Bottom,
+		BorderColor:     BorderColor,
+		BorderThickness: 0.2,
+	})
+}
+
+// appendixColSizes are the grid widths (summing to 12) for the resource
+// inventory table: Step/Stack, Name, Type, Resource ID.
+var appendixColSizes = []int{2, 3, 3, 4}
+
+// appendixBColSizes are the grid widths (summing to 12) for the Kubernetes
+// objects table: Step, Kind, Namespace, Name, UID.
+var appendixBColSizes = []int{2, 2, 2, 3, 3}
+
+// PdfAppendixHeader renders the resource-inventory header at a compact font size.
+func PdfAppendixHeader(headers []string, sizes []int) core.Row {
+	cols := make([]core.Col, len(headers))
+	for i, h := range headers {
+		cols[i] = col.New(sizes[i]).Add(text.New(h, props.Text{
+			Size:  7,
+			Style: fontstyle.Bold,
+			Align: align.Left,
+		}))
+	}
+	return row.New(6).Add(cols...).WithStyle(&props.Cell{
+		BackgroundColor: HeaderBg,
+		BorderType:      border.Bottom,
+		BorderColor:     BorderColor,
+		BorderThickness: 0.3,
+	})
+}
+
+// PdfAppendixRow renders a resource-inventory row. The row auto-sizes its
+// height and each cell uses the dash break strategy so long, space-free values
+// (resource types and cloud ARNs) wrap within the column instead of overflowing.
+func PdfAppendixRow(values []string, sizes []int) core.Row {
+	cols := make([]core.Col, len(values))
+	for i, v := range values {
+		cols[i] = col.New(sizes[i]).Add(text.New(v, props.Text{
+			Size:              7,
+			Align:             align.Left,
+			BreakLineStrategy: breakline.DashStrategy,
+		}))
+	}
+	return row.New().Add(cols...).WithStyle(&props.Cell{
 		BorderType:      border.Bottom,
 		BorderColor:     BorderColor,
 		BorderThickness: 0.2,

--- a/lib/attestation/pdf.go
+++ b/lib/attestation/pdf.go
@@ -275,15 +275,15 @@ func RenderPDF(outputPath string, data *AttestationData) error {
 			Align: align.Left,
 		}),
 		row.New(2),
-		PdfAppendixHeader([]string{"Step / Stack", "Name", "Type", "Cloud / Logical Resource ID"}, appendixColSizes),
+		PdfAppendixHeader([]string{"Pulumi Stack", "Name", "Type", "Cloud / Logical Resource ID"}, appendixColSizes),
 	}
 	for _, res := range data.BootstrapResources {
 		appendixRows = append(appendixRows, PdfAppendixRow([]string{"bootstrap", res.Name, res.Type, res.DisplayID()}, appendixColSizes))
 	}
 	for _, stack := range data.Stacks {
-		step := stack.StepNameFromProject()
+		project := stack.ProjectName
 		for _, res := range stack.Resources {
-			appendixRows = append(appendixRows, PdfAppendixRow([]string{step, res.Name, res.Type, res.DisplayID()}, appendixColSizes))
+			appendixRows = append(appendixRows, PdfAppendixRow([]string{project, res.Name, res.Type, res.DisplayID()}, appendixColSizes))
 		}
 	}
 	m.AddPages(page.New().Add(appendixRows...))
@@ -306,12 +306,12 @@ func RenderPDF(outputPath string, data *AttestationData) error {
 			Align: align.Left,
 		}),
 		row.New(2),
-		PdfAppendixHeader([]string{"Step", "Kind", "Namespace", "Name", "UID"}, appendixBColSizes),
+		PdfAppendixHeader([]string{"Pulumi Stack", "Kind", "Namespace", "Name", "UID"}, appendixBColSizes),
 	}
 	for _, stack := range data.Stacks {
-		step := stack.StepNameFromProject()
+		project := stack.ProjectName
 		for _, obj := range stack.KubernetesObjects {
-			appendixBRows = append(appendixBRows, PdfAppendixRow([]string{step, obj.Kind, obj.DisplayNamespace(), obj.Name, obj.DisplayUID()}, appendixBColSizes))
+			appendixBRows = append(appendixBRows, PdfAppendixRow([]string{project, obj.Kind, obj.DisplayNamespace(), obj.Name, obj.DisplayUID()}, appendixBColSizes))
 		}
 	}
 	m.AddPages(page.New().Add(appendixBRows...))

--- a/lib/attestation/pdf.go
+++ b/lib/attestation/pdf.go
@@ -386,7 +386,7 @@ func PdfParagraph(m core.Maroto, content string) {
 // PdfBullet renders a single bullet point.
 func PdfBullet(m core.Maroto, content string) {
 	m.AddRows(
-		row.New(6).Add(
+		row.New().Add(
 			col.New(1).Add(text.New("•", props.Text{
 				Size:  9,
 				Align: align.Center,
@@ -419,10 +419,12 @@ func PdfStackDetail(m core.Maroto, name string, prose string) {
 			PdfBullet(m, l[2:])
 		} else {
 			m.AddRows(
-				text.NewRow(6, l, props.Text{
-					Size:  9,
-					Align: align.Left,
-				}),
+				row.New().Add(
+					col.New(12).Add(text.New(l, props.Text{
+						Size:  9,
+						Align: align.Left,
+					})),
+				),
 			)
 		}
 	}

--- a/lib/attestation/prose.go
+++ b/lib/attestation/prose.go
@@ -2,6 +2,7 @@ package attestation
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -134,6 +135,11 @@ type InfraConfig struct {
 	CustomerManagedBastionID    string
 	LoadBalancerPerSite         bool
 
+	// ChronicleEnabled is true when any site configures Chronicle telemetry.
+	// Chronicle is optional and frequently not configured, so chronicle-specific
+	// prose (e.g. the Azure storage container) is gated on this flag.
+	ChronicleEnabled bool
+
 	// Sites
 	SiteDomains map[string]string
 }
@@ -202,7 +208,12 @@ func generateAWSPersistentProse(cfg *InfraConfig) string {
 		lines = append(lines, "Integration with customer-managed bastion host for cluster access")
 	}
 
-	return "Provisions the foundational infrastructure layer:\n\n" + BulletList(lines)
+	leadIn := "This stack builds the durable foundation that the rest of the deployment relies on: " +
+		"the private network, the application database, the storage where each Posit product keeps " +
+		"its data, and the security controls that protect them. In plain terms, this is where customer " +
+		"data and configuration physically live. Specifically, it provisions:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 func generateAzurePersistentProse(cfg *InfraConfig) string {
@@ -215,19 +226,50 @@ func generateAzurePersistentProse(cfg *InfraConfig) string {
 		lines = append(lines, fmt.Sprintf(
 			"Integration with customer-provisioned VNet (`%s`)", cfg.ProvisionedVnetName))
 	} else if cfg.VnetCidr != "" {
-		lines = append(lines, fmt.Sprintf("VNet with CIDR `%s`, with public, private, database, and NetApp subnets", cfg.VnetCidr))
+		lines = append(lines, fmt.Sprintf("A private network (VNet) with CIDR `%s`, divided into separate subnets for the application, database, and file storage", cfg.VnetCidr))
 	} else {
-		lines = append(lines, "PTD-managed VNet with public, private, database, and NetApp subnets")
+		lines = append(lines, "A private network (VNet) divided into separate subnets for the application, database, and file storage")
 	}
 
-	lines = append(lines, "Azure Database for PostgreSQL Flexible Server")
-	lines = append(lines, "Azure Storage accounts for Loki logs, Mimir metrics, Package Manager cache, and Chronicle telemetry")
-	lines = append(lines, "Azure NetApp Files for persistent session storage")
-	lines = append(lines, "Azure Key Vault for secrets management")
-	lines = append(lines, "Managed identities for all service components")
-	lines = append(lines, "Network security groups for database, AKS, and internal communication")
+	// Databases (application metadata for all three products).
+	lines = append(lines, "An Azure Database for PostgreSQL Flexible Server. This database holds the "+
+		"application metadata for Posit Connect, Posit Workbench, and Posit Package Manager "+
+		"(for example: user accounts, content listings, schedules, and package index records)")
 
-	return "Provisions the foundational infrastructure layer:\n\n" + BulletList(lines)
+	// Storage accounts.
+	lines = append(lines, "A shared Azure Storage account (created during bootstrap) that holds both the "+
+		"Pulumi state files and the observability data described below")
+	lines = append(lines, "A separate premium Azure Storage account used only to host the Azure Files (NFS) "+
+		"share for Posit Package Manager")
+
+	// Observability containers in the shared account.
+	lines = append(lines, "A `loki` blob container in the shared storage account, holding aggregated logs")
+	lines = append(lines, "A `mimir-blocks` blob container in the shared storage account, holding metrics. "+
+		"This container is created by the Mimir application at runtime (it is not provisioned by Pulumi)")
+	if cfg.ChronicleEnabled {
+		lines = append(lines, "A `chronicle` blob container in the shared storage account, holding Chronicle "+
+			"usage telemetry")
+	}
+
+	// File storage for products.
+	lines = append(lines, "An Azure Files (NFS) share for Posit Package Manager. This is where Package Manager "+
+		"stores the actual package files it serves")
+	lines = append(lines, "Azure NetApp Files volumes (one NFS volume per site, per product) for Posit Connect "+
+		"published content and Posit Workbench user home directories")
+
+	// Secrets, identity, and network controls.
+	lines = append(lines, "An Azure Key Vault for securely storing secrets such as database passwords and keys")
+	lines = append(lines, "Managed identities that let each service authenticate to Azure without storing "+
+		"long-lived credentials")
+	lines = append(lines, "Network security groups that restrict traffic to the database, the Kubernetes "+
+		"cluster, and internal communication")
+
+	leadIn := "This stack builds the durable foundation that the rest of the deployment relies on: " +
+		"the private network, the application database, the storage where each Posit product keeps " +
+		"its data, and the security controls that protect them. In plain terms, this is where customer " +
+		"data and configuration physically live. Specifically, it provisions:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 // generatePostgresConfigProse generates narrative text for the postgres-config stack
@@ -239,7 +281,11 @@ func generatePostgresConfigProse(cfg *InfraConfig) string {
 		secretsNote = "Passwords generated and stored as Key Vault-encrypted secrets in Pulumi state"
 	}
 
-	return fmt.Sprintf("Configures the %s instance with application-specific databases and credentials:\n\n", dbType) +
+	leadIn := fmt.Sprintf("This stack prepares the %s for use. It creates a separate database and "+
+		"login for each component that needs one, so that the monitoring tools and the Posit products "+
+		"each have their own isolated space and credentials. Specifically, it configures:", dbType)
+
+	return leadIn + "\n\n" +
 		BulletList([]string{
 			"Database users for Grafana and internal services",
 			"Dedicated databases with appropriate grants",
@@ -276,7 +322,12 @@ func generateEKSProse(cfg *InfraConfig) string {
 	lines = append(lines, "GP3 default storage class")
 	lines = append(lines, "IAM access entries for cluster administration")
 
-	return "Provisions the Kubernetes control plane and compute:\n\n" + BulletList(lines)
+	leadIn := "This stack creates the managed Kubernetes cluster that runs the Posit products and the " +
+		"supporting services, along with the pool of virtual machines that provide its computing power. " +
+		"Kubernetes is the industry-standard system for running and coordinating containerized " +
+		"applications. Specifically, it provisions:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 func generateAKSProse(cfg *InfraConfig) string {
@@ -297,16 +348,39 @@ func generateAKSProse(cfg *InfraConfig) string {
 	lines = append(lines, "Azure Disk CSI driver for persistent volumes")
 	lines = append(lines, "Managed identity access entries for cluster administration")
 
-	return "Provisions the Kubernetes control plane and compute:\n\n" + BulletList(lines)
+	leadIn := "This stack creates the managed Kubernetes cluster that runs the Posit products and the " +
+		"supporting services, along with the pools of virtual machines that provide its computing power. " +
+		"Kubernetes is the industry-standard system for running and coordinating containerized " +
+		"applications. Specifically, it provisions:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 // generateClustersProse generates narrative text for the clusters stack
 func generateClustersProse(cfg *InfraConfig) string {
-	lines := []string{
-		"Namespaces: `posit-team`, `loki`, `grafana`, `mimir`, and supporting namespaces",
-		"Calico network policies restricting inter-namespace traffic",
-		"Team Operator deployment (manages Posit product lifecycle)",
+	var lines []string
+
+	// Namespaces are logical partitions inside the cluster. Enumerate the ones
+	// this stack creates, with a short purpose for each. The remaining
+	// observability namespaces (loki, mimir, alloy, kube-state-metrics) are
+	// created by the helm stack and are described there. The `grafana`
+	// namespace is the exception: on AWS it is created here in the clusters
+	// stack (see lib/steps/clusters_aws.go), so it is enumerated below for the
+	// AWS branch only; on Azure it is created by the helm stack.
+	lines = append(lines, "The `posit-team` namespace, which runs the Posit product workloads (Connect, Workbench, Package Manager, and their TeamSites)")
+	lines = append(lines, "The `posit-team-system` namespace, which runs the Team Operator (the component that manages the lifecycle of the Posit products)")
+	lines = append(lines, "The `helm-controller` namespace, which runs the in-cluster controller that installs Helm charts in response to `HelmChart` custom resources. These custom resources live in this namespace but can target other namespaces, which is why some objects appear grouped here")
+	lines = append(lines, "The `cert-manager` namespace, which manages the lifecycle of TLS certificates (used when Let's Encrypt is configured)")
+	lines = append(lines, "The `traefik` namespace, which runs the ingress controller that routes incoming web traffic to the right product")
+	if !cfg.IsAzure() {
+		lines = append(lines, "The `grafana` namespace, which hosts the Grafana observability stack (the dashboards and data sources for logs and metrics)")
 	}
+	if cfg.IsAzure() {
+		lines = append(lines, "CoreDNS customization (`coredns-custom`) in the AKS-managed `kube-system` namespace; PTD only patches DNS configuration there and does not otherwise manage that namespace")
+	}
+
+	lines = append(lines, "Calico network policies restricting inter-namespace traffic")
+	lines = append(lines, "Team Operator deployment (manages Posit product lifecycle)")
 
 	if cfg.PublicLoadBalancer {
 		lines = append(lines, "Traefik ingress controller with public-facing load balancer")
@@ -314,11 +388,11 @@ func generateClustersProse(cfg *InfraConfig) string {
 		lines = append(lines, "Traefik ingress controller with internal-only load balancer")
 	}
 
-	if !cfg.ExternalDNSEnabled {
-		lines = append(lines, "External DNS disabled (per customer configuration)")
-	} else {
-		if cfg.IsAzure() {
-			lines = append(lines, "External DNS for automatic Azure DNS record management")
+	// On AWS, external-dns is created in the clusters stack and is flag-driven.
+	// On Azure, external-dns is created in the helm stack and is described there.
+	if !cfg.IsAzure() {
+		if !cfg.ExternalDNSEnabled {
+			lines = append(lines, "External DNS disabled (per customer configuration)")
 		} else {
 			lines = append(lines, "External DNS for automatic Route 53 record management")
 		}
@@ -334,15 +408,30 @@ func generateClustersProse(cfg *InfraConfig) string {
 		lines = append(lines, "Keycloak operator for identity management")
 	}
 
-	return "Configures the Kubernetes cluster with the required namespaces, operators, and network policies:\n\n" + BulletList(lines)
+	leadIn := "This stack takes the empty Kubernetes cluster and sets up the shared groundwork that the " +
+		"Posit products need before they can be installed: it divides the cluster into named areas " +
+		"(namespaces), installs the controllers that manage applications and certificates, configures the " +
+		"component that routes incoming web traffic, and applies network rules that limit how those areas " +
+		"can talk to each other. Specifically, it configures:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 // generateHelmProse generates narrative text for the helm stack
 func generateHelmProse(cfg *InfraConfig) string {
 	lines := []string{
-		"Grafana, Loki, and Mimir for observability and log aggregation",
-		"Grafana Alloy for metrics and log collection",
+		"Grafana, Loki, and Mimir for observability and log aggregation. These components run in their own namespaces (`grafana`, `loki`, and `mimir`)",
+		"Grafana Alloy for metrics and log collection, in the `alloy` namespace, together with kube-state-metrics in the `kube-state-metrics` namespace",
 		"cert-manager for TLS certificate lifecycle",
+	}
+
+	// On Azure, external-dns is deployed by this stack, unconditionally. The
+	// deploy does not consult the enable flag, so there is no "disabled" branch.
+	// (On AWS, external-dns is part of the clusters stack and is described there.)
+	if cfg.IsAzure() {
+		lines = append(lines, "External DNS for automatic Azure DNS record management, in the `external-dns` "+
+			"namespace. Its `azure-config-file` secret holds the workload-identity configuration that lets "+
+			"it update Azure DNS records on behalf of the cluster")
 	}
 
 	if cfg.SecretsStoreAddonEnabled {
@@ -353,26 +442,47 @@ func generateHelmProse(cfg *InfraConfig) string {
 		}
 	}
 
-	return "Deploys supporting services as Helm charts:\n\n" + BulletList(lines)
+	leadIn := "This stack installs the shared supporting services that the platform depends on, packaged as " +
+		"Helm charts (a standard format for deploying applications onto Kubernetes). These services provide " +
+		"monitoring and log collection, manage TLS certificates, and—on Azure—keep public DNS records up to " +
+		"date. Specifically, it deploys:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 // generateSitesProse generates narrative text for the sites stack
 func generateSitesProse(cfg *InfraConfig) string {
 	lines := []string{}
 
-	for name, domain := range cfg.SiteDomains {
-		lines = append(lines, fmt.Sprintf("TeamSite custom resource for the `%s` site at `%s`", name, domain))
+	// Collect site names in a stable order so the per-site config references are
+	// deterministic.
+	siteNames := make([]string, 0, len(cfg.SiteDomains))
+	for name := range cfg.SiteDomains {
+		siteNames = append(siteNames, name)
+	}
+	sort.Strings(siteNames)
+
+	for _, name := range siteNames {
+		domain := cfg.SiteDomains[name]
+		lines = append(lines, fmt.Sprintf("TeamSite custom resource for the `%s` site at `%s`, as declared in `site_%s/site.yaml`", name, domain, name))
 	}
 
-	lines = append(lines, "Posit Connect, Workbench, and Package Manager instances as declared in `site.yaml`")
-	lines = append(lines, "Chronicle observability agent and sidecar")
+	lines = append(lines, "Posit Connect, Workbench, and Package Manager instances at the versions and settings declared in each site's `site_<name>/site.yaml`")
+	if cfg.ChronicleEnabled {
+		lines = append(lines, "Chronicle observability agent and sidecar")
+	}
 	lines = append(lines, "Ingress resources routing traffic from Traefik to each product")
 
 	if cfg.PrivateZone || cfg.HostedZoneManagementEnabled {
 		lines = append(lines, "DNS records in the hosted zone for each product subdomain")
 	}
 
-	return "Deploys the Posit products into the cluster:\n\n" + BulletList(lines)
+	leadIn := "This stack deploys the Posit products themselves into the prepared cluster, one configured " +
+		"site at a time. Each site corresponds to a `site_<name>/site.yaml` file that declares which " +
+		"products run, their versions, and their settings; this stack turns those declarations into " +
+		"running applications reachable at their web addresses. Specifically, it deploys:"
+
+	return leadIn + "\n\n" + BulletList(lines)
 }
 
 // GenerateStackProse generates prose for a stack given its step name and the infrastructure config

--- a/lib/attestation/prose_test.go
+++ b/lib/attestation/prose_test.go
@@ -1,8 +1,157 @@
 package attestation
 
 import (
+	"strings"
 	"testing"
 )
+
+func TestGenerateAzurePersistentProse(t *testing.T) {
+	t.Run("corrected storage facts, chronicle off", func(t *testing.T) {
+		cfg := &InfraConfig{Cloud: "azure", VnetCidr: "10.0.0.0/16", ChronicleEnabled: false}
+		got := generateAzurePersistentProse(cfg)
+
+		// Must contain the corrected facts.
+		mustContain := []string{
+			"Azure Files (NFS) share for Posit Package Manager",
+			"Azure NetApp Files volumes",
+			"Posit Connect",
+			"Posit Workbench user home directories",
+			"PostgreSQL Flexible Server",
+			"application metadata for Posit Connect, Posit Workbench, and Posit Package Manager",
+			"`loki` blob container",
+			"`mimir-blocks` blob container",
+			"created by the Mimir application at runtime",
+			"shared Azure Storage account",
+		}
+		for _, s := range mustContain {
+			if !strings.Contains(got, s) {
+				t.Errorf("expected prose to contain %q\n--- prose ---\n%s", s, got)
+			}
+		}
+
+		// Must NOT contain the old, wrong phrasing.
+		mustNotContain := []string{
+			"Azure Storage accounts for Loki logs, Mimir metrics, Package Manager cache, and Chronicle telemetry",
+			"`chronicle` blob container",
+			"chronicle",
+		}
+		for _, s := range mustNotContain {
+			if strings.Contains(strings.ToLower(got), strings.ToLower(s)) {
+				t.Errorf("expected prose NOT to contain %q\n--- prose ---\n%s", s, got)
+			}
+		}
+	})
+
+	t.Run("chronicle on adds chronicle container", func(t *testing.T) {
+		cfg := &InfraConfig{Cloud: "azure", VnetCidr: "10.0.0.0/16", ChronicleEnabled: true}
+		got := generateAzurePersistentProse(cfg)
+		if !strings.Contains(got, "`chronicle` blob container") {
+			t.Errorf("expected prose to contain chronicle container when enabled\n--- prose ---\n%s", got)
+		}
+	})
+}
+
+func TestGenerateClustersProseNamespaces(t *testing.T) {
+	cfg := &InfraConfig{Cloud: "azure"}
+	got := generateClustersProse(cfg)
+	for _, ns := range []string{"`posit-team`", "`posit-team-system`", "`helm-controller`", "`cert-manager`", "`traefik`", "`coredns-custom`"} {
+		if !strings.Contains(got, ns) {
+			t.Errorf("expected clusters prose to enumerate %s\n--- prose ---\n%s", ns, got)
+		}
+	}
+	// Observability namespaces are described in the helm stack, not clusters.
+	for _, ns := range []string{"`loki`", "`mimir`", "`grafana`", "`alloy`"} {
+		if strings.Contains(got, ns) {
+			t.Errorf("clusters prose should not mention observability namespace %s\n--- prose ---\n%s", ns, got)
+		}
+	}
+	// Azure external-dns is described in helm, not clusters.
+	if strings.Contains(strings.ToLower(got), "external dns") || strings.Contains(strings.ToLower(got), "external-dns") {
+		t.Errorf("azure clusters prose should not mention external-dns\n--- prose ---\n%s", got)
+	}
+}
+
+func TestGenerateClustersProseAWSNamespaces(t *testing.T) {
+	cfg := &InfraConfig{Cloud: "aws"}
+	got := generateClustersProse(cfg)
+	// The shared cluster namespaces are enumerated on AWS too.
+	for _, ns := range []string{"`posit-team`", "`posit-team-system`", "`helm-controller`", "`cert-manager`", "`traefik`"} {
+		if !strings.Contains(got, ns) {
+			t.Errorf("expected AWS clusters prose to enumerate %s\n--- prose ---\n%s", ns, got)
+		}
+	}
+	// On AWS the grafana namespace is created in the clusters stack
+	// (lib/steps/clusters_aws.go), so it must be enumerated here.
+	if !strings.Contains(got, "`grafana`") {
+		t.Errorf("expected AWS clusters prose to enumerate the grafana namespace\n--- prose ---\n%s", got)
+	}
+	if !strings.Contains(got, "Grafana observability stack") {
+		t.Errorf("expected AWS clusters prose to describe the grafana namespace as the Grafana observability stack\n--- prose ---\n%s", got)
+	}
+	// The other observability namespaces remain in the helm stack.
+	for _, ns := range []string{"`loki`", "`mimir`", "`alloy`"} {
+		if strings.Contains(got, ns) {
+			t.Errorf("AWS clusters prose should not mention observability namespace %s (helm stack)\n--- prose ---\n%s", ns, got)
+		}
+	}
+	// kube-system CoreDNS patch is Azure-only; AWS must not mention coredns-custom.
+	if strings.Contains(got, "coredns-custom") {
+		t.Errorf("AWS clusters prose should not mention coredns-custom (Azure-only)\n--- prose ---\n%s", got)
+	}
+}
+
+func TestGenerateHelmProse(t *testing.T) {
+	t.Run("azure deploys external-dns unconditionally", func(t *testing.T) {
+		// ExternalDNSEnabled false should NOT suppress the Azure external-dns prose.
+		cfg := &InfraConfig{Cloud: "azure", ExternalDNSEnabled: false}
+		got := generateHelmProse(cfg)
+		if !strings.Contains(got, "external-dns") {
+			t.Errorf("expected azure helm prose to mention external-dns\n--- prose ---\n%s", got)
+		}
+		if !strings.Contains(got, "azure-config-file") {
+			t.Errorf("expected azure helm prose to mention azure-config-file secret\n--- prose ---\n%s", got)
+		}
+		if strings.Contains(strings.ToLower(got), "disabled") {
+			t.Errorf("azure helm prose must not render a disabled branch\n--- prose ---\n%s", got)
+		}
+		for _, ns := range []string{"`grafana`", "`loki`", "`mimir`", "`alloy`", "`kube-state-metrics`"} {
+			if !strings.Contains(got, ns) {
+				t.Errorf("expected helm prose to mention observability namespace %s\n--- prose ---\n%s", ns, got)
+			}
+		}
+	})
+
+	t.Run("aws does not deploy external-dns in helm", func(t *testing.T) {
+		cfg := &InfraConfig{Cloud: "aws", ExternalDNSEnabled: true}
+		got := generateHelmProse(cfg)
+		if strings.Contains(strings.ToLower(got), "external-dns") || strings.Contains(strings.ToLower(got), "external dns") {
+			t.Errorf("aws helm prose should not mention external-dns (it is in clusters)\n--- prose ---\n%s", got)
+		}
+	})
+}
+
+func TestGenerateSitesProse(t *testing.T) {
+	cfg := &InfraConfig{Cloud: "azure", SiteDomains: map[string]string{"main": "example.com"}}
+
+	t.Run("uses per-site site.yaml path, chronicle off", func(t *testing.T) {
+		cfg.ChronicleEnabled = false
+		got := generateSitesProse(cfg)
+		if !strings.Contains(got, "site_main/site.yaml") {
+			t.Errorf("expected per-site site.yaml path\n--- prose ---\n%s", got)
+		}
+		if strings.Contains(got, "Chronicle observability agent") {
+			t.Errorf("chronicle should not be mentioned when disabled\n--- prose ---\n%s", got)
+		}
+	})
+
+	t.Run("chronicle on adds agent bullet", func(t *testing.T) {
+		cfg.ChronicleEnabled = true
+		got := generateSitesProse(cfg)
+		if !strings.Contains(got, "Chronicle observability agent") {
+			t.Errorf("expected chronicle agent bullet when enabled\n--- prose ---\n%s", got)
+		}
+	})
+}
 
 func TestProductDisplayName(t *testing.T) {
 	tests := []struct {

--- a/lib/steps/bootstrap.go
+++ b/lib/steps/bootstrap.go
@@ -42,6 +42,9 @@ func (s *BootstrapStep) Run(ctx context.Context) error {
 		return err
 	}
 
+	// NOTE: lib/attestation.collectBootstrapResources synthesizes this same
+	// resource list from PTD's naming conventions (bootstrap produces no Pulumi
+	// state). Keep the two in sync if the provisioned resources change here.
 	switch s.DstTarget.CloudProvider() {
 	case types.AWS:
 		err = s.runAws(ctx, creds, s.DstTarget.Name())


### PR DESCRIPTION
## Summary

Extends the attestation document with two new appendices:

- **Appendix A — Full Resource Inventory.** Enumerates every managed
  resource across all Pulumi stacks (excluding Pulumi-internal stack/
  provider resources), with name, type, and cloud/logical resource ID.
  Bootstrap-step resources are synthesized from PTD's naming conventions
  because that step runs imperatively and produces no Pulumi state.
- **Appendix B — Kubernetes Objects.** Lists Kubernetes objects PTD
  configures, with the cluster-assigned `metadata.uid` from state. Helm
  releases wrap multiple objects and carry no single UID.

## Changes

- `lib/attestation/attestation.go` — capture per-resource detail and
  Kubernetes objects during state parsing; synthesize bootstrap resources.
- `lib/attestation/markdown.go` / `pdf.go` — render both appendices.
- `lib/attestation/attestation_test.go` — unit tests for URN parsing,
  resource/k8s extraction, bootstrap synthesis, and display helpers.

## Testing

- `go build ./...`
- `go test ./lib/attestation/...`