### PR TITLE
fix: grant pull-requests write permission so Claude can post reviews

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The workflow had `pull-requests: read`, which silently prevented Claude from posting review comments. The action ran successfully but had no permission to write to the PR. Changed to `write`.