### PR TITLE
Bump the Go toolchain for lib and cmd to 1.26.5

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/posit-dev/ptd/cmd
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/posit-dev/ptd/lib => ../lib
 

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/posit-dev/ptd/lib
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0


### PR DESCRIPTION
Bumps the Go toolchain directive from `1.26.4` to `1.26.5` in `lib/go.mod` and `cmd/go.mod`.

This picks up upstream Go standard-library security fixes flagged by Snyk:
- **High** — `std/os` Symlink Attack
- **Medium** — `std/crypto/tls` Cleartext Transmission of Sensitive Information

Both are fixed in Go 1.26.5. CI derives its Go version from these `go.mod` files via `go-version-file`, so release builds will compile against the patched stdlib. No `go.sum` changes are required for a directive-only bump.