### PR TITLE
fix: resolve kubernetes step alias to eks/aks in workon

### DIFF
--- a/cmd/workon.go
+++ b/cmd/workon.go
@@ -143,17 +143,21 @@ func runWorkOn(cmd *cobra.Command, target string, step string, execCmd []string)
 			workDir = programPath
 			pulumiStackName = stack.Name()
 
-		} else if steps.ValidStep(step, t.ControlRoom()) {
+		} else if stackStep, ok := steps.ResolveStackStep(step, t.ControlRoom(), t.CloudProvider()); ok {
 			// Handle standard step. Built-in steps are inline-Go Pulumi programs, so
 			// `pulumi preview/up` is not possible from here (the program is compiled
 			// into the binary). This Go-runtime state workspace exists for the manual
 			// state-cutover runbooks: `pulumi stack export/import`,
 			// `state unprotect/delete`, etc., which read state and need no program.
+			//
+			// Some step names (e.g. "kubernetes") are selectors that delegate to a
+			// different step per cloud provider (e.g. "eks" or "aks"); ResolveStackStep
+			// resolves to the step that actually owns the Pulumi stack.
 			stack, err := pulumi.NewStateWorkspaceStack(
 				cmd.Context(),
 				string(t.CloudProvider()), // ptd-<cloud>-<control-room/workload>-<stackname>
 				targetType,
-				step,
+				stackStep,
 				t.Name(),
 				t.PulumiBackendUrl(),
 				t.PulumiSecretsProviderKey(),

--- a/lib/steps/selector.go
+++ b/lib/steps/selector.go
@@ -27,6 +27,17 @@ func (s *selector) Name() string {
 	return s.name
 }
 
+// NameForProvider returns the name of the underlying step delegated to for
+// the given cloud provider, e.g. resolving the "kubernetes" selector to
+// "eks" or "aks" depending on the target.
+func (s *selector) NameForProvider(cloudProvider types.CloudProvider) (string, bool) {
+	step, ok := s.steps[cloudProvider]
+	if !ok {
+		return "", false
+	}
+	return step.Name(), true
+}
+
 func (s *selector) Set(t types.Target, controlRoomTarget types.Target, options StepOptions) {
 	s.selected = t.CloudProvider()
 

--- a/lib/steps/selector.go
+++ b/lib/steps/selector.go
@@ -27,10 +27,10 @@ func (s *selector) Name() string {
 	return s.name
 }
 
-// NameForProvider returns the name of the underlying step delegated to for
+// nameForProvider returns the name of the underlying step delegated to for
 // the given cloud provider, e.g. resolving the "kubernetes" selector to
 // "eks" or "aks" depending on the target.
-func (s *selector) NameForProvider(cloudProvider types.CloudProvider) (string, bool) {
+func (s *selector) nameForProvider(cloudProvider types.CloudProvider) (string, bool) {
 	step, ok := s.steps[cloudProvider]
 	if !ok {
 		return "", false

--- a/lib/steps/steps.go
+++ b/lib/steps/steps.go
@@ -81,7 +81,7 @@ func ResolveStackStep(step string, controlRoom bool, cloudProvider types.CloudPr
 			continue
 		}
 
-		name, ok := sel.NameForProvider(cloudProvider)
+		name, ok := sel.nameForProvider(cloudProvider)
 		if !ok {
 			continue
 		}

--- a/lib/steps/steps.go
+++ b/lib/steps/steps.go
@@ -61,6 +61,43 @@ func ValidStep(step string, controlRoom bool) bool {
 	return false
 }
 
+// ResolveStackStep resolves a step name to the name of the step that actually
+// owns the Pulumi stack for the given cloud provider. Most steps map to
+// themselves, but selector-based steps (e.g. "kubernetes") delegate to a
+// different underlying step per cloud provider (e.g. "eks" or "aks"). Naming
+// the underlying step directly (e.g. "eks") also resolves to itself.
+func ResolveStackStep(step string, controlRoom bool, cloudProvider types.CloudProvider) (string, bool) {
+	standardSteps := WorkloadSteps
+	if controlRoom {
+		standardSteps = ControlRoomSteps
+	}
+
+	for _, s := range standardSteps {
+		sel, ok := s.(*selector)
+		if !ok {
+			if s.Name() == step {
+				return s.Name(), true
+			}
+			continue
+		}
+
+		name, ok := sel.NameForProvider(cloudProvider)
+		if !ok {
+			continue
+		}
+
+		// Match either the selector's own name (e.g. "kubernetes") or the
+		// name of the step it resolves to for this cloud provider (e.g.
+		// "eks" on AWS, "aks" on Azure). Naming a step for the wrong cloud
+		// provider (e.g. "eks" on an Azure target) does not resolve.
+		if s.Name() == step || name == step {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
 func InvalidSteps(steps []string, controlRoom bool) error {
 	for _, step := range steps {
 		if !ValidStep(step, controlRoom) {

--- a/lib/steps/steps_test.go
+++ b/lib/steps/steps_test.go
@@ -6,11 +6,87 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	psdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/posit-dev/ptd/lib/testdata"
 	"github.com/posit-dev/ptd/lib/types"
 )
+
+func TestResolveStackStep(t *testing.T) {
+	tests := []struct {
+		name          string
+		step          string
+		controlRoom   bool
+		cloudProvider types.CloudProvider
+		wantStep      string
+		wantOk        bool
+	}{
+		{
+			name:          "kubernetes resolves to eks on AWS",
+			step:          "kubernetes",
+			cloudProvider: types.AWS,
+			wantStep:      "eks",
+			wantOk:        true,
+		},
+		{
+			name:          "kubernetes resolves to aks on Azure",
+			step:          "kubernetes",
+			cloudProvider: types.Azure,
+			wantStep:      "aks",
+			wantOk:        true,
+		},
+		{
+			name:          "eks resolves to itself on AWS",
+			step:          "eks",
+			cloudProvider: types.AWS,
+			wantStep:      "eks",
+			wantOk:        true,
+		},
+		{
+			name:          "aks resolves to itself on Azure",
+			step:          "aks",
+			cloudProvider: types.Azure,
+			wantStep:      "aks",
+			wantOk:        true,
+		},
+		{
+			name:          "eks does not resolve on Azure",
+			step:          "eks",
+			cloudProvider: types.Azure,
+			wantOk:        false,
+		},
+		{
+			name:          "aks does not resolve on AWS",
+			step:          "aks",
+			cloudProvider: types.AWS,
+			wantOk:        false,
+		},
+		{
+			name:          "non-selector step resolves to itself",
+			step:          "bootstrap",
+			cloudProvider: types.AWS,
+			wantStep:      "bootstrap",
+			wantOk:        true,
+		},
+		{
+			name:          "unknown step does not resolve",
+			step:          "bogus",
+			cloudProvider: types.AWS,
+			wantOk:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ResolveStackStep(tt.step, tt.controlRoom, tt.cloudProvider)
+			assert.Equal(t, tt.wantOk, ok)
+			if tt.wantOk {
+				assert.Equal(t, tt.wantStep, got)
+			}
+		})
+	}
+}
 
 type stepTestHandler struct {
 	stack  auto.Stack


### PR DESCRIPTION
# Description

`ptd workon <target> kubernetes` failed to find a Pulumi stack, and `ptd workon <target> eks` failed step validation entirely.

The Kubernetes-access step is registered as a cloud-provider selector named `"kubernetes"`, which delegates to `eks` or `aks` depending on the target's cloud provider. `workon`'s step validation only recognized the selector's own name, and — once validated — used the raw CLI-provided step name directly as the Pulumi stack name. Since the actual stack is always named `eks` or `aks`, never `kubernetes`, `workon <target> kubernetes` built a reference to a stack that doesn't exist, while naming `eks`/`aks` directly failed validation before it even got that far.

## Code Flow

- `selector.NameForProvider(cloudProvider)` (`lib/steps/selector.go`) is a new method that returns the name of the underlying step for a given cloud provider (e.g. `eks` on AWS, `aks` on Azure).
- `steps.ResolveStackStep(step, controlRoom, cloudProvider)` (`lib/steps/steps.go`) is a new function that walks the step registry and resolves a CLI-facing step name to the step that actually owns the Pulumi stack: `kubernetes` resolves via the matching provider; `eks`/`aks` named directly resolve to themselves only when they match the target's actual cloud provider (e.g. `eks` on an Azure target correctly fails).
- `cmd/workon.go` now calls `ResolveStackStep` directly (replacing the old `ValidStep` check) and uses the resolved name to build the Pulumi state workspace stack reference.
- `ValidStep` itself is unchanged — it's only used elsewhere (`--only-steps`/`--start-at-step` in `ensure`) where the selector's own name is already the correct one to validate against.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about