### PR TITLE
fix: default team-operator chart to v1.27.1

### DIFF
--- a/lib/steps/clusters.go
+++ b/lib/steps/clusters.go
@@ -17,7 +17,7 @@ const (
 	// clustersTeamOperatorServiceAccount is the Helm chart default service account name.
 	clustersTeamOperatorServiceAccount = "team-operator-controller-manager"
 	// clustersDefaultTeamOperatorChartVersion is used when no chart version is configured.
-	clustersDefaultTeamOperatorChartVersion = "v1.26.0"
+	clustersDefaultTeamOperatorChartVersion = "v1.27.1"
 	// clustersTraefikForwardAuthSA matches the Python Roles.TRAEFIK_FORWARD_AUTH value.
 	clustersTraefikForwardAuthSA = "traefik-forward-auth.posit.team"
 


### PR DESCRIPTION
## Description

Bumps `clustersDefaultTeamOperatorChartVersion` from `v1.26.0` to `v1.27.1` in `lib/steps/clusters.go`.

The default was a minor version stale (v1.27.0 shipped but the pin was never bumped), so this advances it two releases:

- **v1.27.0** ([release](https://github.com/posit-dev/team-operator/releases/tag/v1.27.0)) — adds an `envVars` field for Workbench, Connect, and Package Manager ([team-operator#141](https://github.com/posit-dev/team-operator/pull/141)). Additive, opt-in config; no behavior change unless a site sets it.
- **v1.27.1** ([release](https://github.com/posit-dev/team-operator/releases/tag/v1.27.1)) — corrects the Workbench load-balancer `XDG_CONFIG_DIRS` path ([team-operator#144](https://github.com/posit-dev/team-operator/pull/144)).

### Why (v1.27.1 fix)

The previous default shipped a broken HA Workbench load-balancer config. `XDG_CONFIG_DIRS` entries are base directories — Workbench appends `rstudio/<filename>` to each when resolving config. The entry was `/mnt/load-balancer/rstudio`, so Workbench looked for `/mnt/load-balancer/rstudio/rstudio/load-balancer` (nonexistent), logged "No load balancing configuration found", and defaulted `www-host-name` to the pod name. Pod names are not resolvable via cluster DNS, so multi-replica Workbench nodes failed to reach each other for distributed events, producing `Host not found (authoritative)` errors and degraded session routing (intermittent failures launching sessions).

### Verification

The v1.27.1 chart and image are published to GHCR. The fix was validated on a staging cluster via the adhoc PR image: after rollout, Workbench pods log `Reading load balancing configuration from '/mnt/load-balancer/rstudio/load-balancer'`, register their pod IP as `www-host-name`, and the distributed-event errors stop.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)