### PR TITLE
feat(azure): pin TLS 1.2 and HTTPS-only on state storage account

### DIFF
--- a/lib/azure/blobstorage.go
+++ b/lib/azure/blobstorage.go
@@ -38,6 +38,12 @@ func CreateStorageAccount(ctx context.Context, credentials *Credentials, subscri
 		Properties: &armstorage.AccountPropertiesCreateParameters{
 			AllowBlobPublicAccess: to.Ptr(false),
 			AccessTier:            to.Ptr(armstorage.AccessTierCool),
+			// Azure defaults MinimumTLSVersion to TLS1_0 when unset; pin to TLS1_2
+			// so the account meets customer security baselines (Azure Policy).
+			MinimumTLSVersion: to.Ptr(armstorage.MinimumTLSVersionTLS12),
+			// Require secure transfer (HTTPS). Set explicitly rather than relying
+			// on the API default.
+			EnableHTTPSTrafficOnly: to.Ptr(true),
 		},
 	}, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

The Pulumi-state storage account created at bootstrap (`CreateStorageAccount` in `lib/azure/blobstorage.go`) left `MinimumTLSVersion` and `EnableHTTPSTrafficOnly` at Azure's API defaults, which are TLS 1.0 and no HTTPS enforcement. Those defaults fail customer security baselines evaluated by Azure Policy.

This sets both explicitly at create time:
- `MinimumTLSVersion: TLS1_2`
- `EnableHTTPSTrafficOnly: true`

## Scope

Applies only to **newly bootstrapped** Azure workloads. The account is created once and guarded by `StorageAccountExists`, so existing workloads' state accounts are not retrofitted by this change.

## Testing

- `go build ./azure/` clean
- Pre-commit format, lint, and lib tests pass