### PR TITLE
fix(alerts): make RDS alerts identify the specific database

### DIFF
--- a/lib/steps/assets/grafana_alerts/rds.yaml
+++ b/lib/steps/assets/grafana_alerts/rds.yaml
@@ -43,7 +43,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: aws_rds_cpuutilization_average{job="integrations/cloudwatch"}
+                expr: aws_rds_cpuutilization_average{job="integrations/cloudwatch", dimension_DBInstanceIdentifier!=""}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -112,7 +112,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: aws_rds_free_storage_space_average{job="integrations/cloudwatch"}
+                expr: aws_rds_free_storage_space_average{job="integrations/cloudwatch", dimension_DBInstanceIdentifier!=""}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -182,7 +182,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: aws_rds_free_storage_space_average{job="integrations/cloudwatch"}
+                expr: aws_rds_free_storage_space_average{job="integrations/cloudwatch", dimension_DBInstanceIdentifier!=""}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -252,7 +252,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: aws_rds_freeable_memory_average{job="integrations/cloudwatch"}
+                expr: aws_rds_freeable_memory_average{job="integrations/cloudwatch", dimension_DBInstanceIdentifier!=""}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -322,7 +322,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: aws_rds_database_connections_average{job="integrations/cloudwatch"}
+                expr: aws_rds_database_connections_average{job="integrations/cloudwatch", dimension_DBInstanceIdentifier!=""}
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto


### PR DESCRIPTION
# Description

Each of the five RDS Grafana alerts queried its CloudWatch metric without restricting to per-database series. CloudWatch publishes these metrics multiple ways simultaneously: one value per individual database, plus combined totals grouped by instance size (e.g. all `db.t3.small` databases together), by engine, and overall. The alert queries matched every series, including the aggregates.

Two problems resulted:

1. **Unidentifiable database.** An alert could fire on a combined "all databases of size X" aggregate rather than a single database. Those aggregate series carry no `DBInstanceIdentifier`, so the alert's `Resource:` line showed `[no value]` and you could not tell which database was affected.
2. **Permanent false CRITICAL.** After databases were resized from `db.t3.small` to `db.t4g.small`, the stale `db.t3.small` aggregate had no databases left in it, reported 0 bytes free, and fired a permanent false CRITICAL that named no database.

This change scopes all five RDS alert queries (CPU, free storage warning, free storage critical, freeable memory, and connections) to per-database series by requiring `dimension_DBInstanceIdentifier!=""`. The combined size/engine/overall aggregates are no longer evaluated, and the `Resource:` line now shows the actual database instance.

## Issue

N/A

## Code Flow

The alert definitions live in `lib/steps/assets/grafana_alerts/rds.yaml`, which is embedded into the `ptd` binary via `go:embed` and provisioned to Grafana during deployment. The fix appends the `dimension_DBInstanceIdentifier!=""` label matcher to the PromQL/Mimir `expr:` selector in each of the five RDS alert rules, so only per-database series (which carry a `DBInstanceIdentifier` dimension) are evaluated.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about

🤖 Generated with [Claude Code](https://claude.com/claude-code)