### PR TITLE
feat(azure): support multiple TLS secrets on Traefik site ingress

### DIFF
--- a/examples/workload/ptd.yaml
+++ b/examples/workload/ptd.yaml
@@ -82,6 +82,16 @@ spec:
         # Required when hosted_zone_management_enabled is false:
         # certificate_arn: arn:aws:acm:us-east-2:123456789012:certificate/example-id
         # certificate_validation_enabled: false
+        # Azure/Traefik only: terminate TLS with multiple certificates for this
+        # site. When set, this REPLACES the default single-wildcard tls entry
+        # ([domain, *.domain] -> "{name}-{domain}-tls") for this site's Traefik
+        # ingress. Each referenced secret must be a kubernetes.io/tls secret in
+        # the "traefik" namespace (same namespace as the ingress).
+        # tls_secrets:
+        #   - hosts: ["analytics.example.com"]
+        #     secret_name: analytics-tls
+        #   - hosts: ["api.analytics.example.com", "api2.analytics.example.com"]
+        #     secret_name: analytics-api-tls
     dev:
       spec:
         domain: analytics-dev.example.com

--- a/lib/steps/clusters_azure.go
+++ b/lib/steps/clusters_azure.go
@@ -47,6 +47,10 @@ type azureClustersParams struct {
 	// siteDomains is always the per-site domains (one per site), independent of root_domain.
 	// Used for Traefik Ingresses, which must be created for every site domain.
 	siteDomains []string
+	// siteTLSSecrets maps a site domain to its optional per-host TLS secrets.
+	// When a domain has a non-empty entry, the Traefik ingress terminates TLS
+	// with those secrets instead of the default single wildcard secret.
+	siteTLSSecrets map[string][]types.SiteTLSSecret
 	// thirdPartyTelemetryEnabled controls whether Traefik telemetry arguments are suppressed.
 	thirdPartyTelemetryEnabled bool
 	// workloadDir is the path to the workload's config directory (contains ptd.yaml, custom_k8s_resources/, etc.)
@@ -54,6 +58,52 @@ type azureClustersParams struct {
 	// rootDomain is the dereferenced value of cfg.RootDomain, or empty string if nil.
 	// Used to select the correct ClusterIssuer name in Traefik Ingress annotations.
 	rootDomain string
+}
+
+// traefikIngressTLSEntry is a plain representation of a single Traefik ingress
+// `tls` entry (hosts + secret name). It is the pure, unit-testable form of the
+// Pulumi `tls` array built by traefikIngressTLS.
+type traefikIngressTLSEntry struct {
+	Hosts      []string
+	SecretName string
+}
+
+// traefikIngressTLSEntries returns the ordered `tls` entries for a site's
+// Traefik ingress. When tlsSecrets is non-empty, it yields one entry per
+// configured secret (preserving order); otherwise it yields the default single
+// wildcard entry ([domain, *.domain] → "{name}-{domain}-tls"), matching the
+// historical behavior byte-for-byte.
+func traefikIngressTLSEntries(name, domain string, tlsSecrets []types.SiteTLSSecret) []traefikIngressTLSEntry {
+	if len(tlsSecrets) > 0 {
+		entries := make([]traefikIngressTLSEntry, 0, len(tlsSecrets))
+		for _, s := range tlsSecrets {
+			entries = append(entries, traefikIngressTLSEntry{Hosts: s.Hosts, SecretName: s.SecretName})
+		}
+		return entries
+	}
+	return []traefikIngressTLSEntry{
+		{
+			Hosts:      []string{domain, fmt.Sprintf("*.%s", domain)},
+			SecretName: fmt.Sprintf("%s-%s-tls", name, domain),
+		},
+	}
+}
+
+// traefikIngressTLS renders the Traefik ingress `spec.tls` value as a
+// pulumi.Array from the pure entries produced by traefikIngressTLSEntries.
+func traefikIngressTLS(name, domain string, tlsSecrets []types.SiteTLSSecret) pulumi.Array {
+	tls := pulumi.Array{}
+	for _, e := range traefikIngressTLSEntries(name, domain, tlsSecrets) {
+		hosts := make(pulumi.StringArray, 0, len(e.Hosts))
+		for _, h := range e.Hosts {
+			hosts = append(hosts, pulumi.String(h))
+		}
+		tls = append(tls, pulumi.Map{
+			"hosts":      hosts,
+			"secretName": pulumi.String(e.SecretName),
+		})
+	}
+	return tls
 }
 
 func (s *ClustersStep) runAzureInlineGo(ctx context.Context, creds types.Credentials, envVars map[string]string) error {
@@ -121,8 +171,12 @@ func (s *ClustersStep) runAzureInlineGo(ctx context.Context, creds types.Credent
 	// siteDomains is always the per-site domains, independent of root_domain.
 	// Used for Traefik Ingresses, which must be created for every site domain.
 	var siteDomains []string
+	siteTLSSecrets := make(map[string][]types.SiteTLSSecret)
 	for _, siteCfg := range cfg.Sites {
 		siteDomains = append(siteDomains, siteCfg.Spec.Domain)
+		if len(siteCfg.Spec.TLSSecrets) > 0 {
+			siteTLSSecrets[siteCfg.Spec.Domain] = siteCfg.Spec.TLSSecrets
+		}
 	}
 	sort.Strings(siteDomains)
 
@@ -147,6 +201,7 @@ func (s *ClustersStep) runAzureInlineGo(ctx context.Context, creds types.Credent
 		clusterIdentityByCluster:     clusterIdentityByCluster,
 		certManagerDomains:           certManagerDomains,
 		siteDomains:                  siteDomains,
+		siteTLSSecrets:               siteTLSSecrets,
 		thirdPartyTelemetryEnabled:   cfg.ThirdPartyTelemetryEnabled == nil || *cfg.ThirdPartyTelemetryEnabled,
 		workloadDir:                  filepath.Join(helpers.GetTargetsConfigPath(), helpers.WorkDir, s.DstTarget.Name()),
 		rootDomain: func() string {
@@ -750,12 +805,7 @@ func azureClustersDeploy(ctx *pulumi.Context, _ types.Target, params azureCluste
 				},
 				"spec": pulumi.Map{
 					"ingressClassName": pulumi.String("traefik"),
-					"tls": pulumi.Array{
-						pulumi.Map{
-							"hosts":      pulumi.StringArray{pulumi.String(domain), pulumi.String(fmt.Sprintf("*.%s", domain))},
-							"secretName": pulumi.String(fmt.Sprintf("%s-%s-tls", name, domain)),
-						},
-					},
+					"tls":              traefikIngressTLS(name, domain, params.siteTLSSecrets[domain]),
 					"rules": pulumi.Array{
 						pulumi.Map{
 							"http": pulumi.Map{

--- a/lib/steps/clusters_test.go
+++ b/lib/steps/clusters_test.go
@@ -553,21 +553,55 @@ func TestAzureClustersDeployTraefikIngressMultipleTLS(t *testing.T) {
 	require.Len(t, tls, 3)
 
 	assert.Equal(t, "app-tls", tls[0].ObjectValue()["secretName"].StringValue())
-	assert.Equal(t, []any{"app.example.com"},
+	assert.Equal(t, []string{"app.example.com"},
 		propArrayToStrings(tls[0].ObjectValue()["hosts"].ArrayValue()))
 
 	assert.Equal(t, "api-tls", tls[1].ObjectValue()["secretName"].StringValue())
-	assert.Equal(t, []any{"api.example.com", "api2.example.com"},
+	assert.Equal(t, []string{"api.example.com", "api2.example.com"},
 		propArrayToStrings(tls[1].ObjectValue()["hosts"].ArrayValue()))
 
 	assert.Equal(t, "data-tls", tls[2].ObjectValue()["secretName"].StringValue())
-	assert.Equal(t, []any{"*.data.example.com"},
+	assert.Equal(t, []string{"*.data.example.com"},
 		propArrayToStrings(tls[2].ObjectValue()["hosts"].ArrayValue()))
 }
 
-// propArrayToStrings converts a PropertyValue array of strings into []any.
-func propArrayToStrings(arr []resource.PropertyValue) []any {
-	out := make([]any, len(arr))
+func TestAzureClustersDeployTraefikIngressSingleTLS(t *testing.T) {
+	// A single tls_secrets entry must SUPPRESS the default wildcard entry:
+	// the ingress should carry exactly the one configured entry, not the
+	// [domain, *.domain] default.
+	mocks := &clustersMocks{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		params := minimalAzureClustersParams("myworkload", []string{"20250101"})
+		params.siteDomains = []string{"example.com"}
+		params.siteTLSSecrets = map[string][]types.SiteTLSSecret{
+			"example.com": {
+				{Hosts: []string{"app.example.com"}, SecretName: "app-tls"},
+			},
+		}
+		return azureClustersDeploy(ctx, nil, params)
+	}, pulumi.WithMocks("ptd-azure-workload-clusters", "myworkload", mocks))
+	require.NoError(t, err)
+
+	rel := findTraefikRelease(mocks.resources, "myworkload-20250101-traefik")
+	require.NotNil(t, rel, "traefik helm release not found")
+
+	ingress := findTraefikIngressExtraObject(rel, "myworkload", "20250101", "example.com")
+	require.NotNil(t, ingress, "traefik ingress extraObject not found")
+
+	tls := ingress["spec"].ObjectValue()["tls"].ArrayValue()
+	require.Len(t, tls, 1)
+	entry := tls[0].ObjectValue()
+	assert.Equal(t, "app-tls", entry["secretName"].StringValue())
+	assert.Equal(t, []string{"app.example.com"}, propArrayToStrings(entry["hosts"].ArrayValue()))
+	// Confirm the wildcard default is gone.
+	assert.NotEqual(t, "myworkload-example.com-tls", entry["secretName"].StringValue())
+}
+
+// propArrayToStrings converts a PropertyValue array of strings into []string.
+// StringValue panics on a non-string property, so a mistyped host fails loudly.
+func propArrayToStrings(arr []resource.PropertyValue) []string {
+	out := make([]string, len(arr))
 	for i, v := range arr {
 		out[i] = v.StringValue()
 	}

--- a/lib/steps/clusters_test.go
+++ b/lib/steps/clusters_test.go
@@ -445,6 +445,135 @@ func TestAzureClustersDeployTraefikReplicasOverride(t *testing.T) {
 	assert.Equal(t, 5.0, deployment["replicas"].NumberValue())
 }
 
+// --- Azure Traefik ingress TLS helper tests ---
+
+func TestTraefikIngressTLSEntriesDefault(t *testing.T) {
+	// Unset tls_secrets → single wildcard entry matching historical behavior.
+	entries := traefikIngressTLSEntries("myworkload", "example.com", nil)
+	require.Len(t, entries, 1)
+	assert.Equal(t, []string{"example.com", "*.example.com"}, entries[0].Hosts)
+	assert.Equal(t, "myworkload-example.com-tls", entries[0].SecretName)
+}
+
+func TestTraefikIngressTLSEntriesEmptySlice(t *testing.T) {
+	// An empty (non-nil) slice is treated the same as unset.
+	entries := traefikIngressTLSEntries("myworkload", "example.com", []types.SiteTLSSecret{})
+	require.Len(t, entries, 1)
+	assert.Equal(t, []string{"example.com", "*.example.com"}, entries[0].Hosts)
+	assert.Equal(t, "myworkload-example.com-tls", entries[0].SecretName)
+}
+
+func TestTraefikIngressTLSEntriesMultiple(t *testing.T) {
+	secrets := []types.SiteTLSSecret{
+		{Hosts: []string{"app.example.com"}, SecretName: "app-tls"},
+		{Hosts: []string{"api.example.com", "api2.example.com"}, SecretName: "api-tls"},
+		{Hosts: []string{"*.data.example.com"}, SecretName: "data-tls"},
+	}
+	entries := traefikIngressTLSEntries("myworkload", "example.com", secrets)
+	require.Len(t, entries, 3)
+
+	assert.Equal(t, []string{"app.example.com"}, entries[0].Hosts)
+	assert.Equal(t, "app-tls", entries[0].SecretName)
+
+	assert.Equal(t, []string{"api.example.com", "api2.example.com"}, entries[1].Hosts)
+	assert.Equal(t, "api-tls", entries[1].SecretName)
+
+	assert.Equal(t, []string{"*.data.example.com"}, entries[2].Hosts)
+	assert.Equal(t, "data-tls", entries[2].SecretName)
+}
+
+// findTraefikIngressExtraObject returns the Ingress extraObject (as a
+// PropertyMap) for the given site domain from a Traefik helm release, or nil.
+func findTraefikIngressExtraObject(rel *pulumi.MockResourceArgs, name, release, domain string) resource.PropertyMap {
+	extraObjects := rel.Inputs["values"].ObjectValue()["extraObjects"].ArrayValue()
+	want := fmt.Sprintf("%s-%s-%s", name, release, domain)
+	for _, obj := range extraObjects {
+		o := obj.ObjectValue()
+		kind, ok := o["kind"]
+		if !ok || kind.StringValue() != "Ingress" {
+			continue
+		}
+		if o["metadata"].ObjectValue()["name"].StringValue() == want {
+			return o
+		}
+	}
+	return nil
+}
+
+func TestAzureClustersDeployTraefikIngressDefaultTLS(t *testing.T) {
+	mocks := &clustersMocks{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		params := minimalAzureClustersParams("myworkload", []string{"20250101"})
+		params.siteDomains = []string{"example.com"}
+		return azureClustersDeploy(ctx, nil, params)
+	}, pulumi.WithMocks("ptd-azure-workload-clusters", "myworkload", mocks))
+	require.NoError(t, err)
+
+	rel := findTraefikRelease(mocks.resources, "myworkload-20250101-traefik")
+	require.NotNil(t, rel, "traefik helm release not found")
+
+	ingress := findTraefikIngressExtraObject(rel, "myworkload", "20250101", "example.com")
+	require.NotNil(t, ingress, "traefik ingress extraObject not found")
+
+	tls := ingress["spec"].ObjectValue()["tls"].ArrayValue()
+	require.Len(t, tls, 1)
+	entry := tls[0].ObjectValue()
+	hosts := entry["hosts"].ArrayValue()
+	require.Len(t, hosts, 2)
+	assert.Equal(t, "example.com", hosts[0].StringValue())
+	assert.Equal(t, "*.example.com", hosts[1].StringValue())
+	assert.Equal(t, "myworkload-example.com-tls", entry["secretName"].StringValue())
+}
+
+func TestAzureClustersDeployTraefikIngressMultipleTLS(t *testing.T) {
+	mocks := &clustersMocks{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		params := minimalAzureClustersParams("myworkload", []string{"20250101"})
+		params.siteDomains = []string{"example.com"}
+		params.siteTLSSecrets = map[string][]types.SiteTLSSecret{
+			"example.com": {
+				{Hosts: []string{"app.example.com"}, SecretName: "app-tls"},
+				{Hosts: []string{"api.example.com", "api2.example.com"}, SecretName: "api-tls"},
+				{Hosts: []string{"*.data.example.com"}, SecretName: "data-tls"},
+			},
+		}
+		return azureClustersDeploy(ctx, nil, params)
+	}, pulumi.WithMocks("ptd-azure-workload-clusters", "myworkload", mocks))
+	require.NoError(t, err)
+
+	rel := findTraefikRelease(mocks.resources, "myworkload-20250101-traefik")
+	require.NotNil(t, rel, "traefik helm release not found")
+
+	ingress := findTraefikIngressExtraObject(rel, "myworkload", "20250101", "example.com")
+	require.NotNil(t, ingress, "traefik ingress extraObject not found")
+
+	tls := ingress["spec"].ObjectValue()["tls"].ArrayValue()
+	require.Len(t, tls, 3)
+
+	assert.Equal(t, "app-tls", tls[0].ObjectValue()["secretName"].StringValue())
+	assert.Equal(t, []any{"app.example.com"},
+		propArrayToStrings(tls[0].ObjectValue()["hosts"].ArrayValue()))
+
+	assert.Equal(t, "api-tls", tls[1].ObjectValue()["secretName"].StringValue())
+	assert.Equal(t, []any{"api.example.com", "api2.example.com"},
+		propArrayToStrings(tls[1].ObjectValue()["hosts"].ArrayValue()))
+
+	assert.Equal(t, "data-tls", tls[2].ObjectValue()["secretName"].StringValue())
+	assert.Equal(t, []any{"*.data.example.com"},
+		propArrayToStrings(tls[2].ObjectValue()["hosts"].ArrayValue()))
+}
+
+// propArrayToStrings converts a PropertyValue array of strings into []any.
+func propArrayToStrings(arr []resource.PropertyValue) []any {
+	out := make([]any, len(arr))
+	for i, v := range arr {
+		out[i] = v.StringValue()
+	}
+	return out
+}
+
 func TestAzureClustersDeployTwoReleases(t *testing.T) {
 	mocks := &clustersMocks{}
 

--- a/lib/types/workload.go
+++ b/lib/types/workload.go
@@ -640,6 +640,20 @@ type SiteConfigSpec struct {
 	VpcAssociations              []string `json:"vpc_associations" yaml:"vpc_associations"`
 	AutoAssociateProvisionedVpc  *bool    `json:"auto_associate_provisioned_vpc" yaml:"auto_associate_provisioned_vpc"`
 	CertificateValidationEnabled *bool    `json:"certificate_validation_enabled" yaml:"certificate_validation_enabled"`
+	// TLSSecrets, when set, replaces the default single wildcard `tls` entry for
+	// this site's Azure Traefik ingress with one entry per listed secret. Each
+	// entry maps a set of hosts to a pre-existing Kubernetes TLS secret, letting
+	// the ingress terminate TLS with multiple certificates instead of the single
+	// wildcard secret. Ignored on AWS (which uses per-site CertificateARN). When
+	// unset, the default single wildcard entry is emitted unchanged.
+	TLSSecrets []SiteTLSSecret `json:"tls_secrets,omitempty" yaml:"tls_secrets,omitempty"`
+}
+
+// SiteTLSSecret maps a set of hostnames to a Kubernetes TLS secret for an
+// Azure Traefik ingress. See SiteConfigSpec.TLSSecrets.
+type SiteTLSSecret struct {
+	Hosts      []string `yaml:"hosts" json:"hosts"`
+	SecretName string   `yaml:"secret_name" json:"secret_name"`
 }
 
 var ValidOutboundTypes = map[string]bool{


### PR DESCRIPTION
# Description

Let an Azure workload's Traefik site ingress terminate TLS with multiple certificates (one Kubernetes TLS secret per hostname) instead of the single hardcoded wildcard secret it used before.

A new optional `tls_secrets` field on a site's spec lets operators map sets of hosts to pre-existing Kubernetes TLS secrets. This is the Azure/Traefik analogue of the existing AWS per-site multi-certificate behavior (per-site `certificate_arn` → comma-separated `alb.ingress.kubernetes.io/certificate-arn`).

Behavior:
For each entry in spec.tls, Traefik loads the explicitly named secretName (from the ingress's namespace) into its certificate store. At request time it then serves the right cert per connection by matching the client's SNI hostname against the loaded certs' SANs.

Example config:

```yaml
sites:
  main:
    spec:
      domain: example.com
      tls_secrets:
        - hosts: ["app.example.com"]
          secret_name: app-tls
        - hosts: ["api.example.com", "api2.example.com"]
          secret_name: api-tls
        - hosts: ["*.data.example.com"]
          secret_name: data-tls
```

When `tls_secrets` is unset, the rendered ingress `spec.tls` is byte-for-byte identical to before (single wildcard entry `[domain, *.domain]` → `{name}-{domain}-tls`), so existing workloads are unaffected.

## Code Flow

- `lib/types/workload.go`: `SiteConfigSpec` gains an optional `TLSSecrets []SiteTLSSecret` (`tls_secrets`, omitempty) plus the new `SiteTLSSecret{Hosts, SecretName}` type.
- `lib/steps/clusters_azure.go`: the per-site domain loop now also collects a `map[string][]types.SiteTLSSecret` keyed by domain into `azureClustersParams`. The Traefik ingress `extraObjects` render calls a new pure helper `traefikIngressTLSEntries(name, domain, tlsSecrets)` (unit-testable, returns typed entries) wrapped by `traefikIngressTLS(...)` which renders the `pulumi.Array`. Non-empty `tls_secrets` yields one entry per secret in config order; otherwise the historical single wildcard entry.
- AWS path is untouched (`SiteTLSSecret` is Azure-only; AWS continues to use `CertificateARN`).

## Category of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about

## Testing

- New unit tests for the pure helper: default (unset), empty slice, and three-entry cases.
- New Pulumi-mock integration tests asserting the rendered Traefik ingress `spec.tls`: default single wildcard entry, and three-secret multi-entry.
- `just test-lib` green; `just check-go` clean; `go build ./...` succeeds in both `lib/` and `cmd/`.