### PR TITLE
fix(azure): resolve bastion NSG subnet from any agent pool profile

### DIFF
--- a/lib/azure/aks.go
+++ b/lib/azure/aks.go
@@ -15,7 +15,7 @@ type ClusterIdentityInfo struct {
 	KubeletPrincipalID string
 	// OIDCIssuerURL is the cluster's OIDC issuer URL (used for federated identity credentials).
 	OIDCIssuerURL string
-	// VNetSubnetID is the subnet resource ID of the first agent pool (used for bastion NSG lookup).
+	// VNetSubnetID is the subnet resource ID of an agent pool (used for bastion NSG lookup).
 	// Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{subnet}
 	VNetSubnetID string
 }
@@ -52,10 +52,17 @@ func GetClusterIdentityInfo(ctx context.Context, creds *Credentials, subscriptio
 		info.OIDCIssuerURL = *result.Properties.OidcIssuerProfile.IssuerURL
 	}
 
-	// VNet subnet ID from the first agent pool profile (used for bastion NSG).
-	if result.Properties != nil && len(result.Properties.AgentPoolProfiles) > 0 {
-		if result.Properties.AgentPoolProfiles[0].VnetSubnetID != nil {
-			info.VNetSubnetID = *result.Properties.AgentPoolProfiles[0].VnetSubnetID
+	// VNet subnet ID for the bastion NSG. Scan all agent pool profiles for the
+	// first non-empty value rather than assuming index 0 carries it: the live
+	// API does not guarantee profile ordering, and pools managed as separate
+	// AgentPool resources may not surface the subnet on the first entry. All
+	// pools are provisioned into the same subnet, so any non-empty value is correct.
+	if result.Properties != nil {
+		for _, pool := range result.Properties.AgentPoolProfiles {
+			if pool.VnetSubnetID != nil && *pool.VnetSubnetID != "" {
+				info.VNetSubnetID = *pool.VnetSubnetID
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

The Azure clusters step only declares the bastion-access NSG (which allows Bastion↔AKS traffic) when it can resolve the cluster's VNet subnet ID. That resolution read `AgentPoolProfiles[0].VnetSubnetID` exclusively, from a live AKS API `GET`.

The live API doesn't guarantee agent-pool ordering, and pools managed as separate `AgentPool` resources may not surface the subnet on the first profile. When index `0` came back empty, the NSG wasn't declared — so Pulumi saw it in state but not in the program and proposed **deleting** it. Deleting that NSG severs the Bastion→AKS path that `ptd proxy` / `ptd workon` rely on to reach the private AKS API.

This is a regression from the Python→Go clusters migration: the NSG was previously created reliably (existing resources still carry the legacy `managed-by` tag), but the rewrite gated creation on this brittle index-0 lookup.

## Fix

Scan all agent pool profiles for the first non-empty `VnetSubnetID` instead of assuming index 0. All pools are provisioned into the same subnet, so any non-empty value is correct. Once the subnet resolves, the NSG is declared and the spurious delete disappears.

## Scope

- Single function (`GetClusterIdentityInfo` in `lib/azure/aks.go`).
- No behavioral change for clusters where index 0 already carried the subnet.

## Follow-up (not in this PR)

A more robust option is to derive the subnet deterministically from config + persistent-stack outputs (as the AKS step already does at `aks.go:104`), removing the live-lookup dependency entirely. That's a larger change (threading outputs into the clusters params) and out of scope here.

## Testing

- `go build ./...`, `go vet ./azure/... ./steps/...`, `go test ./azure/... ./steps/...` pass
- Pre-commit hooks (lib) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)