### PR TITLE
fix(helm): gate Alloy mimir-auth secret and mount on control room

### DIFF
--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -99,9 +99,8 @@ func (s *HelmStep) runAWSInlineGo(ctx context.Context, creds types.Credentials, 
 		}
 	}
 
-	// Fetch mimir password from workload secrets. It feeds only the alloy mimir-auth Secret,
-	// which is created only when the workload has a control room to authenticate against — so
-	// skip the secret-store call (and its warning log) entirely when there is no control room.
+	// Fetch mimir password from workload secrets. Only used for the alloy mimir-auth Secret,
+	// which is created only when the workload has a control room.
 	mimirPassword := ""
 	if len(cfg.Clusters) > 0 && cfg.ControlRoomDomain != "" {
 		secretName := s.DstTarget.Name() + ".posit.team"
@@ -1189,10 +1188,6 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 	}
 	alloyConfigStr := buildAlloyConfig(alloyParams)
 
-	// The mimir-auth Secret and its volume/mount only exist to feed the control-room
-	// remote_write block in the Alloy config. buildAlloyConfig omits that block when there
-	// is no control room, so gate the credential on the same condition to avoid mounting an
-	// orphaned control-room credential in the Alloy pod.
 	hasControlRoom := params.cfg.ControlRoomDomain != ""
 
 	// ConfigMap
@@ -1217,8 +1212,6 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 		return err
 	}
 
-	// Mimir auth Secret (parent was the namespace in Python). Only created when the workload
-	// has a control room to authenticate against.
 	if hasControlRoom {
 		secretResourceName := compoundName + "-" + release + "-alloy-mimir-auth"
 		_, err = corev1.NewSecret(ctx, secretResourceName, &corev1.SecretArgs{
@@ -1250,10 +1243,6 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 	alloyRoleName := "alloy." + compoundName + ".posit.team"
 	thirdParty := isThirdPartyTelemetryEnabled(params.cfg.ThirdPartyTelemetryEnabled)
 
-	// The mimir-auth volume/mount feed the control-room remote_write and only exist when the
-	// workload has a control room. varlog is always present; the mimir-auth mount is added only
-	// when hasControlRoom, and the controller key (whose sole purpose is to carry the mimir-auth
-	// volume) is attached only then.
 	mounts := map[string]interface{}{
 		"varlog": params.cfg.GrafanaScrapeSystemLogs,
 	}

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -99,10 +99,11 @@ func (s *HelmStep) runAWSInlineGo(ctx context.Context, creds types.Credentials, 
 		}
 	}
 
-	// Fetch mimir password from workload secrets. Alloy is always deployed (its version always
-	// resolves to a non-empty default), so we always need this secret.
+	// Fetch mimir password from workload secrets. It feeds only the alloy mimir-auth Secret,
+	// which is created only when the workload has a control room to authenticate against — so
+	// skip the secret-store call (and its warning log) entirely when there is no control room.
 	mimirPassword := ""
-	if len(cfg.Clusters) > 0 {
+	if len(cfg.Clusters) > 0 && cfg.ControlRoomDomain != "" {
 		secretName := s.DstTarget.Name() + ".posit.team"
 		secretJSON, err := s.DstTarget.SecretStore().GetSecretValue(ctx, creds, secretName)
 		if err != nil {

--- a/lib/steps/helm_aws.go
+++ b/lib/steps/helm_aws.go
@@ -1188,6 +1188,12 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 	}
 	alloyConfigStr := buildAlloyConfig(alloyParams)
 
+	// The mimir-auth Secret and its volume/mount only exist to feed the control-room
+	// remote_write block in the Alloy config. buildAlloyConfig omits that block when there
+	// is no control room, so gate the credential on the same condition to avoid mounting an
+	// orphaned control-room credential in the Alloy pod.
+	hasControlRoom := params.cfg.ControlRoomDomain != ""
+
 	// ConfigMap
 	configMapName := compoundName + "-" + release + "-alloy-config"
 	cmResourceName := configMapName + "-configmap"
@@ -1210,35 +1216,51 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 		return err
 	}
 
-	// Mimir auth Secret (parent was the namespace in Python)
-	secretResourceName := compoundName + "-" + release + "-alloy-mimir-auth"
-	_, err = corev1.NewSecret(ctx, secretResourceName, &corev1.SecretArgs{
-		Metadata: metav1.ObjectMetaArgs{
-			Name:      pulumi.String("mimir-auth"),
-			Namespace: pulumi.String(helmAlloyNamespace),
-			Labels:    pulumi.StringMap{"posit.team/managed-by": pulumi.String("ptd.pulumi_resources.aws_workload_helm")},
-		},
-		StringData: pulumi.StringMap{
-			"password": pulumi.String(params.mimirPassword),
-		},
-	}, k8sOpt,
-		// In Python: opts=ResourceOptions(parent=namespace, ...) — so URN path includes Namespace.
-		// Two variants: with and without ptd:AWSWorkloadHelm$ prefix depending on Python state vintage.
-		pulumi.Aliases([]pulumi.Alias{
-			{URN: pulumi.URN(fmt.Sprintf(
-				"urn:pulumi:%s::ptd-aws-workload-helm::ptd:AWSWorkloadHelm$kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
-				ctx.Stack(), secretResourceName))},
-			{URN: pulumi.URN(fmt.Sprintf(
-				"urn:pulumi:%s::ptd-aws-workload-helm::kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
-				ctx.Stack(), secretResourceName))},
-		}),
-		pulumi.DependsOn([]pulumi.Resource{ns}))
-	if err != nil {
-		return err
+	// Mimir auth Secret (parent was the namespace in Python). Only created when the workload
+	// has a control room to authenticate against.
+	if hasControlRoom {
+		secretResourceName := compoundName + "-" + release + "-alloy-mimir-auth"
+		_, err = corev1.NewSecret(ctx, secretResourceName, &corev1.SecretArgs{
+			Metadata: metav1.ObjectMetaArgs{
+				Name:      pulumi.String("mimir-auth"),
+				Namespace: pulumi.String(helmAlloyNamespace),
+				Labels:    pulumi.StringMap{"posit.team/managed-by": pulumi.String("ptd.pulumi_resources.aws_workload_helm")},
+			},
+			StringData: pulumi.StringMap{
+				"password": pulumi.String(params.mimirPassword),
+			},
+		}, k8sOpt,
+			// In Python: opts=ResourceOptions(parent=namespace, ...) — so URN path includes Namespace.
+			// Two variants: with and without ptd:AWSWorkloadHelm$ prefix depending on Python state vintage.
+			pulumi.Aliases([]pulumi.Alias{
+				{URN: pulumi.URN(fmt.Sprintf(
+					"urn:pulumi:%s::ptd-aws-workload-helm::ptd:AWSWorkloadHelm$kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
+					ctx.Stack(), secretResourceName))},
+				{URN: pulumi.URN(fmt.Sprintf(
+					"urn:pulumi:%s::ptd-aws-workload-helm::kubernetes:core/v1:Namespace$kubernetes:core/v1:Secret::%s",
+					ctx.Stack(), secretResourceName))},
+			}),
+			pulumi.DependsOn([]pulumi.Resource{ns}))
+		if err != nil {
+			return err
+		}
 	}
 
 	alloyRoleName := "alloy." + compoundName + ".posit.team"
 	thirdParty := isThirdPartyTelemetryEnabled(params.cfg.ThirdPartyTelemetryEnabled)
+
+	// The mimir-auth volume/mount feed the control-room remote_write and only exist when the
+	// workload has a control room. varlog is always present; the mimir-auth mount is added only
+	// when hasControlRoom, and the controller key (whose sole purpose is to carry the mimir-auth
+	// volume) is attached only then.
+	mounts := map[string]interface{}{
+		"varlog": params.cfg.GrafanaScrapeSystemLogs,
+	}
+	if hasControlRoom {
+		mounts["extra"] = []interface{}{
+			map[string]interface{}{"name": "mimir-auth", "mountPath": "/etc/mimir/", "readOnly": true},
+		}
+	}
 
 	alloyValues := map[string]interface{}{
 		"serviceAccount": map[string]interface{}{
@@ -1248,32 +1270,12 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 				"eks.amazonaws.com/role-arn": fmt.Sprintf("arn:aws:iam::%s:role/%s", params.accountID, alloyRoleName),
 			},
 		},
-		"controller": map[string]interface{}{
-			"volumes": map[string]interface{}{
-				"extra": []interface{}{
-					map[string]interface{}{
-						"name": "mimir-auth",
-						"secret": map[string]interface{}{
-							"secretName": "mimir-auth",
-							"items": []interface{}{
-								map[string]interface{}{"key": "password", "path": "password"},
-							},
-						},
-					},
-				},
-			},
-		},
 		"alloy": map[string]interface{}{
 			"clustering": map[string]interface{}{"enabled": true},
 			"extraPorts": []interface{}{
 				map[string]interface{}{"name": "faro", "port": 12347, "targetPort": 12347, "protocol": "TCP"},
 			},
-			"mounts": map[string]interface{}{
-				"extra": []interface{}{
-					map[string]interface{}{"name": "mimir-auth", "mountPath": "/etc/mimir/", "readOnly": true},
-				},
-				"varlog": params.cfg.GrafanaScrapeSystemLogs,
-			},
+			"mounts": mounts,
 			"securityContext": map[string]interface{}{
 				"privileged": params.cfg.GrafanaScrapeSystemLogs,
 				"runAsUser":  nil,
@@ -1292,6 +1294,23 @@ func awsHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundNam
 		"tolerations": []interface{}{
 			map[string]interface{}{"key": "workload-type", "operator": "Equal", "value": "session", "effect": "NoSchedule"},
 		},
+	}
+	if hasControlRoom {
+		alloyValues["controller"] = map[string]interface{}{
+			"volumes": map[string]interface{}{
+				"extra": []interface{}{
+					map[string]interface{}{
+						"name": "mimir-auth",
+						"secret": map[string]interface{}{
+							"secretName": "mimir-auth",
+							"items": []interface{}{
+								map[string]interface{}{"key": "password", "path": "password"},
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 	if !thirdParty {
 		alloyValues["alloy"].(map[string]interface{})["reporting"] = map[string]interface{}{"enabled": false}

--- a/lib/steps/helm_aws_test.go
+++ b/lib/steps/helm_aws_test.go
@@ -97,6 +97,84 @@ func TestAwsHelmTraefikHA(t *testing.T) {
 	assert.Equal(t, "traefik-critical", values["priorityClassName"])
 }
 
+// runAwsHelmAlloy invokes awsHelmAlloy in isolation with no-op providers/aliases.
+func runAwsHelmAlloy(t *testing.T, controlRoomDomain string) *helmAWSMocks {
+	t.Helper()
+	mocks := &helmAWSMocks{}
+	noopOpt := pulumi.Aliases(nil)
+	withAlias := func(string, string) pulumi.ResourceOption { return pulumi.Aliases(nil) }
+	withNestedAlias := func(string, string, string) pulumi.ResourceOption { return pulumi.Aliases(nil) }
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		params := awsHelmParams{
+			compoundName:  "wl01-staging",
+			trueName:      "wl01",
+			environment:   "staging",
+			accountID:     "123456789012",
+			region:        "us-east-1",
+			mimirPassword: "s3cr3t",
+			cfg: types.AWSWorkloadConfig{
+				ControlRoomDomain: controlRoomDomain,
+			},
+		}
+		resolved := types.ResolvedAWSComponents{AlloyVersion: "0.12.6"}
+		return awsHelmAlloy(ctx, noopOpt, "wl01-staging", "20250101", params, resolved,
+			types.AWSWorkloadClusterSpec{}, withAlias, withNestedAlias)
+	}, pulumi.WithMocks("ptd-aws-workload-helm", "wl01-staging", mocks))
+	require.NoError(t, err)
+	return mocks
+}
+
+// alloyChartValues unmarshals the Alloy HelmChart CR's valuesContent for inspection.
+func alloyChartValues(t *testing.T, mocks *helmAWSMocks) map[string]interface{} {
+	t.Helper()
+	chart := mocks.find("wl01-staging-20250101-grafana-alloy-release")
+	require.NotNil(t, chart, "alloy HelmChart CR not created")
+	valuesContent := chart.Inputs["spec"].ObjectValue()["valuesContent"].StringValue()
+	var values map[string]interface{}
+	require.NoError(t, yamlv2.Unmarshal([]byte(valuesContent), &values))
+	return values
+}
+
+func TestAwsHelmAlloyWithControlRoom(t *testing.T) {
+	mocks := runAwsHelmAlloy(t, "ctrl.example.posit.team")
+
+	// The mimir-auth Secret is created when the workload has a control room.
+	secret := mocks.find("wl01-staging-20250101-alloy-mimir-auth")
+	require.NotNil(t, secret, "mimir-auth Secret should be created when a control room is configured")
+
+	values := alloyChartValues(t, mocks)
+
+	// The controller carries the mimir-auth volume.
+	controller, ok := values["controller"].(map[interface{}]interface{})
+	require.True(t, ok, "controller key should be present when a control room is configured")
+	volumes := controller["volumes"].(map[interface{}]interface{})
+	require.Contains(t, volumes, "extra")
+
+	// The alloy mounts include the mimir-auth mount.
+	mounts := values["alloy"].(map[interface{}]interface{})["mounts"].(map[interface{}]interface{})
+	require.Contains(t, mounts, "extra", "mimir-auth mount should be present when a control room is configured")
+	require.Contains(t, mounts, "varlog")
+}
+
+func TestAwsHelmAlloyWithoutControlRoom(t *testing.T) {
+	mocks := runAwsHelmAlloy(t, "")
+
+	// The mimir-auth Secret is NOT created when there is no control room.
+	secret := mocks.find("wl01-staging-20250101-alloy-mimir-auth")
+	require.Nil(t, secret, "mimir-auth Secret should be omitted when there is no control room")
+
+	values := alloyChartValues(t, mocks)
+
+	// The controller key (which only carries the mimir-auth volume on AWS) is omitted entirely.
+	_, hasController := values["controller"]
+	require.False(t, hasController, "controller key should be omitted when there is no control room")
+
+	// varlog is still present but the mimir-auth mount is gone.
+	mounts := values["alloy"].(map[interface{}]interface{})["mounts"].(map[interface{}]interface{})
+	require.NotContains(t, mounts, "extra", "mimir-auth mount should be omitted when there is no control room")
+	require.Contains(t, mounts, "varlog")
+}
+
 func TestAwsHelmTraefikReplicasOverride(t *testing.T) {
 	mocks := runAwsHelmTraefik(t, 5)
 

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -116,9 +116,8 @@ func (s *HelmStep) runAzureInlineGo(ctx context.Context, creds types.Credentials
 	}
 	storageAccountName := "stptd" + sanitizedStorageName
 
-	// Fetch mimir auth password from Key Vault. It feeds only the alloy mimir-auth Secret, which
-	// is created only when the workload has a control room to authenticate against — so skip the
-	// Key Vault call (and its warning log) entirely when there is no control room.
+	// Fetch mimir auth password from Key Vault. Only used for the alloy mimir-auth Secret,
+	// which is created only when the workload has a control room.
 	mimirPassword := ""
 	if cfg.ControlRoomDomain != "" {
 		mimirSecretName := s.DstTarget.Name() + "-mimir-auth"
@@ -974,10 +973,6 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	}
 	alloyConfigStr := buildAlloyConfig(alloyP)
 
-	// The mimir-auth Secret and its volume/mount only exist to feed the control-room
-	// remote_write block in the Alloy config. buildAlloyConfig omits that block when there
-	// is no control room, so gate the credential on the same condition to avoid mounting an
-	// orphaned control-room credential in the Alloy pod.
 	hasControlRoom := params.cfg.ControlRoomDomain != ""
 
 	// ConfigMap for Alloy. Python named the AlloyConfig component "alloy-config" and the ConfigMap
@@ -998,7 +993,6 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	}
 
 	// Mimir auth Secret (Azure uses base64-encoded data field unlike AWS which uses stringData).
-	// Only created when the workload has a control room to authenticate against.
 	if hasControlRoom {
 		mimirAuthB64 := base64.StdEncoding.EncodeToString([]byte(params.mimirPassword))
 		mimirSecretResourceName := compoundName + "-" + release + "-mimir-auth"
@@ -1022,7 +1016,6 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	chartResourceName := compoundName + "-" + release + "-grafana-alloy-release"
 
 	valuesYAML := identity.ClientId.ApplyT(func(clientID string) (string, error) {
-		// varlog is always present; the mimir-auth mount only exists when there is a control room.
 		mounts := map[string]interface{}{
 			"varlog": true,
 		}
@@ -1057,8 +1050,6 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 			alloyInner["reporting"] = map[string]interface{}{"enabled": false}
 		}
 
-		// The controller always carries the workload-identity podLabels; the mimir-auth volume
-		// is attached only when the workload has a control room.
 		controller := map[string]interface{}{
 			"podLabels": map[string]interface{}{
 				"azure.workload.identity/use": "true",

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -116,13 +116,17 @@ func (s *HelmStep) runAzureInlineGo(ctx context.Context, creds types.Credentials
 	}
 	storageAccountName := "stptd" + sanitizedStorageName
 
-	// Fetch mimir auth password from Key Vault.
+	// Fetch mimir auth password from Key Vault. It feeds only the alloy mimir-auth Secret, which
+	// is created only when the workload has a control room to authenticate against — so skip the
+	// Key Vault call (and its warning log) entirely when there is no control room.
 	mimirPassword := ""
-	mimirSecretName := s.DstTarget.Name() + "-mimir-auth"
-	if mimirPw, secretErr := s.DstTarget.SecretStore().GetSecretValue(ctx, creds, mimirSecretName); secretErr != nil {
-		fmt.Printf("helm azure: warning: failed to get mimir secret %q: %v\n", mimirSecretName, secretErr)
-	} else {
-		mimirPassword = mimirPw
+	if cfg.ControlRoomDomain != "" {
+		mimirSecretName := s.DstTarget.Name() + "-mimir-auth"
+		if mimirPw, secretErr := s.DstTarget.SecretStore().GetSecretValue(ctx, creds, mimirSecretName); secretErr != nil {
+			fmt.Printf("helm azure: warning: failed to get mimir secret %q: %v\n", mimirSecretName, secretErr)
+		} else {
+			mimirPassword = mimirPw
+		}
 	}
 
 	// Fetch grafana admin secret for fqdn.

--- a/lib/steps/helm_azure.go
+++ b/lib/steps/helm_azure.go
@@ -970,6 +970,12 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	}
 	alloyConfigStr := buildAlloyConfig(alloyP)
 
+	// The mimir-auth Secret and its volume/mount only exist to feed the control-room
+	// remote_write block in the Alloy config. buildAlloyConfig omits that block when there
+	// is no control room, so gate the credential on the same condition to avoid mounting an
+	// orphaned control-room credential in the Alloy pod.
+	hasControlRoom := params.cfg.ControlRoomDomain != ""
+
 	// ConfigMap for Alloy. Python named the AlloyConfig component "alloy-config" and the ConfigMap
 	// was a child of that component, so its URN uses the nested AlloyConfig parent type.
 	cmResourceName := compoundName + "-" + release + "-alloy-config-configmap"
@@ -988,20 +994,23 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	}
 
 	// Mimir auth Secret (Azure uses base64-encoded data field unlike AWS which uses stringData).
-	mimirAuthB64 := base64.StdEncoding.EncodeToString([]byte(params.mimirPassword))
-	mimirSecretResourceName := compoundName + "-" + release + "-mimir-auth"
-	_, err = corev1.NewSecret(ctx, mimirSecretResourceName, &corev1.SecretArgs{
-		Metadata: metav1.ObjectMetaArgs{
-			Name:      pulumi.String("mimir-auth"),
-			Namespace: pulumi.String(helmAlloyNamespace),
-		},
-		Data: pulumi.StringMap{
-			"password": pulumi.String(mimirAuthB64),
-		},
-	}, k8sOpt, withAlias("kubernetes:core/v1:Secret", mimirSecretResourceName),
-		pulumi.DependsOn([]pulumi.Resource{ns}))
-	if err != nil {
-		return fmt.Errorf("helm azure: failed to create alloy mimir-auth secret for %s: %w", release, err)
+	// Only created when the workload has a control room to authenticate against.
+	if hasControlRoom {
+		mimirAuthB64 := base64.StdEncoding.EncodeToString([]byte(params.mimirPassword))
+		mimirSecretResourceName := compoundName + "-" + release + "-mimir-auth"
+		_, err = corev1.NewSecret(ctx, mimirSecretResourceName, &corev1.SecretArgs{
+			Metadata: metav1.ObjectMetaArgs{
+				Name:      pulumi.String("mimir-auth"),
+				Namespace: pulumi.String(helmAlloyNamespace),
+			},
+			Data: pulumi.StringMap{
+				"password": pulumi.String(mimirAuthB64),
+			},
+		}, k8sOpt, withAlias("kubernetes:core/v1:Secret", mimirSecretResourceName),
+			pulumi.DependsOn([]pulumi.Resource{ns}))
+		if err != nil {
+			return fmt.Errorf("helm azure: failed to create alloy mimir-auth secret for %s: %w", release, err)
+		}
 	}
 
 	// Alloy Helm chart values (uses identity.ClientId output).
@@ -1009,6 +1018,20 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 	chartResourceName := compoundName + "-" + release + "-grafana-alloy-release"
 
 	valuesYAML := identity.ClientId.ApplyT(func(clientID string) (string, error) {
+		// varlog is always present; the mimir-auth mount only exists when there is a control room.
+		mounts := map[string]interface{}{
+			"varlog": true,
+		}
+		if hasControlRoom {
+			mounts["extra"] = []interface{}{
+				map[string]interface{}{
+					"name":      "mimir-auth",
+					"mountPath": "/etc/mimir/",
+					"readOnly":  true,
+				},
+			}
+		}
+
 		alloyInner := map[string]interface{}{
 			"clustering": map[string]interface{}{"enabled": true},
 			"extraPorts": []interface{}{
@@ -1019,16 +1042,7 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 					"protocol":   "TCP",
 				},
 			},
-			"mounts": map[string]interface{}{
-				"extra": []interface{}{
-					map[string]interface{}{
-						"name":      "mimir-auth",
-						"mountPath": "/etc/mimir/",
-						"readOnly":  true,
-					},
-				},
-				"varlog": true,
-			},
+			"mounts": mounts,
 			"configMap": map[string]interface{}{
 				"create": false,
 				"name":   "alloy-config",
@@ -1037,6 +1051,32 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 		}
 		if !thirdParty {
 			alloyInner["reporting"] = map[string]interface{}{"enabled": false}
+		}
+
+		// The controller always carries the workload-identity podLabels; the mimir-auth volume
+		// is attached only when the workload has a control room.
+		controller := map[string]interface{}{
+			"podLabels": map[string]interface{}{
+				"azure.workload.identity/use": "true",
+			},
+		}
+		if hasControlRoom {
+			controller["volumes"] = map[string]interface{}{
+				"extra": []interface{}{
+					map[string]interface{}{
+						"name": "mimir-auth",
+						"secret": map[string]interface{}{
+							"secretName": "mimir-auth",
+							"items": []interface{}{
+								map[string]interface{}{
+									"key":  "password",
+									"path": "password",
+								},
+							},
+						},
+					},
+				},
+			}
 		}
 
 		v := map[string]interface{}{
@@ -1050,28 +1090,8 @@ func azureHelmAlloy(ctx *pulumi.Context, k8sOpt pulumi.ResourceOption, compoundN
 					"azure.workload.identity/use": "true",
 				},
 			},
-			"controller": map[string]interface{}{
-				"podLabels": map[string]interface{}{
-					"azure.workload.identity/use": "true",
-				},
-				"volumes": map[string]interface{}{
-					"extra": []interface{}{
-						map[string]interface{}{
-							"name": "mimir-auth",
-							"secret": map[string]interface{}{
-								"secretName": "mimir-auth",
-								"items": []interface{}{
-									map[string]interface{}{
-										"key":  "password",
-										"path": "password",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"alloy": alloyInner,
+			"controller": controller,
+			"alloy":      alloyInner,
 			"ingress": map[string]interface{}{
 				"enabled":  true,
 				"faroPort": 12347,

--- a/lib/steps/helm_azure_test.go
+++ b/lib/steps/helm_azure_test.go
@@ -1,0 +1,93 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/posit-dev/ptd/lib/types"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/require"
+	yamlv2 "gopkg.in/yaml.v2"
+)
+
+// runAzureHelmAlloy invokes azureHelmAlloy in isolation with no-op providers/aliases.
+// It reuses the helmAWSMocks recorder from helm_aws_test.go (same package).
+func runAzureHelmAlloy(t *testing.T, controlRoomDomain string) *helmAWSMocks {
+	t.Helper()
+	mocks := &helmAWSMocks{}
+	noopOpt := pulumi.Aliases(nil)
+	withAlias := func(string, string) pulumi.ResourceOption { return pulumi.Aliases(nil) }
+	withNestedAlias := func(string, string, string) pulumi.ResourceOption { return pulumi.Aliases(nil) }
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		params := azureHelmParams{
+			compoundName:      "wl01-staging",
+			trueName:          "wl01",
+			environment:       "staging",
+			subscriptionID:    "00000000-0000-0000-0000-000000000000",
+			tenantID:          "11111111-1111-1111-1111-111111111111",
+			region:            "eastus",
+			resourceGroupName: "rsg-ptd-wl01-staging",
+			mimirPassword:     "s3cr3t",
+			cfg: types.AzureWorkloadConfig{
+				ControlRoomDomain: controlRoomDomain,
+			},
+		}
+		return azureHelmAlloy(ctx, noopOpt, "wl01-staging", "20250101", params,
+			"", "0.12.6", withAlias, withNestedAlias)
+	}, pulumi.WithMocks("ptd-azure-workload-helm", "wl01-staging", mocks))
+	require.NoError(t, err)
+	return mocks
+}
+
+// azureAlloyChartValues unmarshals the Alloy HelmChart CR's valuesContent for inspection.
+func azureAlloyChartValues(t *testing.T, mocks *helmAWSMocks) map[string]interface{} {
+	t.Helper()
+	chart := mocks.find("wl01-staging-20250101-grafana-alloy-release")
+	require.NotNil(t, chart, "alloy HelmChart CR not created")
+	valuesContent := chart.Inputs["spec"].ObjectValue()["valuesContent"].StringValue()
+	var values map[string]interface{}
+	require.NoError(t, yamlv2.Unmarshal([]byte(valuesContent), &values))
+	return values
+}
+
+func TestAzureHelmAlloyWithControlRoom(t *testing.T) {
+	mocks := runAzureHelmAlloy(t, "ctrl.example.posit.team")
+
+	// The mimir-auth Secret is created when the workload has a control room.
+	secret := mocks.find("wl01-staging-20250101-mimir-auth")
+	require.NotNil(t, secret, "mimir-auth Secret should be created when a control room is configured")
+
+	values := azureAlloyChartValues(t, mocks)
+
+	// The controller always carries the workload-identity podLabels, plus the mimir-auth volume.
+	controller := values["controller"].(map[interface{}]interface{})
+	require.Contains(t, controller, "podLabels")
+	volumes, ok := controller["volumes"].(map[interface{}]interface{})
+	require.True(t, ok, "controller.volumes should be present when a control room is configured")
+	require.Contains(t, volumes, "extra")
+
+	// The alloy mounts include the mimir-auth mount alongside varlog.
+	mounts := values["alloy"].(map[interface{}]interface{})["mounts"].(map[interface{}]interface{})
+	require.Contains(t, mounts, "extra", "mimir-auth mount should be present when a control room is configured")
+	require.Contains(t, mounts, "varlog")
+}
+
+func TestAzureHelmAlloyWithoutControlRoom(t *testing.T) {
+	mocks := runAzureHelmAlloy(t, "")
+
+	// The mimir-auth Secret is NOT created when there is no control room.
+	secret := mocks.find("wl01-staging-20250101-mimir-auth")
+	require.Nil(t, secret, "mimir-auth Secret should be omitted when there is no control room")
+
+	values := azureAlloyChartValues(t, mocks)
+
+	// The controller key is still present (it carries the workload-identity podLabels),
+	// but the mimir-auth volume is omitted.
+	controller := values["controller"].(map[interface{}]interface{})
+	require.Contains(t, controller, "podLabels")
+	require.NotContains(t, controller, "volumes", "controller.volumes should be omitted when there is no control room")
+
+	// varlog is still present but the mimir-auth mount is gone.
+	mounts := values["alloy"].(map[interface{}]interface{})["mounts"].(map[interface{}]interface{})
+	require.NotContains(t, mounts, "extra", "mimir-auth mount should be omitted when there is no control room")
+	require.Contains(t, mounts, "varlog")
+}


### PR DESCRIPTION
# Description

The Alloy `mimir-auth` Secret and its volume/mount exist solely to feed the
control-room `prometheus.remote_write "control_room"` block (via
`password_file = /etc/mimir/password`). `buildAlloyConfig` already omits that
block when `control_room_domain` is empty, but the Secret, volume, and mount were
created **unconditionally** — so a workload without a control room ended up with an
orphaned, unused control-room credential mounted in its Alloy pod.

This gates the Secret + volume + mount on `hasControlRoom` (`ControlRoomDomain != ""`),
the same condition `buildAlloyConfig` uses, on both AWS and Azure.

## Code Flow

- `lib/steps/helm_aws.go` (`awsHelmAlloy`): `mimir-auth` Secret creation wrapped in
  `if hasControlRoom`; `alloy.mounts` keeps `varlog` always and adds the mimir-auth
  `extra` only when gated; the `controller` key (whose only content is the mimir-auth
  volume) is attached only when gated.
- `lib/steps/helm_azure.go` (`azureHelmAlloy`): same gating for the base64 Secret and
  the mount; the `controller` map keeps its required `podLabels`
  (`azure.workload.identity/use`) unconditional and gates only `controller.volumes`.
- When a control room is present, the rendered chart values are unchanged.

Migration note: for an existing workload with **no** control room, the next
`ptd ensure --only-steps helm` will delete the now-unmanaged `mimir-auth` Secret and
update the Alloy release (mount/volume removed), restarting the Alloy pod. The Secret
was unused in that case, so this is non-breaking.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about

Tests: added `TestAwsHelmAlloyWith/WithoutControlRoom` and
`TestAzureHelmAlloyWith/WithoutControlRoom`. `gofmt` clean; `cd lib && go build ./...`
and `cd lib && go test ./steps/...` pass.
