### PR TITLE
fix: auto-review triggers on ready_for_review + can read guidelines

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -33,7 +33,7 @@ jobs:
           use_bedrock: true
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --allowedTools "Read,Glob,Grep,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"
+            --disallowedTools "Bash,Edit,Write,MultiEdit,NotebookEdit,WebFetch"
           prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
 

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 env:
   PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
@@ -33,7 +33,7 @@ jobs:
           use_bedrock: true
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"
+            --allowedTools "Read,Glob,Grep,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"
           prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
 


### PR DESCRIPTION
Fixes two bugs that together explain why reviews stopped posting.

**1. Missing `ready_for_review` trigger.** The workflow only fired on `opened`, so switching a draft PR to Ready for Review did nothing. Added `ready_for_review`.

**2. Narrow `--allowedTools` allowlist blocked the review.** The prompt tells Claude to review per `.claude/review-guidelines.md`, but the allowlist only included the GitHub MCP tools — not `Read`. Claude couldn't open the guidelines file, hit `permission_denials_count: 5`, and finished without posting anything. Switched to a `--disallowedTools` denylist that keeps claude-code-action's default tools (Read/Glob/Grep + default GitHub review tools) and blocks only mutation/shell/network. This mirrors the `posit-dev/review-actions` config used by ptd-config, which posts reviews reliably.

> ⚠️ **Can't be verified before merge — which is why this has taken several PRs.** GitHub normally runs a `pull_request` workflow from the PR branch, but `claude-code-action` additionally requires the workflow file to match the default-branch copy before it will exchange the App token (per the action's maintainers — the run fails with `Workflow validation failed`, expected here). So edits to this workflow can't run on the PR that makes them; they only take effect on the next normal PR after merge. Every fix is therefore merge-then-observe, one PR at a time.