### PR TITLE
feat: direct Connect content pods to Karpenter session node pool

### DIFF
--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -288,6 +288,19 @@ func buildAWSSiteSpec(
 		}
 	}
 
+	// Karpenter content placement: allow and direct Connect content pods onto the session node pool.
+	if tolerations := sessionTolerations(clusterCfg.KarpenterConfig); len(tolerations) > 0 {
+		connectSpec := map[string]interface{}{
+			"contentTolerations": tolerations,
+		}
+		if pool := sessionPoolName(clusterCfg.KarpenterConfig); pool != "" {
+			connectSpec["contentNodeSelector"] = map[string]string{
+				"karpenter.sh/nodepool": pool,
+			}
+		}
+		spec["connect"] = connectSpec
+	}
+
 	return spec
 }
 
@@ -311,6 +324,21 @@ func sessionTolerations(kc *types.KarpenterConfig) []map[string]interface{} {
 		}
 	}
 	return nil
+}
+
+// sessionPoolName returns the Name of the first node pool that has
+// session_taints=true, or an empty string if none. This mirrors the
+// selection logic in sessionTolerations.
+func sessionPoolName(kc *types.KarpenterConfig) string {
+	if kc == nil {
+		return ""
+	}
+	for _, pool := range kc.NodePools {
+		if pool.SessionTaints {
+			return pool.Name
+		}
+	}
+	return ""
 }
 
 // --- Azure ---

--- a/lib/steps/sites.go
+++ b/lib/steps/sites.go
@@ -281,15 +281,12 @@ func buildAWSSiteSpec(
 		}
 	}
 
-	// Karpenter session tolerations.
+	// Karpenter session placement: allow and direct both Workbench session pods and
+	// Connect content pods onto the session node pool.
 	if tolerations := sessionTolerations(clusterCfg.KarpenterConfig); len(tolerations) > 0 {
 		spec["workbench"] = map[string]interface{}{
 			"sessionTolerations": tolerations,
 		}
-	}
-
-	// Karpenter content placement: allow and direct Connect content pods onto the session node pool.
-	if tolerations := sessionTolerations(clusterCfg.KarpenterConfig); len(tolerations) > 0 {
 		connectSpec := map[string]interface{}{
 			"contentTolerations": tolerations,
 		}

--- a/lib/steps/sites_test.go
+++ b/lib/steps/sites_test.go
@@ -232,7 +232,7 @@ func TestBuildAWSSiteSpecSessionTolerations(t *testing.T) {
 
 	clusterCfg := types.AWSWorkloadClusterSpec{
 		KarpenterConfig: &types.KarpenterConfig{
-			NodePools: []types.KarpenterNodePool{{SessionTaints: true}},
+			NodePools: []types.KarpenterNodePool{{Name: "session-pool", SessionTaints: true}},
 		},
 	}
 	spec := buildAWSSiteSpec(params, "arn:aws:secretsmanager:us-east-1:123456789012:secret:db", "20250101", "main", types.SiteConfigSpec{Domain: "d.example.com"}, clusterCfg)
@@ -244,6 +244,34 @@ func TestBuildAWSSiteSpecSessionTolerations(t *testing.T) {
 	assert.Equal(t, "Equal", tolerations[0]["operator"])
 	assert.Equal(t, "session", tolerations[0]["value"])
 	assert.Equal(t, "NoSchedule", tolerations[0]["effect"])
+
+	// Connect content pods receive the same toleration plus a nodeSelector
+	// onto the session node pool.
+	connect := spec["connect"].(map[string]interface{})
+	contentTolerations := connect["contentTolerations"].([]map[string]interface{})
+	require.Len(t, contentTolerations, 1)
+	assert.Equal(t, "workload-type", contentTolerations[0]["key"])
+	assert.Equal(t, "Equal", contentTolerations[0]["operator"])
+	assert.Equal(t, "session", contentTolerations[0]["value"])
+	assert.Equal(t, "NoSchedule", contentTolerations[0]["effect"])
+	nodeSelector := connect["contentNodeSelector"].(map[string]string)
+	assert.Equal(t, "session-pool", nodeSelector["karpenter.sh/nodepool"])
+}
+
+func TestBuildAWSSiteSpecNoConnectWithoutSessionTaints(t *testing.T) {
+	params := minimalAWSSiteParams("myworkload", []string{"20250101"}, []string{"main"})
+
+	clusterCfg := types.AWSWorkloadClusterSpec{
+		KarpenterConfig: &types.KarpenterConfig{
+			NodePools: []types.KarpenterNodePool{{Name: "general", SessionTaints: false}},
+		},
+	}
+	spec := buildAWSSiteSpec(params, "arn:aws:secretsmanager:us-east-1:123456789012:secret:db", "20250101", "main", types.SiteConfigSpec{Domain: "d.example.com"}, clusterCfg)
+
+	_, hasWorkbench := spec["workbench"]
+	assert.False(t, hasWorkbench, "workbench should not be set without session taints")
+	_, hasConnect := spec["connect"]
+	assert.False(t, hasConnect, "connect should not be set without session taints")
 }
 
 // --- sessionTolerations unit tests ---
@@ -286,6 +314,36 @@ func TestSessionTolerations(t *testing.T) {
 		}
 		tols := sessionTolerations(kc)
 		require.Len(t, tols, 1)
+	})
+}
+
+// --- sessionPoolName unit tests ---
+
+func TestSessionPoolName(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		assert.Equal(t, "", sessionPoolName(nil))
+	})
+
+	t.Run("no session taints", func(t *testing.T) {
+		kc := &types.KarpenterConfig{
+			NodePools: []types.KarpenterNodePool{{Name: "general", SessionTaints: false}},
+		}
+		assert.Equal(t, "", sessionPoolName(kc))
+	})
+
+	t.Run("returns name of first session-tainted pool", func(t *testing.T) {
+		kc := &types.KarpenterConfig{
+			NodePools: []types.KarpenterNodePool{
+				{Name: "general", SessionTaints: false},
+				{Name: "session-pool", SessionTaints: true},
+			},
+		}
+		assert.Equal(t, "session-pool", sessionPoolName(kc))
+	})
+
+	t.Run("empty node pools", func(t *testing.T) {
+		kc := &types.KarpenterConfig{NodePools: []types.KarpenterNodePool{}}
+		assert.Equal(t, "", sessionPoolName(kc))
 	})
 }
 


### PR DESCRIPTION
## Summary

Extends the existing Workbench session-pod placement capability to Posit Connect content pods.

Today PTD writes `spec.workbench.sessionTolerations` into the Site CR so Workbench session pods can schedule onto Karpenter session-tainted nodes. This PR adds a parallel `spec.connect` block so Connect content pods are both:

- **permitted onto** the session node pool via `contentTolerations` (the same `workload-type=session:NoSchedule` toleration used for Workbench), and
- **directed to** the session node pool via `contentNodeSelector` (`karpenter.sh/nodepool: <session pool name>`).

The node pool name is resolved at runtime from config (the first Karpenter node pool with `session_taints=true`); nothing is hardcoded. This is AWS-only, in `buildAWSSiteSpec`, which is correct since session taints are a Karpenter/AWS feature.

Pairs with a team-operator change adding `contentTolerations` and `contentNodeSelector` fields to the Connect site spec; the JSON key names here match those CRD tags exactly.

## Changes

- `lib/steps/sites.go`: new `sessionPoolName` helper (mirrors `sessionTolerations`); `buildAWSSiteSpec` now emits `spec.connect.contentTolerations` / `contentNodeSelector` when a session-tainted pool exists.
- `lib/steps/sites_test.go`: unit tests for `sessionPoolName` and for the new connect block (present with session taints, absent without).

## Testing

`just test-lib` passes.


---

**Companion PR:** posit-dev/team-operator#150 — adds the `contentTolerations` / `contentNodeSelector` CRD fields this PR populates. These two PRs go together; merge team-operator#150 first.
