### PR TITLE
fix(azure): create Pulumi state storage accounts as StorageV2

### DIFF
--- a/lib/azure/blobstorage.go
+++ b/lib/azure/blobstorage.go
@@ -29,8 +29,12 @@ func CreateStorageAccount(ctx context.Context, credentials *Credentials, subscri
 	accountsClient := clientFactory.NewAccountsClient()
 	pollerResp, err := accountsClient.BeginCreate(ctx, resourceGroupName, name, armstorage.AccountCreateParameters{
 		Location: to.Ptr(region),
-		Kind:     to.Ptr(armstorage.KindBlobStorage),
-		SKU:      to.Ptr(armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)}), // so many pointers.
+		// StorageV2 is the current general-purpose account kind. The legacy
+		// BlobStorage kind lacks newer security/network properties that customer
+		// security baselines (Azure Policy) evaluate against. StorageV2 is a
+		// superset; Pulumi state (block blobs via azblob://) behaves identically.
+		Kind: to.Ptr(armstorage.KindStorageV2),
+		SKU:  to.Ptr(armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)}), // so many pointers.
 		Properties: &armstorage.AccountPropertiesCreateParameters{
 			AllowBlobPublicAccess: to.Ptr(false),
 			AccessTier:            to.Ptr(armstorage.AccessTierCool),


### PR DESCRIPTION
## Summary

The bootstrap step created the Pulumi state storage account with the legacy `BlobStorage` account kind. This switches new accounts to `StorageV2`, the current general-purpose kind.

`StorageV2` is a superset of `BlobStorage`. Pulumi state access (block blobs via the `azblob://` backend) is functionally identical. The legacy `BlobStorage` kind lacks some newer security/network properties that customer security baselines (Azure Policy) evaluate against, so `StorageV2` is the cleaner compliance baseline.

## Scope / impact

- **New workloads only.** `CreateStorageAccount` is guarded by an existence check in bootstrap, so this does not touch existing accounts.
- **Existing accounts** can be upgraded in place, no downtime, via:
  ```sh
  az storage account update --name <acct> --resource-group <rg> --set kind=StorageV2
  ```
  (in-place metadata change — keeps name, endpoints, keys, data; one-way.)

## Testing

- `go build ./...`, `go vet ./azure/...` pass
- Pre-commit hooks (lib) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)