### PR TITLE
fix: stop copying cloud resource tags onto Site k8s labels

### DIFF
--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -88,7 +88,6 @@ type awsSiteParams struct {
 	kubeconfigsByRelease map[string]string
 	clusters             map[string]types.AWSWorkloadClusterConfig
 	sites                map[string]types.SiteConfig
-	resourceTags         map[string]string
 }
 
 func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials, envVars map[string]string) error {
@@ -149,7 +148,6 @@ func (s *SitesStep) runAWSInlineGo(ctx context.Context, creds types.Credentials,
 		kubeconfigsByRelease: kubeconfigsByRelease,
 		clusters:             cfg.Clusters,
 		sites:                cfg.Sites,
-		resourceTags:         cfg.ResourceTags,
 	}
 
 	stack, err := createStack(ctx, s.Name(), s.DstTarget, func(pctx *pulumi.Context, target types.Target) error {
@@ -206,7 +204,7 @@ func awsSitesDeploy(ctx *pulumi.Context, _ types.Target, params awsSiteParams) e
 				return err
 			}
 
-			labels := buildSiteLabels(params.resourceTags, siteName, params.compoundName)
+			labels := buildSiteLabels(siteName, params.compoundName)
 
 			oldURN := fmt.Sprintf(
 				"urn:pulumi:%s::ptd-aws-workload-sites::ptd:AWSWorkloadSites$ptd:TeamSite$kubernetes:yaml:ConfigFile$kubernetes:core.posit.team/v1beta1:Site::%s-%s-%s/%s",
@@ -324,7 +322,6 @@ type azureSiteParams struct {
 	kubeconfigsByRelease map[string]string
 	clusters             map[string]types.AzureWorkloadClusterConfig
 	sites                map[string]types.SiteConfig
-	resourceTags         map[string]string
 }
 
 func (s *SitesStep) runAzureInlineGo(ctx context.Context, creds types.Credentials, envVars map[string]string) error {
@@ -376,7 +373,6 @@ func (s *SitesStep) runAzureInlineGo(ctx context.Context, creds types.Credential
 		kubeconfigsByRelease: kubeconfigsByRelease,
 		clusters:             cfg.Clusters,
 		sites:                cfg.Sites,
-		resourceTags:         cfg.ResourceTags,
 	}
 
 	stack, err := createStack(ctx, s.Name(), s.DstTarget, func(pctx *pulumi.Context, target types.Target) error {
@@ -410,7 +406,7 @@ func azureSitesDeploy(ctx *pulumi.Context, _ types.Target, params azureSiteParam
 				return err
 			}
 
-			labels := buildSiteLabels(params.resourceTags, siteName, params.compoundName)
+			labels := buildSiteLabels(siteName, params.compoundName)
 
 			oldURN := fmt.Sprintf(
 				"urn:pulumi:%s::ptd-azure-workload-sites::ptd:AzureWorkloadSites$ptd:TeamSite$kubernetes:yaml:ConfigFile$kubernetes:core.posit.team/v1beta1:Site::%s-%s-%s/%s",
@@ -479,7 +475,7 @@ func buildAzureSiteSpec(
 
 // --- Shared helpers ---
 
-func buildSiteLabels(resourceTags map[string]string, siteName, compoundName string) pulumi.StringMap {
+func buildSiteLabels(siteName, compoundName string) pulumi.StringMap {
 	labels := pulumi.StringMap{
 		"posit.team/managed-by":      pulumi.String(siteManagedByLabel),
 		"posit.team/site-name":       pulumi.String(siteName),
@@ -499,12 +495,11 @@ func buildSiteLabels(resourceTags map[string]string, siteName, compoundName stri
 		labels["posit.team/environment"] = pulumi.String(compoundName[idx+1:])
 	}
 
-	// Include resource tags that are valid K8s label keys (no colon character).
-	for k, v := range resourceTags {
-		if !strings.Contains(k, ":") {
-			labels[k] = pulumi.String(v)
-		}
-	}
+	// Azure/cloud resource tags are intentionally NOT propagated here. They are
+	// cloud inventory metadata with permissive value rules (spaces, '@', '/', etc.)
+	// that are invalid as Kubernetes label values, and they have no meaning as
+	// k8s selectors. Resource tags are applied to cloud resources in the
+	// persistent/clusters steps, not to in-cluster objects.
 	return labels
 }
 

--- a/lib/steps/sites_test.go
+++ b/lib/steps/sites_test.go
@@ -83,7 +83,6 @@ func minimalAWSSiteParams(compoundName string, releases []string, siteNames []st
 		kubeconfigsByRelease: kubeconfigsByRelease,
 		clusters:             clusters,
 		sites:                sites,
-		resourceTags:         map[string]string{},
 	}
 }
 
@@ -320,7 +319,6 @@ func minimalAzureSiteParams(compoundName string, releases []string, siteNames []
 		kubeconfigsByRelease: kubeconfigsByRelease,
 		clusters:             clusters,
 		sites:                sites,
-		resourceTags:         map[string]string{},
 	}
 }
 


### PR DESCRIPTION
## Problem

The sites step copied workload `resource_tags` onto the `Site` custom resource as Kubernetes `metadata.labels`, filtering only by key (`!strings.Contains(k, ":")`) and never validating the value.

Cloud resource tags have permissive value rules — spaces, `@`, `/`, etc. — that are invalid as Kubernetes label values (`(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`, ≤63 chars). A workload whose tags include free-text values (owner names, contact emails, `n/a`) makes the `Site` fail to apply:

```
Site.core.posit.team "dev" is invalid: metadata.labels: Invalid value:
"...": a valid label must consist of alphanumeric characters, '-', '_' or '.'...
```

This surfaced when a workload adopted colon-less tag keys with free-text values. Previously most tags used colon-prefixed keys (e.g. `rs:owner`) which the key filter already dropped, hiding the gap.

## Fix

Stop propagating cloud resource tags to `Site` labels entirely. They're cloud inventory metadata, not k8s selectors, and are already applied to cloud resources in the persistent/clusters steps — they have no business on in-cluster objects. Applies symmetrically to the AWS and Azure sites paths; the now-unused `resourceTags` params/fields are removed.

### Labels retained (unchanged)

The fixed label set is untouched:

- `posit.team/managed-by`
- `posit.team/site-name`
- `posit.team/true-name` (derived from compound name)
- `posit.team/environment` (derived from compound name)
- `app.kubernetes.io/instance`
- `app.kubernetes.io/name`
- `app.kubernetes.io/part-of`
- `app.kubernetes.io/managed-by`
- `app.kubernetes.io/created-by`

### Labels removed

Any label whose key came from a workload `resource_tag` with a colon-less key. With a CSI-style tag set, that means bare labels like:

`systemName`, `systemCode`, `systemOwner`, `businessOwner`, `environment`, `businessCriticality`, `technicalContact`, `terraformManaged`

Note: the bare `environment` label (sourced from a resource tag) is removed, but `posit.team/environment` (derived from the compound name) is retained — they are distinct keys.

For workloads whose tags all used colon-prefixed keys, no labels change (those were already filtered out). For workloads that had colon-less tag labels applied, the next apply removes those labels from the `Site`.

## Testing

- `go build ./...`, `go vet ./steps/...`, `go test ./steps/...` pass
- Pre-commit hooks (lib) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)