### PR TITLE
feat(azure): tag resource group with workload resource_tags on creation

### DIFF
--- a/lib/azure/resourcegroup.go
+++ b/lib/azure/resourcegroup.go
@@ -12,10 +12,10 @@ import (
 
 // FormatTagKey converts a PTD tag key to a valid Azure tag key. Azure tag keys
 // cannot contain '/', so we replace '/' with ':' (e.g. posit.team/environment ->
-// posit.team:environment). This mirrors the Python azure_tag_key_format helper and
-// is the single source of truth for the key-format rule shared by the persistent
-// step (azureTagMap) and resource-group creation, so tags applied at RG creation
-// match the tags placed on child resources and do not churn.
+// posit.team:environment). It is the single source of truth for the key-format
+// rule shared by the persistent step (azureTagMap) and resource-group creation,
+// so tags applied at RG creation match the tags placed on child resources and do
+// not churn.
 func FormatTagKey(key string) string {
 	return strings.ReplaceAll(key, "/", ":")
 }
@@ -33,12 +33,17 @@ func ResourceGroupExists(ctx context.Context, credentials *Credentials, subscrip
 	return true
 }
 
-// CreateResourceGroup creates the resource group, applying tags at creation time.
-// Tag keys are run through FormatTagKey so they match the keys placed on child
-// resources by the persistent step (azureTagMap), preventing tag churn. Note that
-// this only tags the RG on creation; existing resource groups are backfilled with
-// tags manually out-of-band (the caller guards this with an existence check), so
-// changing a workload's resource_tags will not retroactively retag an existing RG.
+// CreateResourceGroup creates (or updates) the resource group, applying tags at
+// creation time. Tag keys are run through FormatTagKey so they match the keys
+// placed on child resources by the persistent step (azureTagMap), preventing tag
+// churn.
+//
+// This wraps ARM's CreateOrUpdate, which is idempotent but WILL overwrite the tags
+// of an already-existing resource group. Callers that must not retag an existing
+// RG (e.g. to leave manually backfilled tags intact) must guard the call with
+// ResourceGroupExists, as bootstrap does. Consequently a change to a workload's
+// resource_tags is applied only to newly created RGs, never retroactively to
+// existing ones.
 func CreateResourceGroup(ctx context.Context, credentials *Credentials, subscriptionId string, region string, name string, tags map[string]string) error {
 	rgClient, err := armresources.NewResourceGroupsClient(subscriptionId, credentials.credentials, nil)
 	if err != nil {

--- a/lib/azure/resourcegroup.go
+++ b/lib/azure/resourcegroup.go
@@ -2,12 +2,23 @@ package azure
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/google/uuid"
 )
+
+// FormatTagKey converts a PTD tag key to a valid Azure tag key. Azure tag keys
+// cannot contain '/', so we replace '/' with ':' (e.g. posit.team/environment ->
+// posit.team:environment). This mirrors the Python azure_tag_key_format helper and
+// is the single source of truth for the key-format rule shared by the persistent
+// step (azureTagMap) and resource-group creation, so tags applied at RG creation
+// match the tags placed on child resources and do not churn.
+func FormatTagKey(key string) string {
+	return strings.ReplaceAll(key, "/", ":")
+}
 
 func ResourceGroupExists(ctx context.Context, credentials *Credentials, subscriptionId string, region string, name string) bool {
 	rgClient, err := armresources.NewResourceGroupsClient(subscriptionId, credentials.credentials, nil)
@@ -22,7 +33,13 @@ func ResourceGroupExists(ctx context.Context, credentials *Credentials, subscrip
 	return true
 }
 
-func CreateResourceGroup(ctx context.Context, credentials *Credentials, subscriptionId string, region string, name string) error {
+// CreateResourceGroup creates the resource group, applying tags at creation time.
+// Tag keys are run through FormatTagKey so they match the keys placed on child
+// resources by the persistent step (azureTagMap), preventing tag churn. Note that
+// this only tags the RG on creation; existing resource groups are backfilled with
+// tags manually out-of-band (the caller guards this with an existence check), so
+// changing a workload's resource_tags will not retroactively retag an existing RG.
+func CreateResourceGroup(ctx context.Context, credentials *Credentials, subscriptionId string, region string, name string, tags map[string]string) error {
 	rgClient, err := armresources.NewResourceGroupsClient(subscriptionId, credentials.credentials, nil)
 	if err != nil {
 		return err
@@ -30,6 +47,13 @@ func CreateResourceGroup(ctx context.Context, credentials *Credentials, subscrip
 
 	param := armresources.ResourceGroup{
 		Location: to.Ptr(region),
+	}
+	if len(tags) > 0 {
+		azureTags := make(map[string]*string, len(tags))
+		for k, v := range tags {
+			azureTags[FormatTagKey(k)] = to.Ptr(v)
+		}
+		param.Tags = azureTags
 	}
 
 	_, err = rgClient.CreateOrUpdate(ctx, name, param, nil)

--- a/lib/azure/resourcegroup_test.go
+++ b/lib/azure/resourcegroup_test.go
@@ -1,0 +1,42 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatTagKey(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "slash is replaced with colon",
+			in:   "posit.team/environment",
+			want: "posit.team:environment",
+		},
+		{
+			name: "multiple slashes are all replaced",
+			in:   "a/b/c",
+			want: "a:b:c",
+		},
+		{
+			name: "key without slash is unchanged",
+			in:   "CostCenter",
+			want: "CostCenter",
+		},
+		{
+			name: "empty key is unchanged",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FormatTagKey(tt.in))
+		})
+	}
+}

--- a/lib/steps/bootstrap.go
+++ b/lib/steps/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/posit-dev/ptd/lib/aws"
 	"github.com/posit-dev/ptd/lib/azure"
 	"github.com/posit-dev/ptd/lib/consts"
+	"github.com/posit-dev/ptd/lib/helpers"
 	"github.com/posit-dev/ptd/lib/secrets"
 	"github.com/posit-dev/ptd/lib/types"
 )
@@ -158,11 +159,23 @@ func (s *BootstrapStep) runAzure(ctx context.Context, c types.Credentials, _ str
 
 	azureTarget := s.DstTarget.(azure.Target)
 
+	// Load the workload's configured resource_tags so they can be applied to the
+	// resource group at creation time (below). These mirror the tags the persistent
+	// step places on child resources.
+	var resourceTags map[string]string
+	if rawConfig, cfgErr := helpers.ConfigForTarget(s.DstTarget); cfgErr == nil {
+		if cfg, ok := rawConfig.(types.AzureWorkloadConfig); ok {
+			resourceTags = cfg.ResourceTags
+		}
+	}
+
 	// ensure pulumi state resource group
 	s.Log.Info("Creating resource group for pulumi state if it doesn't exist", "resourceGroup", azureTarget.ResourceGroupName())
 	exists := azure.ResourceGroupExists(ctx, azureCreds, azureTarget.SubscriptionID(), azureTarget.Region(), azureTarget.ResourceGroupName())
 	if !exists {
-		err := azure.CreateResourceGroup(ctx, azureCreds, azureTarget.SubscriptionID(), azureTarget.Region(), azureTarget.ResourceGroupName())
+		// Tags are only applied on creation; existing RGs are not retroactively
+		// retagged here (backfilled manually out-of-band).
+		err := azure.CreateResourceGroup(ctx, azureCreds, azureTarget.SubscriptionID(), azureTarget.Region(), azureTarget.ResourceGroupName(), resourceTags)
 		if err != nil {
 			return err
 		}

--- a/lib/steps/bootstrap.go
+++ b/lib/steps/bootstrap.go
@@ -163,11 +163,17 @@ func (s *BootstrapStep) runAzure(ctx context.Context, c types.Credentials, _ str
 	// resource group at creation time (below). These mirror the tags the persistent
 	// step places on child resources.
 	var resourceTags map[string]string
-	if rawConfig, cfgErr := helpers.ConfigForTarget(s.DstTarget); cfgErr == nil {
-		if cfg, ok := rawConfig.(types.AzureWorkloadConfig); ok {
-			resourceTags = cfg.ResourceTags
-		}
+	if rawConfig, cfgErr := helpers.ConfigForTarget(s.DstTarget); cfgErr != nil {
+		// Don't fail bootstrap on this; the RG is still created (untagged), matching
+		// the previous behavior. But warn so a missing/malformed config doesn't
+		// silently drop compliance tags.
+		s.Log.Warn("could not load workload config for resource_tags; resource group will be created untagged", "err", cfgErr)
+	} else if cfg, ok := rawConfig.(types.AzureWorkloadConfig); ok {
+		resourceTags = cfg.ResourceTags
 	}
+	// Note: runAzure is only invoked for Azure workload targets, so the assertion
+	// above always holds here. Control-room targets won't satisfy AzureWorkloadConfig
+	// and would fall through with no tags, which is the intended no-op for them.
 
 	// ensure pulumi state resource group
 	s.Log.Info("Creating resource group for pulumi state if it doesn't exist", "resourceGroup", azureTarget.ResourceGroupName())

--- a/lib/steps/persistent_azure.go
+++ b/lib/steps/persistent_azure.go
@@ -429,12 +429,13 @@ func protectOpt(protect bool) pulumi.ResourceOption {
 func azureTagMap(tags map[string]string) pulumi.StringMap {
 	out := pulumi.StringMap{}
 	for k, v := range tags {
-		// Azure tag keys cannot contain '/'. Mirror Python azure_tag_key_format,
-		// which replaces '/' with ':' (e.g. posit.team/environment ->
-		// posit.team:environment). Without this every Azure resource's tags churn.
-		// See CLAUDE.md "Resource Naming Conventions / Azure tags"
-		// (azure_tag_key_format) for the canonical key-format rule.
-		out[strings.ReplaceAll(k, "/", ":")] = pulumi.String(v)
+		// Azure tag keys cannot contain '/'. azure.FormatTagKey replaces '/' with
+		// ':' (e.g. posit.team/environment -> posit.team:environment). Without this
+		// every Azure resource's tags churn. It is the single source of truth for the
+		// key-format rule, shared with resource-group creation (CreateResourceGroup)
+		// so RG tags match child-resource tags. See CLAUDE.md "Resource Naming
+		// Conventions / Azure tags" (azure_tag_key_format).
+		out[azure.FormatTagKey(k)] = pulumi.String(v)
 	}
 	return out
 }

--- a/lib/steps/persistent_test.go
+++ b/lib/steps/persistent_test.go
@@ -557,6 +557,21 @@ func TestAzureWorkloadPersistentDeploy_PerSiteZones(t *testing.T) {
 	assert.Equal(t, 2, mocks.typeCount("azure-native:dns:Zone"), "one zone per site")
 }
 
+func TestAzureTagMapFormatsKeys(t *testing.T) {
+	// azureTagMap must apply azure.FormatTagKey ('/' -> ':') so that child-resource
+	// tags match the tags applied to the resource group at creation time (which run
+	// through the same helper); otherwise every Azure resource's tags would churn.
+	out := azureTagMap(map[string]string{
+		"posit.team/environment": "staging",
+		"CostCenter":             "rnd",
+	})
+	assert.Equal(t, pulumi.String("staging"), out["posit.team:environment"])
+	assert.Equal(t, pulumi.String("rnd"), out["CostCenter"])
+	// The unformatted key must not be present.
+	_, hasUnformatted := out["posit.team/environment"]
+	assert.False(t, hasUnformatted, "tag key with '/' must be reformatted to ':'")
+}
+
 func TestAzureNamingHelpers(t *testing.T) {
 	// acr_registry: "crptd" + parts[0] + lower(parts[1:]).
 	assert.Equal(t, "crptddemo01staging", azureACRRegistryName("demo01-staging"))


### PR DESCRIPTION
# Description

The Azure resource group is created in the bootstrap step via the ARM SDK and
was never tagged. A workload's configured `resource_tags` therefore applied to
Pulumi-managed child resources but not to the RG itself, so resource groups
stayed untagged.

This also defeated the "inherit a tag from the resource group" Azure Policy
used for compliance: with no tags on the RG there was nothing to inherit, so
the inheritance-based backfill was a no-op.

This change applies the workload's `resource_tags` to the RG at creation time.

## Issue

PTD-214

## Code Flow

- `lib/azure/resourcegroup.go`
  - New exported `FormatTagKey(key)` — single source of truth for the Azure
    tag-key rule (`/` -> `:`, e.g. `posit.team/environment` ->
    `posit.team:environment`).
  - `CreateResourceGroup(...)` takes a `tags map[string]string`; when non-empty
    it formats each key via `FormatTagKey` and sets `param.Tags` before
    `CreateOrUpdate`.
- `lib/steps/bootstrap.go`
  - `runAzure` loads the workload config (`helpers.ConfigForTarget`), reads
    `cfg.ResourceTags`, and passes it to `CreateResourceGroup`. The existing
    `if !exists` guard is unchanged, so tags are applied on creation only;
    existing RGs are not retroactively retagged. A failed / non-Azure config
    load degrades to untagged (no new failure mode).
- `lib/steps/persistent_azure.go`
  - `azureTagMap` now delegates to `azure.FormatTagKey` so the persistent step
    and RG creation share one formatter and produce matching keys (no tag
    churn between the RG and its child resources).

Tests: `TestFormatTagKey` (lib/azure) and `TestAzureTagMapFormatsKeys`
(lib/steps). `just check-go`, `just test-lib`, `just format`, and `just cli`
all pass.

## Category of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about