### PR TITLE
feat(alerts): add Launcher Pod Pending alert for stuck session/content pods

### DIFF
--- a/lib/steps/assets/grafana_alerts/pods.yaml
+++ b/lib/steps/assets/grafana_alerts/pods.yaml
@@ -34,6 +34,8 @@ deleteRules:
       uid: PodNotHealthy
     - orgId: 1
       uid: PodRestarts
+    - orgId: 1
+      uid: launcher_pod_pending
 groups:
     - orgId: 1
       name: Pods
@@ -240,6 +242,8 @@ groups:
               Triage:      kubectl describe pod {{ $labels.pod }} -n {{ $labels.namespace }}
                            (check Events for FailedScheduling / volume errors)
 
+          labels:
+            opsgenie: "1"
           isPaused: false
         - uid: DeploymentReplicaMismatch
           title: Deployment Replicas Mismatch

--- a/lib/steps/assets/grafana_alerts/pods.yaml
+++ b/lib/steps/assets/grafana_alerts/pods.yaml
@@ -139,6 +139,108 @@ groups:
           labels:
             opsgenie: "1"
           isPaused: false
+        - uid: launcher_pod_pending
+          title: Launcher Pod Pending
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: mimir
+              model:
+                datasource:
+                    type: prometheus
+                    uid: mimir
+                editorMode: code
+                expr: count by (cluster, namespace, pod, label_launcher_instance_id)((kube_pod_status_phase{namespace="posit-team",phase="Pending"} == 1) * on (namespace, pod) group_left(label_launcher_instance_id) kube_pod_labels{label_launcher_instance_id=~".+"})
+                instant: true
+                intervalMs: 1000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          noDataState: OK
+          execErrState: Error
+          for: 5m
+          annotations:
+            summary: "🟡 WARNING: Launcher Pod Pending"
+            description: |
+              A launcher-spawned pod (Workbench session or Connect content) has
+              been stuck in Pending for 5+ minutes. Likely unschedulable —
+              insufficient node resources / failed scale-up, or a blocked PVC /
+              volume mount.
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+              Namespace:   {{ $labels.namespace }}
+              Pod:         {{ $labels.pod }}
+              Launcher:    {{ $labels.label_launcher_instance_id }}
+
+              ─── DETAILS ─────────────────────────
+              Status:      Pending
+              Duration:    5 minutes
+              Triage:      kubectl describe pod {{ $labels.pod }} -n {{ $labels.namespace }}
+                           (check Events for FailedScheduling / volume errors)
+
+          isPaused: false
         - uid: DeploymentReplicaMismatch
           title: Deployment Replicas Mismatch
           condition: C


### PR DESCRIPTION
# Description

Adds a Grafana alert, **Launcher Pod Pending**, that fires when a
launcher-spawned pod — a Workbench session (`session-*`) or a Connect content
execution (`run-*`) — has been stuck in `Pending` for 5+ minutes.

These pods are created on demand by the rstudio-launcher Kubernetes plugin and
often trigger node scale-up. When they can't schedule (insufficient resources,
failed Karpenter scale-up) or are blocked on a PVC / volume mount, they sit in
`Pending` indefinitely — today that goes unnoticed until a user reports a
session or published app that never starts. No existing alert covers this:
`crash_loop_backoff` needs a running-then-crashing container, and
`DeploymentReplicaMismatch` doesn't apply to launcher Jobs.

## Code Flow

Alert rules live in `lib/steps/assets/grafana_alerts/*.yaml`, embedded into the
`ptd` binary via `go:embed`, materialized as ConfigMaps (label `grafana_alert:
"1"`) during the cluster step, and provisioned by the Grafana sidecar. This PR
adds one rule to the existing `Pods` group in `pods.yaml`.

Query (refId A, instant) → `reduce (last)` (B) → `threshold > 0` (C), `for: 5m`
— the same scaffold as `crash_loop_backoff`:

```promql
count by (cluster, namespace, pod, label_launcher_instance_id)(
  (kube_pod_status_phase{namespace="posit-team", phase="Pending"} == 1)
  * on (namespace, pod) group_left(label_launcher_instance_id)
  kube_pod_labels{label_launcher_instance_id=~".+"}
)
```

- `kube_pod_status_phase` carries only `pod` (no pod labels), so scoping to
  launcher pods requires a join with `kube_pod_labels`, which exposes
  `label_launcher_instance_id` (present via the kube-state-metrics
  `metricLabelsAllowlist: pods=[launcher-instance-id,...]`). Both server pods
  and non-launcher workloads lack this label and are excluded.
- The `== 1` **must** be parenthesized: `*` binds tighter than `==` in PromQL,
  so without parens the join silently matches nothing.
- `group_left(label_launcher_instance_id)` carries the launcher instance into
  the result; the alert annotation surfaces it as `Launcher:` so responders
  know whether it's Workbench or Connect and which site.

Warning-only: the `opsgenie` label is intentionally omitted (every other rule
sets it). Severity is conveyed by the 🟡 WARNING summary.

### Validation

Validated live against a test workload with a running RStudio Pro session:
`kube_pod_status_phase` reports the session pod's phase, `kube_pod_labels`
exposes `label_launcher_instance_id=main-workbench`, and the join returns the
pod with the label carried through (confirmed against `phase="Running"` while
the pod was live; the rule uses `phase="Pending"`, which differs only in the
phase literal). A live Connect `run-*` pod was not available during testing;
coverage there relies on those pods carrying `launcher-instance-id`
(`main-connect`), which is set by the same launcher mechanism.

## Category of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
