### PR TITLE
fix: default team-operator chart to v1.29.0

### DIFF
--- a/lib/steps/clusters.go
+++ b/lib/steps/clusters.go
@@ -17,7 +17,7 @@ const (
 	// clustersTeamOperatorServiceAccount is the Helm chart default service account name.
 	clustersTeamOperatorServiceAccount = "team-operator-controller-manager"
 	// clustersDefaultTeamOperatorChartVersion is used when no chart version is configured.
-	clustersDefaultTeamOperatorChartVersion = "v1.27.1"
+	clustersDefaultTeamOperatorChartVersion = "v1.29.0"
 	// clustersTraefikForwardAuthSA matches the Python Roles.TRAEFIK_FORWARD_AUTH value.
 	clustersTraefikForwardAuthSA = "traefik-forward-auth.posit.team"
 


### PR DESCRIPTION
Bumps the default team-operator Helm chart version from `v1.27.1` to `v1.29.0`.

## Change
- `lib/steps/clusters.go`: `clustersDefaultTeamOperatorChartVersion` `v1.27.1` → `v1.29.0`

Both consumers (`clusters_aws.go`, `clusters_azure.go`) reference the constant by name, so they pick up the new default automatically. No other occurrences of the old version exist outside historical CHANGELOG entries.

## Changelog
`CHANGELOG.md` is auto-generated by semantic-release; the `fix:` commit produces a patch release + changelog entry on merge, so no manual edit.

## Tests
No tests reference the constant or assert on the default chart version.
- `go vet ./steps/...` → clean
- `go test ./steps/...` → `ok github.com/posit-dev/ptd/lib/steps`