### PR TITLE
fix(clusters): pin helm-controller klipper-helm job image

### DIFF
--- a/lib/steps/clusters_aws.go
+++ b/lib/steps/clusters_aws.go
@@ -705,7 +705,7 @@ func awsClustersDeploy(ctx *pulumi.Context, _ types.Target, params awsClustersPa
 									pulumi.String("--namespace"),
 									pulumi.String(clustersHelmControllerNamespace),
 									pulumi.String("--default-job-image"),
-									pulumi.String("ghcr.io/k3s-io/klipper-helm:latest"),
+									pulumi.String("ghcr.io/k3s-io/klipper-helm:v0.9.5-build20250306"),
 								},
 							},
 						},

--- a/lib/steps/clusters_azure.go
+++ b/lib/steps/clusters_azure.go
@@ -436,7 +436,7 @@ func azureClustersDeploy(ctx *pulumi.Context, _ types.Target, params azureCluste
 									pulumi.String("--namespace"),
 									pulumi.String(clustersHelmControllerNamespace),
 									pulumi.String("--default-job-image"),
-									pulumi.String("ghcr.io/k3s-io/klipper-helm:latest"),
+									pulumi.String("ghcr.io/k3s-io/klipper-helm:v0.9.5-build20250306"),
 								},
 							},
 						},


### PR DESCRIPTION
# Description

helm-controller (deployed by the `clusters` step) was configured with `--default-job-image ghcr.io/k3s-io/klipper-helm:latest`. The unpinned `latest` tag has drifted to a klipper-helm build whose install/upgrade detection is broken: it misparses the existing-release lookup, fails to recognize an already-deployed release, and runs `helm install` instead of `helm upgrade`, failing with `cannot reuse a name that is still in use`. Because the `helm-install-<chart>` Job retries with a high backoff limit, this silently blocks every `helm.cattle.io/v1:HelmChart`-managed chart upgrade (e.g. Traefik). The running chart is unaffected (the job fails at helm's name check before mutating anything), so it can go unnoticed until a chart values change never actually takes effect.

## Code Flow

The helm-controller Deployment is created inline in the `clusters` step for both clouds:
- `lib/steps/clusters_aws.go` (AWS)
- `lib/steps/clusters_azure.go` (Azure)

Its `--default-job-image` arg is the image the controller uses for the `helm-install-<chart>` Jobs it spawns to reconcile `HelmChart` CRs. Pinning it to `v0.9.5-build20250306` (the `DefaultJobImage` constant shipped with helm-controller `v0.16.10`, the version this step already pins) makes the controller run the klipper-helm build it was tested against, restoring correct upgrade behavior.

Note for rollout: re-applying the `clusters` step updates the Deployment arg, but the controller does not rewrite already-created Jobs, any existing failed `helm-install-*` Job must be deleted so the controller respawns it on the pinned image.

Validated on a staging environment: after this change the controller ran a proper `helm upgrade` and the previously-stuck Traefik chart upgraded cleanly.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
