### PR TITLE
ci: correct Sonnet 4.6 Bedrock model identifier

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           use_bedrock: true
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --model us.anthropic.claude-sonnet-4-6
             --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
           prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,6 +65,6 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --model us.anthropic.claude-sonnet-4-6
             --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."


### PR DESCRIPTION
# Description

Both Claude GitHub Actions workflows passed an invalid AWS Bedrock model identifier to `claude-code-action`, causing the action to fail with a 400 "The provided model identifier is invalid" error. (e.g. https://github.com/posit-dev/ptd/actions/runs/27966714423)

The `--model` argument was set to `us.anthropic.claude-sonnet-4-6-20250514-v1:0`. The `-20250514-v1:0` date/version suffix does not belong to the Sonnet 4.6 inference profile. The correct, verified active inference profile ID for Sonnet 4.6 (account 616070551740 / us-east-2) is `us.anthropic.claude-sonnet-4-6` (no suffix).

## Code Flow

Two workflow files invoke `anthropics/claude-code-action` with `use_bedrock: true` and a `--model` value inside `claude_args`:

- `.github/workflows/claude.yml` (Run Claude Code Action)
- `.github/workflows/claude-auto-review.yml` (Automatic PR Review)

Both `--model` values are corrected to `us.anthropic.claude-sonnet-4-6`. No other lines change.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about