### PR TITLE
fix(alerts): rework NetApp throughput alerting (attributable + split) and kill anonymous NoData pagers

### DIFF
--- a/lib/steps/assets/grafana_alerts/azure_netapp.yaml
+++ b/lib/steps/assets/grafana_alerts/azure_netapp.yaml
@@ -11,6 +11,8 @@
 #     uid: azure_netapp_write_latency_high
 #   - orgId: 1
 #     uid: azure_netapp_throughput_limit
+#   - orgId: 1
+#     uid: azure_netapp_metrics_silent
 #
 # See https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/
 #
@@ -305,6 +307,125 @@ groups:
               ─── ACTION ──────────────────────────
               Consider increasing the volume's service level or quota
               to provision more throughput capacity.
+
+          labels:
+            opsgenie: "1"
+          isPaused: false
+        - uid: azure_netapp_metrics_silent
+          title: Azure NetApp Files Metrics Silent
+          condition: C
+          data:
+            # A cluster that was exporting NetApp metrics 24h ago but is now
+            # silent. Grouping by cluster/tenant means the fired alert *names*
+            # the cluster whose Azure Monitor scrape went dark — unlike the
+            # threshold rules above, whose NoData instances carry no labels.
+            # VolumeConsumedSizePercentage is used as the witness series because
+            # it is always present for every volume (not conditional like
+            # ThroughputLimitReached).
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: mimir
+              model:
+                editorMode: code
+                expr: |
+                  count by (cluster, tenant_name, __tenant_id__) (
+                    azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"} offset 24h
+                  )
+                  unless
+                  count by (cluster, tenant_name, __tenant_id__) (
+                    azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}
+                  )
+                instant: true
+                intervalMs: 1000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          # noDataState: OK is correct here - an empty result means every cluster
+          # that reported 24h ago is still reporting (healthy). This is the
+          # attribution alert the label-less NoData pages could not provide.
+          noDataState: OK
+          execErrState: Error
+          for: 10m
+          annotations:
+            summary: "🔴 CRITICAL: Azure NetApp Files Metrics Silent"
+            description: |
+              NetApp Files metrics stopped arriving from a cluster that was
+              reporting them 24h ago. The Azure Monitor scrape (Alloy
+              prometheus.exporter.azure "netapp") is likely down, throttled,
+              or missing credentials. While silent, the NetApp threshold
+              alerts (capacity/latency/throughput) are blind for this cluster.
+
+              ─── WHERE ───────────────────────────
+              Tenant:      {{ $labels.tenant_name }}
+              Cluster:     {{ $labels.cluster }}
+
+              ─── DETAILS ─────────────────────────
+              Component:   Azure Monitor NetApp exporter
+              Issue:       Volume was reporting 24h ago but is now silent
+              Duration:    10 minutes
+
+              ─── ACTION ──────────────────────────
+              Check the Alloy pod on this cluster and the Azure Monitor
+              exporter credentials/permissions for the NetApp resource group.
 
           labels:
             opsgenie: "1"

--- a/lib/steps/assets/grafana_alerts/azure_netapp.yaml
+++ b/lib/steps/assets/grafana_alerts/azure_netapp.yaml
@@ -82,9 +82,9 @@ groups:
               NetApp Files volume capacity utilization is above 80%
 
               ─── WHERE ───────────────────────────
-              Tenant:      {{ $labels.tenant_name }}
-              Cluster:     {{ $labels.cluster }}
-              Volume:      {{ $labels.volume }}
+              Tenant:         {{ $labels.tenant_name }}
+              Cluster:        {{ $labels.cluster }}
+              Volume:         {{ $labels.volume }}
               Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────
@@ -154,9 +154,9 @@ groups:
               NetApp Files volume read latency is above 500ms
 
               ─── WHERE ───────────────────────────
-              Tenant:      {{ $labels.tenant_name }}
-              Cluster:     {{ $labels.cluster }}
-              Volume:      {{ $labels.volume }}
+              Tenant:         {{ $labels.tenant_name }}
+              Cluster:        {{ $labels.cluster }}
+              Volume:         {{ $labels.volume }}
               Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────
@@ -224,9 +224,9 @@ groups:
               NetApp Files volume write latency is above 500ms
 
               ─── WHERE ───────────────────────────
-              Tenant:      {{ $labels.tenant_name }}
-              Cluster:     {{ $labels.cluster }}
-              Volume:      {{ $labels.volume }}
+              Tenant:         {{ $labels.tenant_name }}
+              Cluster:        {{ $labels.cluster }}
+              Volume:         {{ $labels.volume }}
               Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────

--- a/lib/steps/assets/grafana_alerts/azure_netapp.yaml
+++ b/lib/steps/assets/grafana_alerts/azure_netapp.yaml
@@ -38,7 +38,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}[5m])
+                expr: label_replace(last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}[5m]), "volume", "$1", "resourceID", ".*/volumes/(.+)")
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -84,8 +84,8 @@ groups:
               ─── WHERE ───────────────────────────
               Tenant:      {{ $labels.tenant_name }}
               Cluster:     {{ $labels.cluster }}
-              Resource:    {{ $labels.resourceName}}
-              Location:    {{ $labels.location }}
+              Volume:      {{ $labels.volume }}
+              Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────
               Metric:      Volume Capacity
@@ -110,7 +110,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}[5m])
+                expr: label_replace(last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagereadlatency_average_milliseconds{job="integrations/azure"}[5m]), "volume", "$1", "resourceID", ".*/volumes/(.+)")
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -156,8 +156,8 @@ groups:
               ─── WHERE ───────────────────────────
               Tenant:      {{ $labels.tenant_name }}
               Cluster:     {{ $labels.cluster }}
-              Resource:    {{ $labels.resourceName}}
-              Location:    {{ $labels.location }}
+              Volume:      {{ $labels.volume }}
+              Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────
               Metric:      Read Latency
@@ -180,7 +180,7 @@ groups:
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagewritelatency_average_milliseconds{job="integrations/azure"}[5m])
+                expr: label_replace(last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_averagewritelatency_average_milliseconds{job="integrations/azure"}[5m]), "volume", "$1", "resourceID", ".*/volumes/(.+)")
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -226,8 +226,8 @@ groups:
               ─── WHERE ───────────────────────────
               Tenant:      {{ $labels.tenant_name }}
               Cluster:     {{ $labels.cluster }}
-              Resource:    {{ $labels.resourceName}}
-              Location:    {{ $labels.location }}
+              Volume:      {{ $labels.volume }}
+              Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────
               Metric:      Write Latency

--- a/lib/steps/assets/grafana_alerts/azure_netapp.yaml
+++ b/lib/steps/assets/grafana_alerts/azure_netapp.yaml
@@ -245,12 +245,16 @@ groups:
           data:
             - refId: A
               relativeTimeRange:
-                from: 600
+                from: 1800
                 to: 0
               datasourceUid: mimir
               model:
                 editorMode: code
-                expr: last_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_throughputlimitreached_average_count{job="integrations/azure"}[5m])
+                # avg_over_time(...[30m]) = fraction of the last 30m the volume was throttled.
+                # label_replace derives a real per-volume label from resourceID, because the
+                # exporter's resourceName label is the NetApp *account* (identical for every
+                # volume in the cluster), not the volume.
+                expr: label_replace(avg_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_throughputlimitreached_average_count{job="integrations/azure"}[30m]), "volume", "$1", "resourceID", ".*/volumes/(.+)")
                 instant: true
                 intervalMs: 1000
                 legendFormat: __auto
@@ -259,14 +263,14 @@ groups:
                 refId: A
             - refId: B
               relativeTimeRange:
-                from: 600
+                from: 1800
                 to: 0
               datasourceUid: __expr__
               model:
                 conditions:
                     - evaluator:
                         params:
-                            - 0.5 # Fires when metric is 1 (limit reached)
+                            - 0.5 # Fires when throttled >50% of the 30m window (sustained, not a burst)
                         type: gt
                       operator:
                         type: and
@@ -291,17 +295,19 @@ groups:
           annotations:
             summary: "🔴 CRITICAL: Azure NetApp Files Throughput Limit Reached"
             description: |
-              NetApp Files volume has reached its throughput limit
+              NetApp Files volume has been at its throughput limit for the
+              majority of the last 30 minutes (sustained saturation, not a
+              transient burst).
 
               ─── WHERE ───────────────────────────
-              Tenant:      {{ $labels.tenant_name }}
-              Cluster:     {{ $labels.cluster }}
-              Resource:    {{ $labels.resourceName}}
-              Location:    {{ $labels.location }}
+              Tenant:         {{ $labels.tenant_name }}
+              Cluster:        {{ $labels.cluster }}
+              Volume:         {{ $labels.volume }}
+              Resource group: {{ $labels.resourceGroup }}
 
               ─── DETAILS ─────────────────────────
-              Metric:      Throughput Limit Reached (boolean)
-              Current:     Limit reached
+              Metric:      Throughput Limit Reached (fraction of 30m throttled)
+              Threshold:   >50% of a 30m window
               Duration:    5 minutes
 
               ─── ACTION ──────────────────────────

--- a/lib/steps/assets/grafana_alerts/azure_netapp.yaml
+++ b/lib/steps/assets/grafana_alerts/azure_netapp.yaml
@@ -321,27 +321,30 @@ groups:
           title: Azure NetApp Files Metrics Silent
           condition: C
           data:
-            # A cluster that was exporting NetApp metrics 24h ago but is now
-            # silent. Grouping by cluster/tenant means the fired alert *names*
-            # the cluster whose Azure Monitor scrape went dark — unlike the
-            # threshold rules above, whose NoData instances carry no labels.
-            # VolumeConsumedSizePercentage is used as the witness series because
-            # it is always present for every volume (not conditional like
-            # ThroughputLimitReached).
+            # Fires when a cluster reported NetApp metrics at some point in the
+            # last 24h (present_over_time[24h]) but has now been silent for 15m
+            # (present_over_time[15m] empty). Grouping by cluster/tenant means the
+            # alert *names* the cluster whose Azure Monitor scrape went dark —
+            # unlike the threshold rules above, whose NoData instances carry no
+            # labels. A windowed baseline (not `offset 24h`) is deliberate: a
+            # single-point offset can't cover clusters younger than 24h and would
+            # self-resolve once the outage itself is older than 24h. Volume-
+            # ConsumedSizePercentage is the witness series because it is always
+            # present for every volume (unlike the conditional ThroughputLimitReached).
             - refId: A
               relativeTimeRange:
-                from: 600
+                from: 86400
                 to: 0
               datasourceUid: mimir
               model:
                 editorMode: code
                 expr: |
                   count by (cluster, tenant_name, __tenant_id__) (
-                    azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"} offset 24h
+                    present_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}[24h])
                   )
                   unless
                   count by (cluster, tenant_name, __tenant_id__) (
-                    azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}
+                    present_over_time(azure_microsoft_netapp_netappaccounts_capacitypools_volumes_volumeconsumedsizepercentage_average_percent{job="integrations/azure"}[15m])
                   )
                 instant: true
                 intervalMs: 1000
@@ -406,16 +409,17 @@ groups:
                 refId: C
                 type: threshold
           # noDataState: OK is correct here - an empty result means every cluster
-          # that reported 24h ago is still reporting (healthy). This is the
-          # attribution alert the label-less NoData pages could not provide.
+          # that reported within the last 24h is still reporting (healthy). This is
+          # the attribution alert the label-less NoData pages could not provide.
           noDataState: OK
           execErrState: Error
-          for: 10m
+          for: 5m
           annotations:
             summary: "🔴 CRITICAL: Azure NetApp Files Metrics Silent"
             description: |
-              NetApp Files metrics stopped arriving from a cluster that was
-              reporting them 24h ago. The Azure Monitor scrape (Alloy
+              NetApp Files metrics have stopped arriving from a cluster that was
+              reporting within the last 24h and has now been silent for 15+
+              minutes. The Azure Monitor scrape (Alloy
               prometheus.exporter.azure "netapp") is likely down, throttled,
               or missing credentials. While silent, the NetApp threshold
               alerts (capacity/latency/throughput) are blind for this cluster.
@@ -426,8 +430,8 @@ groups:
 
               ─── DETAILS ─────────────────────────
               Component:   Azure Monitor NetApp exporter
-              Issue:       Volume was reporting 24h ago but is now silent
-              Duration:    10 minutes
+              Issue:       Reported within 24h but now silent for 15m+
+              Duration:    silent ≥15m, sustained 5m
 
               ─── ACTION ──────────────────────────
               Check the Alloy pod on this cluster and the Azure Monitor

--- a/lib/steps/assets/grafana_alerts/loadbalancer.yaml
+++ b/lib/steps/assets/grafana_alerts/loadbalancer.yaml
@@ -209,7 +209,12 @@ groups:
                 maxDataPoints: 43200
                 refId: B
                 type: threshold
-          noDataState: NoData
+          # noDataState: OK - the fleet uses ALBs for ingress; Network Load
+          # Balancers are optional and usually absent, so aws_networkelb_* has no
+          # series (confirmed: 0 series across the fleet). Alerting on NoData here
+          # only produced anonymous DatasourceNoData pages with blank labels. Fire
+          # only when an NLB actually exists and has unhealthy targets.
+          noDataState: OK
           execErrState: Error
           for: 5m
           annotations:

--- a/lib/steps/helm_helpers.go
+++ b/lib/steps/helm_helpers.go
@@ -830,7 +830,7 @@ prometheus.exporter.azure "netapp" {
     subscriptions    = ["%s"]
     resource_type    = "Microsoft.NetApp/netAppAccounts/capacityPools/volumes"
     resource_graph_query_filter = "where resourceGroup == '%s'"
-    metrics          = ["VolumeConsumedSizePercentage", "VolumeLogicalSize", "AverageReadLatency", "AverageWriteLatency", "ReadIops", "WriteIops"]
+    metrics          = ["VolumeConsumedSizePercentage", "VolumeLogicalSize", "AverageReadLatency", "AverageWriteLatency", "ReadIops", "WriteIops", "ThroughputLimitReached"]
 }
 
 prometheus.scrape "azure_netapp" {


### PR DESCRIPTION
# Description

The `Azure NetApp Files Throughput Limit Reached` alert paged CRITICAL with every field blank. Root cause: it queries `ThroughputLimitReached`, which the Alloy exporter never scraped (**0 series in 20 days**), so it sat in permanent `NoData` — and `NoData` still pages anonymously via the rule's `opsgenie` label. Meanwhile a real throughput-saturation problem on a volume was invisible to PTD.

This splits NetApp throughput alerting into two purpose-built rules and fixes the related labelling bugs.

## The existing rule was broken five ways
1. Queried a metric that was never scraped → permanent `NoData`.
2. `NoData` paged anonymously — every field rendered `[no value]`.
3. One rule conflated *"limit reached"* and *"no data"* — conditions with opposite fixes.
4. Couldn't name the volume even with data: `resourceName` is the NetApp **account**, and there is no `location` label.
5. The metric is bursty, so a single-sample threshold would flap.

## Changes
- **`azure_netapp_throughput_limit` (fixed):** scrape the metric ([Azure Monitor ref](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-netapp-netappaccounts-capacitypools-volumes-metrics)); fire on `avg_over_time(...[30m]) > 0.5` (sustained saturation, not bursts); derive a `volume` label from `resourceID` and show `Volume` + `Resource group`.
- **`azure_netapp_metrics_silent` (new):** owns the "exporter went dark" signal, grouped `by (cluster, tenant_name)` so it names the cluster. Windowed baseline `present_over_time(metric[24h]) unless present_over_time(metric[15m])`; `noDataState: OK`.
- **Other three NetApp rules:** same `volume` label + annotation fix (they had the identical `resourceName`/`location` bug).
- **`nlb_unhealthy_targets`:** 0 series because the fleet has no NLBs → `noDataState: OK`, stopping its own anonymous `NoData` pages (ALB rules unchanged).

**Why split the throughput rule in two:** the two conditions have opposite remediations (grow the volume/pool vs. fix Alloy/creds). One `NoData`-driven rule made every page blind and ambiguous; split, each carries the right labels and points at the right fix.

## Category of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
`go build ./...` and `go test ./steps/` pass in `lib/`; both YAMLs parse. The `volume` extraction (`.*/volumes/(.+)`) and 5-min cadence were confirmed against live Mimir.

## Follow-up (not in this PR)
The `postgres` / `storage` Azure integrations have no silent-alert equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
