### PR TITLE
ci: self-refreshing Go build cache via reusable composite action

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -4,15 +4,19 @@ description: >-
   cache (~/go/pkg/mod). Keyed on a hash of the Go sources and go.sum so the key
   rotates when source changes (immutable cache entries can then re-save), with a
   prefix-based restore-keys fallback to recover the most recent prior cache for
-  an incremental rebuild. Use a distinct prefix per job to keep namespaces
-  separate.
+  an incremental rebuild. Jobs that build with the same Go flags (here, all jobs
+  run CGO_ENABLED=0 with no -trimpath) can share one prefix so each job warms the
+  others; pass a distinct prefix only to isolate a job with a different build
+  fingerprint.
 
 inputs:
   prefix:
     description: >-
-      Cache namespace for this job (e.g. cmd-test, cmd-build, lib-test). Keeps
-      each job's cache separate so differing build fingerprints do not collide.
-    required: true
+      Cache namespace. Jobs sharing a build fingerprint should share a prefix so
+      compiled packages are reused across jobs. Override only to isolate a job
+      whose build flags differ.
+    required: false
+    default: go
 
 runs:
   using: composite

--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -1,0 +1,27 @@
+name: Go build and module cache
+description: >-
+  Self-refreshing cache for the Go build cache (~/.cache/go-build) and module
+  cache (~/go/pkg/mod). Keyed on a hash of the Go sources and go.sum so the key
+  rotates when source changes (immutable cache entries can then re-save), with a
+  prefix-based restore-keys fallback to recover the most recent prior cache for
+  an incremental rebuild. Use a distinct prefix per job to keep namespaces
+  separate.
+
+inputs:
+  prefix:
+    description: >-
+      Cache namespace for this job (e.g. cmd-test, cmd-build, lib-test). Keeps
+      each job's cache separate so differing build fingerprints do not collide.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-gocache-${{ inputs.prefix }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gocache-${{ inputs.prefix }}-

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -10,6 +10,13 @@ on:
     paths: [cmd/**,lib/**,.github/workflows/cmd.yml,.github/actions/go-cache/**]
 
   merge_group:
+
+# Build and test with cgo disabled to match the shipped binary (goreleaser sets
+# CGO_ENABLED=0). Keeping every job on one build fingerprint lets them share a
+# single go-cache namespace.
+env:
+  CGO_ENABLED: "0"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,8 +34,6 @@ jobs:
           cache: false
 
       - uses: ./.github/actions/go-cache
-        with:
-          prefix: cmd-test
 
       - name: Test cmd
         run: just test-cmd
@@ -49,8 +54,6 @@ jobs:
           cache: false
 
       - uses: ./.github/actions/go-cache
-        with:
-          prefix: cmd-build
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main]
     tags: [v*]
-    paths: [cmd/**,lib/**,.github/workflows/cli.yml]
+    paths: [cmd/**,lib/**,.github/workflows/cmd.yml,.github/actions/go-cache/**]
 
   pull_request:
-    paths: [cmd/**,lib/**,.github/workflows/cli.yml]
+    paths: [cmd/**,lib/**,.github/workflows/cmd.yml,.github/actions/go-cache/**]
 
   merge_group:
 jobs:
@@ -24,10 +24,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: cmd/go.mod
-          cache: true
-          cache-dependency-path: |
-            cmd/go.sum
-            lib/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-cache
+        with:
+          prefix: cmd-test
 
       - name: Test cmd
         run: just test-cmd
@@ -45,10 +46,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: cmd/go.mod
-          cache: true
-          cache-dependency-path: |
-            cmd/go.sum
-            lib/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-cache
+        with:
+          prefix: cmd-build
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -10,6 +10,12 @@ on:
     paths: [lib/**,.github/workflows/lib.yml,.github/actions/go-cache/**]
 
   merge_group:
+
+# Build and test with cgo disabled to match the shipped binary and share one
+# go-cache namespace across the cmd and lib workflows.
+env:
+  CGO_ENABLED: "0"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,8 +33,6 @@ jobs:
           cache: false
 
       - uses: ./.github/actions/go-cache
-        with:
-          prefix: lib-test
 
       - name: Test lib with coverage
         run: just test-lib

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main]
     tags: [v*]
-    paths: [lib/**,.github/workflows/lib.yml]
+    paths: [lib/**,.github/workflows/lib.yml,.github/actions/go-cache/**]
 
   pull_request:
-    paths: [lib/**,.github/workflows/lib.yml]
+    paths: [lib/**,.github/workflows/lib.yml,.github/actions/go-cache/**]
 
   merge_group:
 jobs:
@@ -24,9 +24,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: lib/go.mod
-          cache: true
-          cache-dependency-path: |
-            lib/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-cache
+        with:
+          prefix: lib-test
 
       - name: Test lib with coverage
         run: just test-lib


### PR DESCRIPTION
# Description

Follow-up to #318. The `actions/setup-go` build cache was keyed only on the `go.sum` hash, so once `go.sum` stabilized the cache key always hit and the post step never re-saved ("Cache hit ... not saving cache"). The `~/.cache/go-build` snapshot froze at whatever was compiled the one time `go.sum` last changed, so the goreleaser build effectively recompiled cold (~6m on the `cmd` build job).

This replaces it with a self-refreshing cache fronted by a reusable composite action.

## Code Flow

New composite action at `.github/actions/go-cache/action.yml` wraps `actions/cache@v4`:

- Caches both `~/.cache/go-build` (compile cache) and `~/go/pkg/mod` (module cache).
- Takes a required `prefix` input so each job gets its own cache namespace.
- Key/restore-keys (source-hash variant):

  ```yaml
  key: ${{ runner.os }}-gocache-${{ inputs.prefix }}-${{ hashFiles('**/*.go', '**/go.sum') }}
  restore-keys: |
    ${{ runner.os }}-gocache-${{ inputs.prefix }}-
  ```

GitHub cache entries are immutable, so a key that never changes never re-saves. Keying on a hash of the Go sources plus `go.sum` rotates the key whenever source changes, which lets the entry re-save. On a real change the key misses, `restore-keys` restores the newest prior cache for the prefix, the build recompiles incrementally, and the result saves under the new key. On a no-op rerun the key hits exactly and we skip both recompile and a redundant save.

Wired into the Go jobs, with `cache: false` on `setup-go` everywhere so the composite action owns both caches (no double management):

- `cmd.yml` `test` job: prefix `cmd-test`
- `cmd.yml` `build` job: prefix `cmd-build`
- `lib.yml` `test` job: prefix `lib-test`

Per-job prefixes (separate namespaces) are deliberate: the goreleaser build runs `CGO_ENABLED=0` while the test jobs default to `CGO_ENABLED=1`, so their Go build fingerprints differ. Sharing one namespace would cross-contaminate and defeat the warm cache, so each job keeps its own.

Also fixes a latent path-filter bug: `cmd.yml` referenced `.github/workflows/cli.yml`, which does not exist (corrected to `.github/workflows/cmd.yml`). Added `.github/actions/go-cache/**` to the `push` and `pull_request` `paths` lists in both `cmd.yml` and `lib.yml` so changes to the cache action trigger the jobs that consume it.

Cache-reuse behavior will be validated across two pushes on this PR (first push primes the cache, a second push confirms restore + incremental rebuild rather than a cold compile).

Note on cache churn: each entry is large (~1.5 GB) and the repo cache cap is 10 GB with LRU eviction, so only a few entries survive at a time. That is expected and acceptable.

## Category of change

- [x] Build: a code change that affects the build system or external dependencies
- [x] Performance: a code change that improves performance

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about