### PR TITLE
fix(aks): stable far-future force-upgrade expiry to stop perpetual dry-run diff

### DIFF
--- a/lib/steps/aks.go
+++ b/lib/steps/aks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/containerservice/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -195,12 +194,17 @@ func (s *AKSStep) deploy(ctx *pulumi.Context, target types.Target) error {
 		// Configure upgrade settings - use ForceUpgrade to bypass PDBs during maintenance
 		var upgradeSettings *containerservice.ClusterUpgradeSettingsArgs
 		if clusterConfig.ForceMaintenance {
-			// ForceUpgrade bypasses PDB constraints during cluster upgrades
-			// The 'Until' field sets when the override expires (required for it to take effect)
+			// ForceUpgrade bypasses PDB constraints during cluster upgrades.
+			// The 'Until' field sets when the override expires and must be a
+			// future timestamp for AKS to honor the override. Use a fixed
+			// far-future constant rather than a now-relative value: a stable
+			// value converges and avoids a perpetual preview diff on
+			// upgradeSettings.overrideSettings.until, while keeping ForceUpgrade
+			// permanently armed so PDBs never block a maintenance upgrade.
 			upgradeSettings = &containerservice.ClusterUpgradeSettingsArgs{
 				OverrideSettings: &containerservice.UpgradeOverrideSettingsArgs{
 					ForceUpgrade: pulumi.Bool(true),
-					Until:        pulumi.String(time.Now().Add(24 * time.Hour).Format(time.RFC3339)),
+					Until:        pulumi.String("2035-01-01T00:00:00Z"),
 				},
 			}
 		}


### PR DESCRIPTION
## What
AKS clusters with `force_maintenance` enabled showed a perpetual dry-run diff on `upgradeSettings.overrideSettings.until`. The value was `time.Now().Add(24h)`, recomputed on every run, so it never matched state and the step never converged.

## Change
- Set `until` to a fixed far-future constant (`2035-01-01T00:00:00Z`) so the value is stable and converges after one apply.
- The override remains permanently armed: `ForceUpgrade` is still true, so PodDisruptionBudgets never block a maintenance upgrade.
- Remove the now-unused `time` import.

## Testing
- `just cli`, `just check-go`, `just test-lib`, `just format` all pass.
- Dry-run against a live AKS workload confirms `until` now renders as the fixed constant (one-time reconcile) with no other change to the step.

## Follow-up
- Validate at apply time that AKS accepts an `until` this far in the future (confirm there is no max-window clamp/rejection on the override expiry). If clamped, a nearer but still-stable date can be used.
