### PR TITLE
fix(aks): restore user node pool SecurityProfile and remove conflicting powerState ignore

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -156,7 +156,7 @@ require (
 	github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.16.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/compute/v3 v3.16.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.16.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.16.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.16.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/dns/v3 v3.16.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/keyvault/v3 v3.14.0 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -380,8 +380,8 @@ github.com/pulumi/pulumi-azure-native-sdk/compute/v3 v3.16.0 h1:5D4MJdPI/y/IZBy/
 github.com/pulumi/pulumi-azure-native-sdk/compute/v3 v3.16.0/go.mod h1:Q8TDW2YGA/RnGqu4bd3hG/aJu7sExRMl/JjTcZAEOSI=
 github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.16.0 h1:FH5Me4ZjzozVlmtqatPhUpUZB7vGJkGWvqk63qu6iCY=
 github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.16.0/go.mod h1:E9QYEfEfcPlj7BC0j6n8QV7LnURip1pwpQCKGmYGB54=
-github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1 h1:+TOXp54h+42zk6/dHDYUEUgHph0oCIIHave+1PlNAek=
-github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1/go.mod h1:N7eNJSg9C7gJETX1PNx3c54XaB5LhxD8xIzQkv7QpfU=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.16.0 h1:7YYTYy4SaDL/oafEoiDIiXhxFxnKFaH8EAZfhZcuhJI=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.16.0/go.mod h1:F4jK+3pqz8eXYg53Q+zcvsdix/RJ7VJvuKafVMJCung=
 github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.16.0 h1:0ahdGJXgSOI/zcTLHsoxLyJoDhhgT7m39DqDjFWfAxQ=
 github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.16.0/go.mod h1:JMfQ+jmQf0YYI31s3fQe5hJ73hWEv0Mlc/sjukf6o8U=
 github.com/pulumi/pulumi-azure-native-sdk/dns/v3 v3.16.0 h1:h9/CobKEpu6M7az6FV9KjNuAuHULF4drn9qsTMljQkQ=

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -182,7 +182,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.24.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1
+	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.16.0
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sagikazarmark/locafero v0.9.0 // indirect

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -376,8 +376,8 @@ github.com/pulumi/pulumi-azure-native-sdk/compute/v3 v3.16.0 h1:5D4MJdPI/y/IZBy/
 github.com/pulumi/pulumi-azure-native-sdk/compute/v3 v3.16.0/go.mod h1:Q8TDW2YGA/RnGqu4bd3hG/aJu7sExRMl/JjTcZAEOSI=
 github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.16.0 h1:FH5Me4ZjzozVlmtqatPhUpUZB7vGJkGWvqk63qu6iCY=
 github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.16.0/go.mod h1:E9QYEfEfcPlj7BC0j6n8QV7LnURip1pwpQCKGmYGB54=
-github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1 h1:+TOXp54h+42zk6/dHDYUEUgHph0oCIIHave+1PlNAek=
-github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.6.1/go.mod h1:N7eNJSg9C7gJETX1PNx3c54XaB5LhxD8xIzQkv7QpfU=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.16.0 h1:7YYTYy4SaDL/oafEoiDIiXhxFxnKFaH8EAZfhZcuhJI=
+github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3 v3.16.0/go.mod h1:F4jK+3pqz8eXYg53Q+zcvsdix/RJ7VJvuKafVMJCung=
 github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.16.0 h1:0ahdGJXgSOI/zcTLHsoxLyJoDhhgT7m39DqDjFWfAxQ=
 github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.16.0/go.mod h1:JMfQ+jmQf0YYI31s3fQe5hJ73hWEv0Mlc/sjukf6o8U=
 github.com/pulumi/pulumi-azure-native-sdk/dns/v3 v3.16.0 h1:h9/CobKEpu6M7az6FV9KjNuAuHULF4drn9qsTMljQkQ=

--- a/lib/steps/aks.go
+++ b/lib/steps/aks.go
@@ -346,7 +346,7 @@ func (s *AKSStep) deploy(ctx *pulumi.Context, target types.Target) error {
 					SecurityProfile: &containerservice.AgentPoolSecurityProfileArgs{
 						EnableSecureBoot: pulumi.Bool(false),
 						EnableVTPM:       pulumi.Bool(false),
-						SshAccess:        pulumi.String("LocalUser"),
+						SshAccess:        pulumi.String(containerservice.AgentPoolSSHAccessLocalUser),
 					},
 					Tags: buildResourceTags(config.ResourceTags),
 					Type: pulumi.String(containerservice.AgentPoolTypeVirtualMachineScaleSets),

--- a/lib/steps/aks.go
+++ b/lib/steps/aks.go
@@ -174,7 +174,6 @@ func (s *AKSStep) deploy(ctx *pulumi.Context, target types.Target) error {
 			"networkProfile.podCidrs",
 			"networkProfile.serviceCidrs",
 			"nodeResourceGroup",
-			"agentPoolProfiles[*].powerState",
 			"privateLinkResources",
 			"windowsProfile",
 			// Customer-enabled out-of-band (Defender for Cloud); we never set this field.
@@ -344,8 +343,13 @@ func (s *AKSStep) deploy(ctx *pulumi.Context, target types.Target) error {
 					OsSKU:               pulumi.String(containerservice.OSSKUUbuntu),
 					OsType:              pulumi.String(containerservice.OSTypeLinux),
 					ScaleDownMode:       pulumi.String(containerservice.ScaleDownModeDelete),
-					Tags:                buildResourceTags(config.ResourceTags),
-					Type:                pulumi.String(containerservice.AgentPoolTypeVirtualMachineScaleSets),
+					SecurityProfile: &containerservice.AgentPoolSecurityProfileArgs{
+						EnableSecureBoot: pulumi.Bool(false),
+						EnableVTPM:       pulumi.Bool(false),
+						SshAccess:        pulumi.String("LocalUser"),
+					},
+					Tags: buildResourceTags(config.ResourceTags),
+					Type: pulumi.String(containerservice.AgentPoolTypeVirtualMachineScaleSets),
 					UpgradeSettings: &containerservice.AgentPoolUpgradeSettingsArgs{
 						MaxSurge: pulumi.String("10%"),
 					},


### PR DESCRIPTION
## Summary
Fixes two preview regressions on Azure AKS workloads introduced when user node pools were migrated from inline `agentPoolProfiles` to standalone `AgentPool` resources.

## Changes
- Remove `agentPoolProfiles[*].powerState` from the cluster `IgnoreChanges` list. The whole `agentPoolProfiles` array is already ignored whenever user pools exist (always, since resolution errors with none), and the per-element leaf ignore conflicts with the whole-array ignore, failing preview with `cannot ignore changes in added or removed elements of the path`.
- Add `SecurityProfile` (`EnableSecureBoot=false`, `EnableVTPM=false`, `SshAccess="LocalUser"`) to the standalone user-pool `AgentPoolArgs`, matching the inline system pool and the live AKS default, eliminating a spurious `securityProfile` removal diff.
- Bump `pulumi-azure-native-sdk/containerservice/v3` from `v3.6.1` to `v3.16.0` so the `SshAccess` field is modeled. The pin was incidental (set at lib creation, never deliberately held back); all other azure-native modules and the provider plugin are already at `v3.16.0`.

## Testing
- `just cli` build succeeds
- `just check-go` (go vet) clean
- `just test-lib` all packages pass
- Validated against a live Azure AKS workload: the `powerState` preview error and the spurious `securityProfile` removal are gone; genuine version/autoscaler-bound reconciliations remain visible (not masked).
