### PR TITLE
fix(azure): external-dns extraArgs must be a list, not a map

### DIFF
--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -510,8 +510,8 @@ func azureHelmExternalDNS(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, com
 		v := map[string]interface{}{
 			"provider":      "azure",
 			"domainFilters": domainFilters,
-			"extraArgs": map[string]interface{}{
-				"txt-wildcard-replacement": "wildcard",
+			"extraArgs": []interface{}{
+				"--txt-wildcard-replacement=wildcard",
 			},
 			"extraVolumes": []interface{}{
 				map[string]interface{}{


### PR DESCRIPTION
# Description

The ExternalDNS Helm install fails on the kubernetes-sigs external-dns chart (v1.14.4) with:

> `Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s)... - extraArgs: Invalid type. Expected: array, given: object`

In `lib/steps/helm_azure.go` (`azureHelmExternalDNS`), `extraArgs` was set as a **map**:

```go
"extraArgs": map[string]interface{}{
    "txt-wildcard-replacement": "wildcard",
},
```

The kubernetes-sigs external-dns chart expects `extraArgs` to be an **array of raw flag strings** (the chart does `range .Values.extraArgs` and appends each item to the container args). The map form fails the chart's `values.schema.json` and, even without the strict schema, would have rendered the bare value (`wildcard`) instead of the flag.

## Code Flow

`azureHelmExternalDNS` builds the external-dns Helm values map that is marshalled to YAML and applied via a `HelmChart` custom resource. This change switches `extraArgs` to the list form, passing the full flag string `--txt-wildcard-replacement=wildcard` — matching the convention already used in the AWS path (`lib/steps/clusters_aws.go`, which passes `--aws-zone-match-parent` as a list item). This is the only place the Azure external-dns values are built.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Version upgrade (upgrading the version of a service or product)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about