### PR TITLE
ci: upgrade Claude actions to Sonnet 4.6, fix tool name

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           use_bedrock: true
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --model us.anthropic.claude-sonnet-4-6
             --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
           prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           use_bedrock: true
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
             --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
           prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,6 +65,6 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
             --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,6 +65,6 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --model us.anthropic.claude-sonnet-4-6
             --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."


### PR DESCRIPTION
Upgrades both Claude workflows to Sonnet 4.6 and fixes a wrong MCP tool name that's been there since the original setup.

- Switches model to Sonnet 4.6 (`us.anthropic.claude-sonnet-4-6`) in both `claude-auto-review.yml` and `claude.yml`
- Fixes wrong MCP tool name (`add_pull_request_review_comment_to_pending_review` → `add_comment_to_pending_review`)