### PR TITLE
chore: bump default team operator chart version to v1.29.1

### DIFF
--- a/lib/steps/clusters.go
+++ b/lib/steps/clusters.go
@@ -17,7 +17,7 @@ const (
 	// clustersTeamOperatorServiceAccount is the Helm chart default service account name.
 	clustersTeamOperatorServiceAccount = "team-operator-controller-manager"
 	// clustersDefaultTeamOperatorChartVersion is used when no chart version is configured.
-	clustersDefaultTeamOperatorChartVersion = "v1.29.0"
+	clustersDefaultTeamOperatorChartVersion = "v1.29.1"
 	// clustersTraefikForwardAuthSA matches the Python Roles.TRAEFIK_FORWARD_AUTH value.
 	clustersTraefikForwardAuthSA = "traefik-forward-auth.posit.team"
 


### PR DESCRIPTION
Bumps `clustersDefaultTeamOperatorChartVersion` from `v1.29.0` to `v1.29.1`.

This updates the default Team Operator Helm chart version used when no chart version is configured for a cluster.

Defined in `lib/steps/clusters.go`.