### PR TITLE
fix(eject): correct IRSA/OIDC note in disaster-recovery runbook

### DIFF
--- a/lib/eject/runbooks.go
+++ b/lib/eject/runbooks.go
@@ -408,7 +408,7 @@ ptd ensure {{.WorkloadName}} --only-steps helm --refresh
 ptd ensure {{.WorkloadName}} --only-steps sites --refresh
 ` + "```" + `
 
-A rebuilt cluster has a new OIDC issuer. {{if eq .Cloud "aws"}}The workload IRSA roles now live in the ` + "`eks`" + ` step and build their trust policy from the cluster OIDC provider, so ` + "`eks --refresh`" + ` above re-establishes IRSA trust against the new issuer.{{else}}Workload identity federation is established by the ` + "`clusters`" + ` and ` + "`helm`" + ` steps above, which bind the federated credentials to the new issuer.{{end}} No separate final pass is needed (the former ` + "`persistent_reprise`" + ` step was removed).
+A rebuilt cluster has a new OIDC issuer. {{if eq .Cloud "aws"}}The workload IRSA roles are created by both the ` + "`eks`" + ` step (platform components) and the ` + "`clusters`" + ` step (Team Operator, Chronicle, and the Posit product roles), each building its trust policy from the cluster OIDC provider — so the ` + "`eks --refresh`" + ` and ` + "`clusters --refresh`" + ` runs above re-establish IRSA trust against the new issuer.{{else}}Workload identity federation is established by the ` + "`clusters`" + ` and ` + "`helm`" + ` steps above, which bind the federated credentials to the new issuer.{{end}} No separate final pass is needed (the former ` + "`persistent_reprise`" + ` step was removed).
 
 ### Partial Failure (Node Groups)
 


### PR DESCRIPTION
# Description

The AWS disaster-recovery runbook produced by `ptd eject` claimed that workload
IRSA roles live only in the `eks` step, and that `eks --refresh` alone
re-establishes IRSA trust after a cluster rebuild (which yields a new OIDC
issuer). That is inaccurate: IRSA roles are created in **two** steps —

- `eks` — platform components (Alloy, the EBS/FSx CSI drivers, the load-balancer
  controller, external-dns, Loki, Mimir, Traefik forward-auth), and
- `clusters` — application roles (Team Operator, Chronicle, and the per-site
  product roles)

— each building its trust policy from the cluster OIDC provider. Both
`eks --refresh` and `clusters --refresh` already appear in the runbook's
cluster-loss recovery sequence; this only corrects the accompanying note so both
are credited with rebuilding IRSA trust against the new issuer.

Documentation-only wording fix in the runbook template; no recovery step or
ordering changes.

## Category of change

- [x] Documentation: documentation changes

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
