### PR TITLE
feat(attestation): exclude retired steps from attestation output

### DIFF
--- a/lib/attestation/attestation.go
+++ b/lib/attestation/attestation.go
@@ -162,6 +162,14 @@ var stackPurposes = map[string]map[string]string{
 	},
 }
 
+// retiredStepNames are steps that were removed from PTD but whose Pulumi
+// state may still linger in older workloads' state backends. They are
+// excluded from attestation output so the document reflects only
+// currently-supported steps.
+var retiredStepNames = map[string]bool{
+	"ecr-cache": true, // AWS ECR pull-through cache; removed from PTD
+}
+
 // StepNameFromProjectName extracts the step name from a Pulumi project name like "ptd-aws-workload-persistent".
 func StepNameFromProjectName(projectName string) string {
 	parts := strings.SplitN(projectName, "-", 4)
@@ -774,8 +782,9 @@ func DownloadStateFiles(ctx context.Context, creds types.Credentials, target typ
 }
 
 // summarizeStateFiles converts a map of state file keys to raw JSON into
-// StackSummary values, filtering out backup files (e.g. "name(1).json") and
-// stacks with zero managed resources.
+// StackSummary values, filtering out backup files (e.g. "name(1).json"),
+// stacks with zero managed resources, and retired steps whose stale state may
+// still linger in older workloads' backends (see retiredStepNames).
 func summarizeStateFiles(files map[string][]byte) ([]StackSummary, error) {
 	var summaries []StackSummary
 	for key, data := range files {
@@ -789,6 +798,11 @@ func summarizeStateFiles(files map[string][]byte) ([]StackSummary, error) {
 			return nil, fmt.Errorf("failed to process state file %s: %w", key, err)
 		}
 		if summary.ResourceCount == 0 {
+			continue
+		}
+		// Skip steps that were removed from PTD but whose Pulumi state may
+		// still exist in older workloads' state backends.
+		if retiredStepNames[summary.StepNameFromProject()] {
 			continue
 		}
 		summaries = append(summaries, summary)

--- a/lib/attestation/attestation_test.go
+++ b/lib/attestation/attestation_test.go
@@ -653,4 +653,26 @@ func TestSummarizeStateFiles(t *testing.T) {
 			t.Errorf("got projects %v, want [ptd-azure-workload-aks ptd-azure-workload-clusters]", names)
 		}
 	})
+
+	t.Run("filters out retired steps even with resources", func(t *testing.T) {
+		files := map[string][]byte{
+			".pulumi/stacks/ptd-aws-workload-clusters/prod.json":  []byte(realStack),
+			".pulumi/stacks/ptd-aws-workload-ecr-cache/prod.json": []byte(realStack),
+		}
+		summaries, err := summarizeStateFiles(files)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if summaries[0].ProjectName != "ptd-aws-workload-clusters" {
+			t.Errorf("ProjectName = %q, want %q", summaries[0].ProjectName, "ptd-aws-workload-clusters")
+		}
+		for _, s := range summaries {
+			if s.StepNameFromProject() == "ecr-cache" {
+				t.Errorf("retired step ecr-cache was not filtered out")
+			}
+		}
+	})
 }


### PR DESCRIPTION
## What

Adds a `retiredStepNames` allowlist to the attestation package and filters
those steps out of `summarizeStateFiles`. Retired steps are ones removed
from PTD whose stale Pulumi state may still exist in older workloads'
state backends; excluding them keeps attestation output limited to
currently supported steps.

Seeded with `ecr-cache` (AWS ECR pull-through cache, removed from PTD).

## Testing

- `go build ./...`, `go vet ./lib/attestation/...`
- `go test ./lib/attestation/...` — new subtest
  `filters_out_retired_steps_even_with_resources` passes alongside existing
  `TestSummarizeStateFiles` cases.