### PR TITLE
fix(azure): poll for bastion tunnel port instead of one-shot check

### DIFF
--- a/lib/azure/proxy.go
+++ b/lib/azure/proxy.go
@@ -180,9 +180,21 @@ func (p *ProxySession) Start(ctx context.Context) error {
 		return err
 	}
 
-	// wait for the tunnel to be established
-	time.Sleep(3 * time.Second)
-	if !helpers.PortOpen("localhost", "22001") {
+	// wait for the tunnel to be established. `az network bastion tunnel` reliably
+	// takes a few seconds to bind port 22001, so poll rather than doing a single
+	// one-shot check (which fires too early and kills a tunnel that would have
+	// come up).
+	tunnelOpen := false
+	for i := 0; i < 10; i++ {
+		if helpers.PortOpen("localhost", "22001") {
+			slog.Debug("Tunnel port open", "tunnel_port", "22001")
+			tunnelOpen = true
+			break
+		}
+		slog.Debug("Waiting for tunnel port open", "attempt", i+1, "tunnel_port", "22001")
+		time.Sleep(1 * time.Second)
+	}
+	if !tunnelOpen {
 		slog.Error("Tunnel is not listening on port 22001")
 		if killErr := helpers.KillProcess(p.tunnelCommand.Process.Pid); killErr != nil {
 			slog.Warn("Error killing orphaned tunnel command", "pid", p.tunnelCommand.Process.Pid, "error", killErr)


### PR DESCRIPTION
# Description

`ptd workon` against Azure targets was intermittently failing to bring up the bastion tunnel, dropping the user into a proxy-less shell where `kubectl` could not reach the cluster. The failure surfaced as:

```
tunnel session did not start successfully on port 22001
```

## Issue

Intermittent Azure bastion tunnel startup failures during `ptd workon`.

## Code Flow

`ProxySession.Start` launches `az network bastion tunnel` and then must confirm the tunnel is listening on local port 22001 before wiring up the SOCKS proxy and handing back a working shell.

The previous implementation slept a fixed 3s and then checked port 22001 exactly once. `az network bastion tunnel` reliably takes ~3s to bind the port, so the single check raced the bind and could fail by ~1s. On that miss the code killed the tunnel process, even though it was about to come up — leaving the resulting shell with no working proxy.

The fix replaces the one-shot check with a poll loop that checks the port once per second (up to a 10s budget), succeeding as soon as the port opens. This mirrors the existing `RunningProxy.WaitForPortOpen` pattern already used for the SOCKS port, and logs each attempt at debug level.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about

## Verification

- Rebuilt the CLI with `just cli`.
- Ran `ptd workon argenx01-production -- kubectl get nodes` successfully — the tunnel came up and kubectl reached the cluster.
- Debug logging confirmed the poll loop catching the tunnel after a few attempts rather than failing on the first check.
